### PR TITLE
Added StatefulSmartContract class, eliminating the need to worry about preimage handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,10 @@ class Escrow extends SmartContract {
 
 ### Stateful Contracts (OP_PUSH_TX)
 
-Stateful contracts have non-`readonly` properties. State is carried across transactions using the OP_PUSH_TX pattern: the contract verifies a sighash preimage to inspect its own transaction outputs and enforce that the new state is correctly propagated.
+Stateful contracts extend `StatefulSmartContract` and have non-`readonly` properties. State is carried across transactions using the OP_PUSH_TX pattern. The compiler automatically handles preimage verification and state continuation — you just write the business logic:
 
 ```typescript
-class Counter extends SmartContract {
+class Counter extends StatefulSmartContract {
   count: bigint;  // mutable = stateful
 
   constructor(count: bigint) {
@@ -328,20 +328,20 @@ class Counter extends SmartContract {
     this.count = count;
   }
 
-  public increment(txPreimage: SigHashPreimage) {
-    assert(checkPreimage(txPreimage));
+  public increment() {
     this.count++;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 }
 ```
+
+The compiler auto-injects `checkPreimage` at method entry and state continuation at method exit for any method that modifies state. Access preimage fields via `this.txPreimage` when needed (e.g. `extractLocktime(this.txPreimage)`).
 
 ### Token Contracts
 
 **Fungible Token:**
 
 ```typescript
-class SimpleFungibleToken extends SmartContract {
+class SimpleFungibleToken extends StatefulSmartContract {
   owner: PubKey;
   readonly supply: bigint;
 
@@ -351,11 +351,9 @@ class SimpleFungibleToken extends SmartContract {
     this.supply = supply;
   }
 
-  public transfer(sig: Sig, newOwner: PubKey, txPreimage: SigHashPreimage) {
+  public transfer(sig: Sig, newOwner: PubKey) {
     assert(checkSig(sig, this.owner));
-    assert(checkPreimage(txPreimage));
     this.owner = newOwner;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 }
 ```

--- a/compilers/go/frontend/anf_lower.go
+++ b/compilers/go/frontend/anf_lower.go
@@ -133,13 +133,50 @@ func lowerMethods(contract *ContractNode) []ir.ANFMethod {
 	// Lower each method (including private methods as separate entries)
 	for _, method := range contract.Methods {
 		methodCtx := newLowerCtx(contract)
-		methodCtx.lowerStatements(method.Body)
-		result = append(result, ir.ANFMethod{
-			Name:     method.Name,
-			Params:   lowerParams(method.Params),
-			Body:     methodCtx.bindings,
-			IsPublic: method.Visibility == "public",
-		})
+
+		if contract.ParentClass == "StatefulSmartContract" && method.Visibility == "public" {
+			// Register txPreimage as an implicit parameter
+			methodCtx.addParam("txPreimage")
+
+			// Inject checkPreimage(txPreimage) at the start
+			preimageRef := methodCtx.emit(ir.ANFValue{Kind: "load_param", Name: "txPreimage"})
+			checkResult := methodCtx.emit(ir.ANFValue{Kind: "check_preimage", Preimage: preimageRef})
+			methodCtx.emit(makeAssert(checkResult))
+
+			// Lower the developer's method body
+			methodCtx.lowerStatements(method.Body)
+
+			// If the method mutates state, inject state continuation assertion at the end
+			if methodMutatesState(method, contract) {
+				stateScriptRef := methodCtx.emit(ir.ANFValue{Kind: "get_state_script"})
+				hashRef := methodCtx.emit(makeCall("hash256", []string{stateScriptRef}))
+				preimageRef2 := methodCtx.emit(ir.ANFValue{Kind: "load_param", Name: "txPreimage"})
+				outputHashRef := methodCtx.emit(makeCall("extractOutputHash", []string{preimageRef2}))
+				eqRef := methodCtx.emit(ir.ANFValue{Kind: "bin_op", Op: "===", Left: hashRef, Right: outputHashRef, ResultType: "bytes"})
+				methodCtx.emit(makeAssert(eqRef))
+			}
+
+			// Append implicit txPreimage param to the method's param list
+			augmentedParams := append(lowerParams(method.Params), ir.ANFParam{
+				Name: "txPreimage",
+				Type: "SigHashPreimage",
+			})
+
+			result = append(result, ir.ANFMethod{
+				Name:     method.Name,
+				Params:   augmentedParams,
+				Body:     methodCtx.bindings,
+				IsPublic: true,
+			})
+		} else {
+			methodCtx.lowerStatements(method.Body)
+			result = append(result, ir.ANFMethod{
+				Name:     method.Name,
+				Params:   lowerParams(method.Params),
+				Body:     methodCtx.bindings,
+				IsPublic: method.Visibility == "public",
+			})
+		}
 	}
 
 	return result
@@ -171,12 +208,14 @@ type lowerCtx struct {
 	counter    int
 	contract   *ContractNode
 	localNames map[string]bool // tracks variable names registered via addLocal
+	paramNames map[string]bool // tracks parameter names registered via addParam
 }
 
 func newLowerCtx(contract *ContractNode) *lowerCtx {
 	return &lowerCtx{
 		contract:   contract,
 		localNames: make(map[string]bool),
+		paramNames: make(map[string]bool),
 	}
 }
 
@@ -207,6 +246,16 @@ func (ctx *lowerCtx) addLocal(name string) {
 // isLocal checks if a name is a registered local variable.
 func (ctx *lowerCtx) isLocal(name string) bool {
 	return ctx.localNames[name]
+}
+
+// addParam records a parameter name so we know to use load_param for it.
+func (ctx *lowerCtx) addParam(name string) {
+	ctx.paramNames[name] = true
+}
+
+// isParam checks if a name is a registered parameter.
+func (ctx *lowerCtx) isParam(name string) bool {
+	return ctx.paramNames[name]
 }
 
 // isProperty checks if a name is a contract property.
@@ -245,16 +294,21 @@ func (ctx *lowerCtx) getPropertyType(name string) (string, bool) {
 }
 
 // subContext creates a sub-context for nested blocks (if/else, loops).
-// The counter continues from the parent. Local names are shared.
+// The counter continues from the parent. Local names and param names are shared.
 func (ctx *lowerCtx) subContext() *lowerCtx {
 	sub := &lowerCtx{
 		contract:   ctx.contract,
 		counter:    ctx.counter,
 		localNames: make(map[string]bool),
+		paramNames: make(map[string]bool),
 	}
 	// Share local name set
 	for k := range ctx.localNames {
 		sub.localNames[k] = true
+	}
+	// Share param name set
+	for k := range ctx.paramNames {
+		sub.paramNames[k] = true
 	}
 	return sub
 }
@@ -452,6 +506,10 @@ func (ctx *lowerCtx) lowerExprToRef(expr Expression) string {
 		return ctx.lowerIdentifier(e)
 
 	case PropertyAccessExpr:
+		// this.txPreimage in StatefulSmartContract -> load_param (it's an implicit param, not a stored property)
+		if ctx.isParam(e.Property) {
+			return ctx.emit(ir.ANFValue{Kind: "load_param", Name: e.Property})
+		}
 		// this.x -> load_prop
 		return ctx.emit(ir.ANFValue{Kind: "load_prop", Name: e.Property})
 
@@ -508,8 +566,10 @@ func (ctx *lowerCtx) lowerIdentifier(id Identifier) string {
 		return ctx.emit(makeLoadConstString("@this"))
 	}
 
-	// isParam check: always false since addParam is never called (matching TS)
-	// (no check needed)
+	// Check if it's a registered parameter (e.g. txPreimage in StatefulSmartContract)
+	if ctx.isParam(name) {
+		return ctx.emit(ir.ANFValue{Kind: "load_param", Name: name})
+	}
 
 	// Check if it's a local variable -- reference it directly
 	if ctx.isLocal(name) {
@@ -741,4 +801,74 @@ func makeUpdateProp(name, valueRef string) ir.ANFValue {
 		RawValue: raw,
 		ValueRef: valueRef,
 	}
+}
+
+// ---------------------------------------------------------------------------
+// State mutation analysis for StatefulSmartContract
+// ---------------------------------------------------------------------------
+
+// methodMutatesState determines whether a method mutates any mutable
+// (non-readonly) property. Conservative: if ANY code path can mutate state,
+// returns true.
+func methodMutatesState(method MethodNode, contract *ContractNode) bool {
+	mutableProps := make(map[string]bool)
+	for _, p := range contract.Properties {
+		if !p.Readonly {
+			mutableProps[p.Name] = true
+		}
+	}
+	if len(mutableProps) == 0 {
+		return false
+	}
+	return bodyMutatesState(method.Body, mutableProps)
+}
+
+func bodyMutatesState(stmts []Statement, mutableProps map[string]bool) bool {
+	for _, stmt := range stmts {
+		if stmtMutatesState(stmt, mutableProps) {
+			return true
+		}
+	}
+	return false
+}
+
+func stmtMutatesState(stmt Statement, mutableProps map[string]bool) bool {
+	switch s := stmt.(type) {
+	case AssignmentStmt:
+		if pa, ok := s.Target.(PropertyAccessExpr); ok && mutableProps[pa.Property] {
+			return true
+		}
+		return false
+	case ExpressionStmt:
+		return exprMutatesState(s.Expr, mutableProps)
+	case IfStmt:
+		if bodyMutatesState(s.Then, mutableProps) {
+			return true
+		}
+		if len(s.Else) > 0 && bodyMutatesState(s.Else, mutableProps) {
+			return true
+		}
+		return false
+	case ForStmt:
+		if stmtMutatesState(s.Update, mutableProps) {
+			return true
+		}
+		return bodyMutatesState(s.Body, mutableProps)
+	default:
+		return false
+	}
+}
+
+func exprMutatesState(expr Expression, mutableProps map[string]bool) bool {
+	switch e := expr.(type) {
+	case IncrementExpr:
+		if pa, ok := e.Operand.(PropertyAccessExpr); ok && mutableProps[pa.Property] {
+			return true
+		}
+	case DecrementExpr:
+		if pa, ok := e.Operand.(PropertyAccessExpr); ok && mutableProps[pa.Property] {
+			return true
+		}
+	}
+	return false
 }

--- a/compilers/go/frontend/ast.go
+++ b/compilers/go/frontend/ast.go
@@ -51,6 +51,7 @@ func (CustomType) typeNodeMarker() {}
 // ContractNode is the parsed representation of a TSOP smart contract class.
 type ContractNode struct {
 	Name        string
+	ParentClass string // "SmartContract" or "StatefulSmartContract"
 	Properties  []PropertyNode
 	Constructor MethodNode
 	Methods     []MethodNode

--- a/compilers/go/frontend/parser.go
+++ b/compilers/go/frontend/parser.go
@@ -39,7 +39,7 @@ func Parse(source []byte, fileName string) *ParseResult {
 
 	contract := p.findContract(root)
 	if contract == nil {
-		return &ParseResult{Errors: append(p.errors, "no class extending SmartContract found")}
+		return &ParseResult{Errors: append(p.errors, "no class extending SmartContract or StatefulSmartContract found")}
 	}
 
 	return &ParseResult{
@@ -128,9 +128,14 @@ func (p *parseContext) tryParseContractClass(node *sitter.Node) *ContractNode {
 		return nil
 	}
 
-	// The heritage clause should contain "SmartContract"
+	// The heritage clause should contain "SmartContract" or "StatefulSmartContract"
 	heritageText := p.nodeText(heritage)
-	if !strings.Contains(heritageText, "SmartContract") {
+	parentClass := ""
+	if strings.Contains(heritageText, "StatefulSmartContract") {
+		parentClass = "StatefulSmartContract"
+	} else if strings.Contains(heritageText, "SmartContract") {
+		parentClass = "SmartContract"
+	} else {
 		return nil
 	}
 
@@ -188,6 +193,7 @@ func (p *parseContext) tryParseContractClass(node *sitter.Node) *ContractNode {
 
 	return &ContractNode{
 		Name:        className,
+		ParentClass: parentClass,
 		Properties:  properties,
 		Constructor: *constructor,
 		Methods:     methods,

--- a/compilers/go/frontend/typecheck.go
+++ b/compilers/go/frontend/typecheck.go
@@ -200,6 +200,11 @@ func newTypeChecker(contract *ContractNode) *typeChecker {
 		tc.propTypes[prop.Name] = typeNodeToString(prop.Type)
 	}
 
+	// For StatefulSmartContract, add the implicit txPreimage property
+	if contract.ParentClass == "StatefulSmartContract" {
+		tc.propTypes["txPreimage"] = "SigHashPreimage"
+	}
+
 	for _, method := range contract.Methods {
 		params := make([]string, len(method.Params))
 		for i, p := range method.Params {

--- a/compilers/go/frontend/validator.go
+++ b/compilers/go/frontend/validator.go
@@ -155,8 +155,9 @@ func (ctx *validationContext) validateMethods() {
 }
 
 func (ctx *validationContext) validateMethod(method MethodNode) {
-	// Public methods must end with assert()
-	if method.Visibility == "public" {
+	// Public methods must end with assert() (unless StatefulSmartContract,
+	// where the compiler auto-injects the final assert)
+	if method.Visibility == "public" && ctx.contract.ParentClass != "StatefulSmartContract" {
 		if !endsWithAssert(method.Body) {
 			ctx.addError(fmt.Sprintf("public method '%s' must end with an assert() call", method.Name))
 		}

--- a/compilers/rust/src/frontend/anf_lower.rs
+++ b/compilers/rust/src/frontend/anf_lower.rs
@@ -77,13 +77,72 @@ fn lower_methods(contract: &ContractNode) -> Vec<ANFMethod> {
     // Lower each method (including private methods as separate entries)
     for method in &contract.methods {
         let mut method_ctx = LoweringContext::new(contract);
-        lower_statements(&method.body, &mut method_ctx);
-        result.push(ANFMethod {
-            name: method.name.clone(),
-            params: lower_params(&method.params),
-            body: method_ctx.bindings,
-            is_public: method.visibility == Visibility::Public,
-        });
+
+        if contract.parent_class == "StatefulSmartContract"
+            && method.visibility == Visibility::Public
+        {
+            // Register txPreimage as an implicit parameter
+            method_ctx.add_param("txPreimage");
+
+            // Inject checkPreimage(txPreimage) at the start
+            let preimage_ref = method_ctx.emit(ANFValue::LoadParam {
+                name: "txPreimage".to_string(),
+            });
+            let check_result = method_ctx.emit(ANFValue::CheckPreimage {
+                preimage: preimage_ref,
+            });
+            method_ctx.emit(ANFValue::Assert {
+                value: check_result,
+            });
+
+            // Lower the developer's method body
+            lower_statements(&method.body, &mut method_ctx);
+
+            // If the method mutates state, inject state continuation assertion at the end
+            if method_mutates_state(method, contract) {
+                let state_script_ref = method_ctx.emit(ANFValue::GetStateScript {});
+                let hash_ref = method_ctx.emit(ANFValue::Call {
+                    func: "hash256".to_string(),
+                    args: vec![state_script_ref],
+                });
+                let preimage_ref2 = method_ctx.emit(ANFValue::LoadParam {
+                    name: "txPreimage".to_string(),
+                });
+                let output_hash_ref = method_ctx.emit(ANFValue::Call {
+                    func: "extractOutputHash".to_string(),
+                    args: vec![preimage_ref2],
+                });
+                let eq_ref = method_ctx.emit(ANFValue::BinOp {
+                    op: "===".to_string(),
+                    left: hash_ref,
+                    right: output_hash_ref,
+                    result_type: Some("bytes".to_string()),
+                });
+                method_ctx.emit(ANFValue::Assert { value: eq_ref });
+            }
+
+            // Append implicit txPreimage param to the method's param list
+            let mut augmented_params = lower_params(&method.params);
+            augmented_params.push(ANFParam {
+                name: "txPreimage".to_string(),
+                param_type: "SigHashPreimage".to_string(),
+            });
+
+            result.push(ANFMethod {
+                name: method.name.clone(),
+                params: augmented_params,
+                body: method_ctx.bindings,
+                is_public: true,
+            });
+        } else {
+            lower_statements(&method.body, &mut method_ctx);
+            result.push(ANFMethod {
+                name: method.name.clone(),
+                params: lower_params(&method.params),
+                body: method_ctx.bindings,
+                is_public: method.visibility == Visibility::Public,
+            });
+        }
     }
 
     result
@@ -113,6 +172,7 @@ struct LoweringContext<'a> {
     bindings: Vec<ANFBinding>,
     counter: usize,
     contract: &'a ContractNode,
+    param_names: HashSet<String>,
     local_names: HashSet<String>,
 }
 
@@ -122,6 +182,7 @@ impl<'a> LoweringContext<'a> {
             bindings: Vec::new(),
             counter: 0,
             contract,
+            param_names: HashSet::new(),
             local_names: HashSet::new(),
         }
     }
@@ -151,6 +212,15 @@ impl<'a> LoweringContext<'a> {
         });
     }
 
+    /// Record a parameter name so we know to use load_param for it.
+    fn add_param(&mut self, name: &str) {
+        self.param_names.insert(name.to_string());
+    }
+
+    fn is_param(&self, name: &str) -> bool {
+        self.param_names.contains(name)
+    }
+
     /// Record a local variable name.
     fn add_local(&mut self, name: &str) {
         self.local_names.insert(name.to_string());
@@ -165,10 +235,11 @@ impl<'a> LoweringContext<'a> {
     }
 
     /// Create a sub-context for nested blocks (if/else, loops).
-    /// The counter continues from the parent. Local names are shared.
+    /// The counter continues from the parent. Local names and param names are shared.
     fn sub_context(&self) -> LoweringContext<'a> {
         let mut sub = LoweringContext::new(self.contract);
         sub.counter = self.counter;
+        sub.param_names = self.param_names.clone();
         sub.local_names = self.local_names.clone();
         sub
     }
@@ -396,6 +467,12 @@ fn lower_expr_to_ref(expr: &Expression, ctx: &mut LoweringContext) -> String {
         Expression::Identifier { name } => lower_identifier(name, ctx),
 
         Expression::PropertyAccess { property } => {
+            // this.txPreimage in StatefulSmartContract -> load_param (it's an implicit param, not a stored property)
+            if ctx.is_param(property) {
+                return ctx.emit(ANFValue::LoadParam {
+                    name: property.clone(),
+                });
+            }
             // this.x -> load_prop
             ctx.emit(ANFValue::LoadProp {
                 name: property.clone(),
@@ -442,8 +519,12 @@ fn lower_identifier(name: &str, ctx: &mut LoweringContext) -> String {
         });
     }
 
-    // isParam check: always false since addParam is never called (matching TS)
-    // (no check needed)
+    // Check if it's a registered parameter (e.g. txPreimage for StatefulSmartContract)
+    if ctx.is_param(name) {
+        return ctx.emit(ANFValue::LoadParam {
+            name: name.to_string(),
+        });
+    }
 
     // Check if it's a local variable -- reference it directly
     if ctx.is_local(name) {
@@ -469,9 +550,14 @@ fn lower_member_expr(
     property: &str,
     ctx: &mut LoweringContext,
 ) -> String {
-    // this.x -> load_prop
+    // this.x -> load_prop (or load_param for implicit params like txPreimage)
     if let Expression::Identifier { name } = object {
         if name == "this" {
+            if ctx.is_param(property) {
+                return ctx.emit(ANFValue::LoadParam {
+                    name: property.to_string(),
+                });
+            }
             return ctx.emit(ANFValue::LoadProp {
                 name: property.to_string(),
             });
@@ -879,5 +965,75 @@ fn type_node_to_string(node: &TypeNode) -> String {
             format!("FixedArray<{}, {}>", type_node_to_string(element), length)
         }
         TypeNode::Custom(name) => name.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State mutation analysis for StatefulSmartContract
+// ---------------------------------------------------------------------------
+
+/// Determine whether a method mutates any mutable (non-readonly) property.
+/// Conservative: if ANY code path can mutate state, returns true.
+fn method_mutates_state(method: &MethodNode, contract: &ContractNode) -> bool {
+    let mutable_prop_names: HashSet<String> = contract
+        .properties
+        .iter()
+        .filter(|p| !p.readonly)
+        .map(|p| p.name.clone())
+        .collect();
+    if mutable_prop_names.is_empty() {
+        return false;
+    }
+    body_mutates_state(&method.body, &mutable_prop_names)
+}
+
+fn body_mutates_state(stmts: &[Statement], mutable_props: &HashSet<String>) -> bool {
+    for stmt in stmts {
+        if stmt_mutates_state(stmt, mutable_props) {
+            return true;
+        }
+    }
+    false
+}
+
+fn stmt_mutates_state(stmt: &Statement, mutable_props: &HashSet<String>) -> bool {
+    match stmt {
+        Statement::Assignment { target, .. } => {
+            if let Expression::PropertyAccess { property } = target {
+                if mutable_props.contains(property) {
+                    return true;
+                }
+            }
+            false
+        }
+        Statement::ExpressionStatement { expression, .. } => {
+            expr_mutates_state(expression, mutable_props)
+        }
+        Statement::IfStatement {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            body_mutates_state(then_branch, mutable_props)
+                || else_branch
+                    .as_ref()
+                    .map_or(false, |e| body_mutates_state(e, mutable_props))
+        }
+        Statement::ForStatement { body, .. } => body_mutates_state(body, mutable_props),
+        _ => false,
+    }
+}
+
+fn expr_mutates_state(expr: &Expression, mutable_props: &HashSet<String>) -> bool {
+    match expr {
+        Expression::IncrementExpr { operand, .. } | Expression::DecrementExpr { operand, .. } => {
+            if let Expression::PropertyAccess { property } = operand.as_ref() {
+                if mutable_props.contains(property) {
+                    return true;
+                }
+            }
+            false
+        }
+        _ => false,
     }
 }

--- a/compilers/rust/src/frontend/ast.rs
+++ b/compilers/rust/src/frontend/ast.rs
@@ -94,6 +94,7 @@ pub enum TypeNode {
 #[derive(Debug, Clone)]
 pub struct ContractNode {
     pub name: String,
+    pub parent_class: String, // "SmartContract" or "StatefulSmartContract"
     pub properties: Vec<PropertyNode>,
     pub constructor: MethodNode,
     pub methods: Vec<MethodNode>,

--- a/compilers/rust/src/frontend/parser.rs
+++ b/compilers/rust/src/frontend/parser.rs
@@ -67,19 +67,21 @@ pub fn parse(source: &str, file_name: Option<&str>) -> ParseResult {
         errors.push(format!("Parse error: {:?}", e));
     }
 
-    // Find the class that extends SmartContract
+    // Find the class that extends SmartContract or StatefulSmartContract
     let mut contract_class: Option<&ClassDecl> = None;
+    let mut detected_parent_class: &str = "SmartContract";
 
     for item in &module.body {
         if let ModuleItem::Stmt(Stmt::Decl(Decl::Class(class_decl))) = item {
             if let Some(super_class) = &class_decl.class.super_class {
-                if is_smart_contract_base(super_class) {
+                if let Some(base_name) = get_base_class_name(super_class) {
                     if contract_class.is_some() {
                         errors.push(
                             "Only one SmartContract subclass is allowed per file".to_string(),
                         );
                     }
                     contract_class = Some(class_decl);
+                    detected_parent_class = base_name;
                 }
             }
         }
@@ -90,13 +92,14 @@ pub fn parse(source: &str, file_name: Option<&str>) -> ParseResult {
         if let ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) = item {
             if let Decl::Class(class_decl) = &export_decl.decl {
                 if let Some(super_class) = &class_decl.class.super_class {
-                    if is_smart_contract_base(super_class) {
+                    if let Some(base_name) = get_base_class_name(super_class) {
                         if contract_class.is_some() {
                             errors.push(
                                 "Only one SmartContract subclass is allowed per file".to_string(),
                             );
                         }
                         contract_class = Some(class_decl);
+                        detected_parent_class = base_name;
                     }
                 }
             }
@@ -106,7 +109,7 @@ pub fn parse(source: &str, file_name: Option<&str>) -> ParseResult {
     let class_decl = match contract_class {
         Some(c) => c,
         None => {
-            errors.push("No class extending SmartContract found".to_string());
+            errors.push("No class extending SmartContract or StatefulSmartContract found".to_string());
             return ParseResult {
                 contract: None,
                 errors,
@@ -128,6 +131,7 @@ pub fn parse(source: &str, file_name: Option<&str>) -> ParseResult {
 
     let contract = ContractNode {
         name: contract_name,
+        parent_class: detected_parent_class.to_string(),
         properties,
         constructor: constructor_node,
         methods,
@@ -144,10 +148,17 @@ pub fn parse(source: &str, file_name: Option<&str>) -> ParseResult {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn is_smart_contract_base(expr: &Expr) -> bool {
+fn get_base_class_name(expr: &Expr) -> Option<&str> {
     match expr {
-        Expr::Ident(ident) => ident.sym.as_ref() == "SmartContract",
-        _ => false,
+        Expr::Ident(ident) => {
+            let name = ident.sym.as_ref();
+            if name == "SmartContract" || name == "StatefulSmartContract" {
+                Some(name)
+            } else {
+                None
+            }
+        }
+        _ => None,
     }
 }
 

--- a/compilers/rust/src/frontend/typecheck.rs
+++ b/compilers/rust/src/frontend/typecheck.rs
@@ -236,6 +236,11 @@ impl<'a> TypeChecker<'a> {
             prop_types.insert(prop.name.clone(), type_node_to_ttype(&prop.prop_type));
         }
 
+        // For StatefulSmartContract, add the implicit txPreimage property
+        if contract.parent_class == "StatefulSmartContract" {
+            prop_types.insert("txPreimage".to_string(), "SigHashPreimage".to_string());
+        }
+
         let mut method_sigs = HashMap::new();
         for method in &contract.methods {
             let params: Vec<TType> = method

--- a/compilers/rust/src/frontend/validator.rs
+++ b/compilers/rust/src/frontend/validator.rs
@@ -155,11 +155,11 @@ fn is_super_call(stmt: &Statement) -> bool {
 
 fn validate_methods(contract: &ContractNode, errors: &mut Vec<String>) {
     for method in &contract.methods {
-        validate_method(method, errors);
+        validate_method(method, contract, errors);
     }
 }
 
-fn validate_method(method: &MethodNode, errors: &mut Vec<String>) {
+fn validate_method(method: &MethodNode, contract: &ContractNode, errors: &mut Vec<String>) {
     // All params must have type annotations
     for param in &method.params {
         if let TypeNode::Custom(ref name) = param.param_type {
@@ -172,8 +172,9 @@ fn validate_method(method: &MethodNode, errors: &mut Vec<String>) {
         }
     }
 
-    // Public methods must end with an assert() call
-    if method.visibility == Visibility::Public {
+    // Public methods must end with an assert() call (unless StatefulSmartContract,
+    // where the compiler auto-injects the final assert)
+    if method.visibility == Visibility::Public && contract.parent_class == "SmartContract" {
         if !ends_with_assert(&method.body) {
             errors.push(format!(
                 "Public method '{}' must end with an assert() call",

--- a/docs/contract-patterns.md
+++ b/docs/contract-patterns.md
@@ -83,12 +83,9 @@ Because this contract has two public methods, the compiler generates a dispatch 
 A contract whose state persists across transactions. The counter can be incremented or decremented, and the updated value is carried to the next UTXO.
 
 ```typescript
-import {
-  SmartContract, assert, SigHashPreimage,
-  checkPreimage, hash256, extractOutputHash
-} from 'tsop-lang';
+import { StatefulSmartContract, assert } from 'tsop-lang';
 
-class Counter extends SmartContract {
+class Counter extends StatefulSmartContract {
   count: bigint; // non-readonly = stateful
 
   constructor(count: bigint) {
@@ -96,17 +93,13 @@ class Counter extends SmartContract {
     this.count = count;
   }
 
-  public increment(txPreimage: SigHashPreimage) {
-    assert(checkPreimage(txPreimage));
+  public increment() {
     this.count++;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 
-  public decrement(txPreimage: SigHashPreimage) {
+  public decrement() {
     assert(this.count > 0n);
-    assert(checkPreimage(txPreimage));
     this.count--;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 }
 ```
@@ -114,11 +107,9 @@ class Counter extends SmartContract {
 **How it works:**
 
 1. The `count` property is mutable (no `readonly`), making this a stateful contract.
-2. `checkPreimage(txPreimage)` verifies the sighash preimage matches the current transaction. This is the OP_PUSH_TX pattern -- it lets the contract inspect its own transaction.
-3. `this.count++` updates the in-memory state.
-4. `this.getStateScript()` serializes the updated state. `hash256(...)` computes a double-SHA-256 of the new locking script.
-5. `extractOutputHash(txPreimage)` reads the `hashOutputs` field from the preimage.
-6. The final assert verifies the transaction output contains the updated contract state. If someone tries to spend this UTXO without propagating the correct new state, the transaction is invalid.
+2. Extending `StatefulSmartContract` tells the compiler to automatically handle the OP_PUSH_TX pattern. For every public method, the compiler injects a preimage check at entry.
+3. `this.count++` / `this.count--` updates the in-memory state.
+4. Because these methods mutate state, the compiler automatically appends a state continuation assertion at the end — it serializes the updated state, hashes it, and verifies the transaction output carries the new state forward.
 
 **State lifecycle:**
 
@@ -136,12 +127,10 @@ Decrement: Spend UTXO, create new UTXO with count=1
 A simple fungible token where ownership can be transferred. The total supply is immutable; the owner is mutable state.
 
 ```typescript
-import {
-  SmartContract, assert, PubKey, Sig, SigHashPreimage,
-  checkSig, checkPreimage, hash256, extractOutputHash
-} from 'tsop-lang';
+import { StatefulSmartContract, assert, checkSig } from 'tsop-lang';
+import type { PubKey, Sig } from 'tsop-lang';
 
-class SimpleFungibleToken extends SmartContract {
+class SimpleFungibleToken extends StatefulSmartContract {
   owner: PubKey;           // stateful: current token owner
   readonly supply: bigint; // immutable: total supply
 
@@ -151,11 +140,9 @@ class SimpleFungibleToken extends SmartContract {
     this.supply = supply;
   }
 
-  public transfer(sig: Sig, newOwner: PubKey, txPreimage: SigHashPreimage) {
+  public transfer(sig: Sig, newOwner: PubKey) {
     assert(checkSig(sig, this.owner));
-    assert(checkPreimage(txPreimage));
     this.owner = newOwner;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 }
 ```
@@ -163,9 +150,8 @@ class SimpleFungibleToken extends SmartContract {
 **How it works:**
 
 1. Only the current `owner` can transfer the token (verified by `checkSig`).
-2. The preimage check ensures the transaction is valid and self-referential.
-3. `this.owner = newOwner` updates the state.
-4. The final assertion enforces that the output UTXO carries the updated state (new owner).
+2. `this.owner = newOwner` updates the state.
+3. The compiler auto-injects preimage verification and state continuation, ensuring the output UTXO carries the updated state (new owner).
 
 The `supply` is `readonly` and baked into the locking script at deploy time -- it cannot change across transfers.
 
@@ -176,12 +162,10 @@ The `supply` is `readonly` and baked into the locking script at deploy time -- i
 An NFT with a unique token ID, metadata, and a burn function.
 
 ```typescript
-import {
-  SmartContract, assert, PubKey, Sig, SigHashPreimage, ByteString,
-  checkSig, checkPreimage, hash256, extractOutputHash
-} from 'tsop-lang';
+import { StatefulSmartContract, assert, checkSig } from 'tsop-lang';
+import type { PubKey, Sig, ByteString } from 'tsop-lang';
 
-class SimpleNFT extends SmartContract {
+class SimpleNFT extends StatefulSmartContract {
   owner: PubKey;                   // stateful
   readonly tokenId: ByteString;    // immutable: unique identifier
   readonly metadata: ByteString;   // immutable: metadata URI/hash
@@ -193,21 +177,19 @@ class SimpleNFT extends SmartContract {
     this.metadata = metadata;
   }
 
-  public transfer(sig: Sig, newOwner: PubKey, txPreimage: SigHashPreimage) {
+  public transfer(sig: Sig, newOwner: PubKey) {
     assert(checkSig(sig, this.owner));
-    assert(checkPreimage(txPreimage));
     this.owner = newOwner;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 
   public burn(sig: Sig) {
     assert(checkSig(sig, this.owner));
-    // No state continuation = token is destroyed
+    // No state mutation = token is destroyed
   }
 }
 ```
 
-**Key difference from FT:** The `burn` method has no state propagation. When it executes successfully, the UTXO is spent without creating a new contract UTXO. The token ceases to exist.
+**Key difference from FT:** The `burn` method does not modify any state. The compiler detects this and only injects the preimage check — no state continuation. The UTXO is spent without creating a new contract UTXO. The token ceases to exist.
 
 ---
 

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -6,39 +6,54 @@ TSOP is a strict subset of TypeScript designed for compilation to Bitcoin SV Scr
 
 ## Contract Structure
 
-A TSOP source file contains exactly one contract class that extends `SmartContract`:
+A TSOP source file contains exactly one contract class that extends `SmartContract` (stateless) or `StatefulSmartContract` (stateful):
+
+**Stateless contract** — all properties are `readonly`:
 
 ```typescript
-import { SmartContract, assert, PubKey, Sig, checkSig } from 'tsop-lang';
+import { SmartContract, assert, checkSig } from 'tsop-lang';
+import type { PubKey, Sig } from 'tsop-lang';
 
-class MyContract extends SmartContract {
-  // Properties (contract state)
-  readonly fixedValue: bigint;
-  mutableValue: bigint;
+class P2PKH extends SmartContract {
+  readonly pubKeyHash: Addr;
 
-  // Constructor (deployment parameters)
-  constructor(fixedValue: bigint, mutableValue: bigint) {
-    super(fixedValue, mutableValue);
-    this.fixedValue = fixedValue;
-    this.mutableValue = mutableValue;
+  constructor(pubKeyHash: Addr) {
+    super(pubKeyHash);
+    this.pubKeyHash = pubKeyHash;
   }
 
-  // Public methods (spending entry points)
-  public spend(sig: Sig, pubKey: PubKey) {
+  public unlock(sig: Sig, pubKey: PubKey) {
+    assert(hash160(pubKey) === this.pubKeyHash);
     assert(checkSig(sig, pubKey));
-  }
-
-  // Private methods (inlined helpers)
-  private helper(x: bigint): bigint {
-    return x * x;
   }
 }
 ```
 
+**Stateful contract** — has mutable properties, state persists across transactions:
+
+```typescript
+import { StatefulSmartContract, assert } from 'tsop-lang';
+
+class Counter extends StatefulSmartContract {
+  count: bigint;  // mutable = stateful
+
+  constructor(count: bigint) {
+    super(count);
+    this.count = count;
+  }
+
+  public increment() {
+    this.count++;
+  }
+}
+```
+
+`StatefulSmartContract` automatically handles the OP_PUSH_TX pattern: preimage verification at method entry and state continuation at exit for any method that modifies state. Access preimage fields via `this.txPreimage`.
+
 ### Rules
 
-- One class per file, extending `SmartContract` directly.
-- No decorators, no generics on the class, no intermediate base classes.
+- One class per file, extending `SmartContract` or `StatefulSmartContract`.
+- No decorators, no generics on the class.
 - Imports are restricted to `tsop-lang` (or `tsop` / `tsop/builtins`).
 
 ---
@@ -65,7 +80,7 @@ count: bigint;
 
 - Initialized in the constructor. Can be reassigned in public methods.
 - Changes are propagated across transactions using the OP_PUSH_TX pattern.
-- Having any mutable property makes the contract **stateful**.
+- Having any mutable property makes the contract **stateful**. Use `StatefulSmartContract` as the base class.
 
 Properties must not have initializers at the declaration site. All initialization happens in the constructor.
 
@@ -85,7 +100,7 @@ public unlock(sig: Sig, pubKey: PubKey) {
 ```
 
 - Must return `void`.
-- Must end with an `assert(...)` call as the final statement.
+- In `SmartContract`, must end with an `assert(...)` call as the final statement. In `StatefulSmartContract`, the compiler auto-injects the final assert.
 - Parameters form part of the unlocking script (scriptSig).
 - When a contract has multiple public methods, a dispatch table is generated. The unlocking script includes a method index.
 
@@ -337,12 +352,21 @@ private helper(x: bigint): bigint {
 
 ### Preimage (Stateful Contracts)
 
+In `StatefulSmartContract`, `checkPreimage` and state continuation are handled automatically by the compiler. The preimage is available via `this.txPreimage`. Use the `extract*` functions to read specific fields:
+
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `checkPreimage` | `(preimage: SigHashPreimage) => boolean` | Verify sighash preimage matches current tx |
-| `this.getStateScript()` | `() => ByteString` | Serialize current mutable state |
+| `this.txPreimage` | `SigHashPreimage` | Implicit preimage property (StatefulSmartContract only) |
 | `extractOutputHash` | `(preimage: SigHashPreimage) => Sha256` | Extract hashOutputs from preimage |
 | `extractLocktime` | `(preimage: SigHashPreimage) => bigint` | Extract nLocktime from preimage |
+| `extractAmount` | `(preimage: SigHashPreimage) => bigint` | Extract input amount from preimage |
+| `extractVersion` | `(preimage: SigHashPreimage) => bigint` | Extract tx version from preimage |
+| `extractSequence` | `(preimage: SigHashPreimage) => bigint` | Extract sequence number from preimage |
+
+### Oracle
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
 | `verifyRabinSig` | `(msg, sig, padding, pubKey) => boolean` | Verify a Rabin signature |
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ Each example is a self-contained directory with a `.tsop.ts` source file and its
 |---|---|---|---|---|
 | **P2PKH** | `p2pkh/` | Stateless | Beginner | Pay-to-Public-Key-Hash. The simplest possible contract: verify a signature against a hashed public key. |
 | **Escrow** | `escrow/` | Stateless, Multi-method | Beginner | Three-party escrow with buyer, seller, and arbiter. Two spending paths: release to seller or refund to buyer. |
-| **Counter** | `stateful-counter/` | Stateful (OP_PUSH_TX) | Intermediate | On-chain counter that persists across transactions. Demonstrates state chaining with `checkPreimage` and `getStateScript`. |
+| **Counter** | `stateful-counter/` | Stateful (OP_PUSH_TX) | Intermediate | On-chain counter that persists across transactions. Uses `StatefulSmartContract` for automatic state management. |
 | **Fungible Token** | `token-ft/` | Stateful, Token | Intermediate | Simple fungible token with transferable ownership. Owner signs to transfer; state tracks current owner. |
 | **Non-Fungible Token** | `token-nft/` | Stateful, Token | Intermediate | NFT with transfer and burn operations. Immutable token ID and metadata, mutable owner. |
 | **Oracle Price Feed** | `oracle-price/` | Oracle (Rabin) | Advanced | Contract that settles based on an oracle-signed price. Uses Rabin signatures for cheap on-chain verification. |
@@ -105,9 +105,9 @@ Start with `p2pkh/` and `escrow/`. These are stateless contracts with straightfo
 
 Move to `stateful-counter/`, `token-ft/`, and `token-nft/`. These add state management:
 
-- Mutable properties
-- `SigHashPreimage` and `checkPreimage`
-- `getStateScript()` and `extractOutputHash()`
+- `StatefulSmartContract` for automatic preimage verification and state continuation
+- Mutable properties for on-chain state
+- `this.txPreimage` for accessing preimage fields (e.g. `extractLocktime`)
 - State chaining across transactions
 
 ### Advanced

--- a/examples/auction/Auction.tsop.ts
+++ b/examples/auction/Auction.tsop.ts
@@ -1,6 +1,7 @@
-import { SmartContract, assert, PubKey, Sig, SigHashPreimage, ByteString, checkSig, checkPreimage, hash256, extractOutputHash, extractLocktime } from 'tsop-lang';
+import { StatefulSmartContract, assert, checkSig, extractLocktime } from 'tsop-lang';
+import type { PubKey, Sig } from 'tsop-lang';
 
-class Auction extends SmartContract {
+class Auction extends StatefulSmartContract {
   readonly auctioneer: PubKey;
   highestBidder: PubKey;     // stateful
   highestBid: bigint;         // stateful
@@ -14,31 +15,25 @@ class Auction extends SmartContract {
     this.deadline = deadline;
   }
 
-  public bid(bidder: PubKey, bidAmount: bigint, txPreimage: SigHashPreimage) {
-    assert(checkPreimage(txPreimage));
-
+  // State-mutating: compiler auto-injects checkPreimage + state continuation
+  public bid(bidder: PubKey, bidAmount: bigint) {
     // Bid must be higher than current highest
     assert(bidAmount > this.highestBid);
 
     // Auction must not have ended
-    assert(extractLocktime(txPreimage) < this.deadline);
+    assert(extractLocktime(this.txPreimage) < this.deadline);
 
     // Update state
     this.highestBidder = bidder;
     this.highestBid = bidAmount;
-
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 
-  public close(sig: Sig, txPreimage: SigHashPreimage) {
-    assert(checkPreimage(txPreimage));
-
+  // Non-mutating: compiler auto-injects checkPreimage only (no state continuation)
+  public close(sig: Sig) {
     // Only auctioneer can close
     assert(checkSig(sig, this.auctioneer));
 
     // Auction must have ended
-    assert(extractLocktime(txPreimage) >= this.deadline);
-
-    // No state continuation - auction is done
+    assert(extractLocktime(this.txPreimage) >= this.deadline);
   }
 }

--- a/examples/auction/README.md
+++ b/examples/auction/README.md
@@ -7,20 +7,20 @@ A stateful on-chain auction contract with time-locked bidding and closing phases
 Implements a simple ascending-price auction. Funds are locked in the contract, and participants can place bids until a deadline. After the deadline, the auctioneer can close the auction.
 
 - **Bid** -- anyone can place a bid that is higher than the current highest bid, as long as the deadline has not passed. The contract state updates with the new highest bidder and bid amount.
-- **Close** -- only the auctioneer can close the auction, and only after the deadline has passed. No state continuation occurs; the auction is finalized.
+- **Close** -- only the auctioneer can close the auction, and only after the deadline has passed. Since close does not modify state, the compiler does not inject state continuation -- the auction is finalized.
 
 ## Design pattern
 
-**Stateful contract with time locks** -- combines mutable state (`highestBidder`, `highestBid`) with locktime-based conditions extracted from the transaction preimage. The `extractLocktime()` function reads the nLockTime field from the spending transaction to enforce temporal constraints. Immutable fields (`auctioneer`, `deadline`) set the rules that govern the auction lifecycle.
+**Stateful contract with time locks** -- extends `StatefulSmartContract` and combines mutable state (`highestBidder`, `highestBid`) with locktime-based conditions. The `extractLocktime(this.txPreimage)` function reads the nLockTime field from the spending transaction to enforce temporal constraints. Immutable fields (`auctioneer`, `deadline`) set the rules that govern the auction lifecycle.
 
 ## TSOP features demonstrated
 
-- Time-lock enforcement via `extractLocktime(txPreimage)`
+- `StatefulSmartContract` for automatic preimage verification and state continuation
+- Time-lock enforcement via `extractLocktime(this.txPreimage)`
 - Multiple stateful fields updated atomically
 - Mixed `readonly` and mutable properties
 - Two distinct spending paths with different authorization and timing rules
-- OP_PUSH_TX for state continuity during bidding
-- Terminal method (close) with no state continuation
+- State-mutating method (`bid`) vs non-mutating method (`close`) with automatic detection
 
 ## Compile and use
 
@@ -28,4 +28,4 @@ Implements a simple ascending-price auction. Funds are locked in the contract, a
 tsop compile Auction.tsop.ts
 ```
 
-Deploy with the auctioneer's public key, an initial bidder/bid (can be zero), and a block height deadline. Bidders construct transactions with `nLockTime` set appropriately. The auctioneer closes after the deadline by providing a signature and a preimage from a transaction with `nLockTime >= deadline`.
+Deploy with the auctioneer's public key, an initial bidder/bid (can be zero), and a block height deadline. Bidders construct transactions with `nLockTime` set appropriately. The auctioneer closes after the deadline by providing a signature.

--- a/examples/stateful-counter/Counter.tsop.ts
+++ b/examples/stateful-counter/Counter.tsop.ts
@@ -1,6 +1,6 @@
-import { SmartContract, assert, SigHashPreimage, checkPreimage, hash256, extractOutputHash } from 'tsop-lang';
+import { StatefulSmartContract, assert } from 'tsop-lang';
 
-class Counter extends SmartContract {
+class Counter extends StatefulSmartContract {
   count: bigint; // non-readonly = stateful
 
   constructor(count: bigint) {
@@ -8,16 +8,12 @@ class Counter extends SmartContract {
     this.count = count;
   }
 
-  public increment(txPreimage: SigHashPreimage) {
-    assert(checkPreimage(txPreimage));
+  public increment() {
     this.count++;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 
-  public decrement(txPreimage: SigHashPreimage) {
+  public decrement() {
     assert(this.count > 0n);
-    assert(checkPreimage(txPreimage));
     this.count--;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 }

--- a/examples/stateful-counter/README.md
+++ b/examples/stateful-counter/README.md
@@ -1,6 +1,6 @@
 # Stateful Counter
 
-A simple counter contract that maintains mutable state across transactions using the OP_PUSH_TX pattern.
+A simple counter contract that maintains mutable state across transactions using `StatefulSmartContract`.
 
 ## What it does
 
@@ -11,15 +11,14 @@ Maintains an on-chain counter that can be incremented or decremented. Each call 
 
 ## Design pattern
 
-**Stateful contract (OP_PUSH_TX)** -- the `count` property is non-`readonly`, making it mutable state. The contract uses `checkPreimage()` to verify the sighash preimage of the spending transaction, then asserts that the transaction output contains the updated contract state via `hash256(this.getStateScript()) === extractOutputHash(txPreimage)`. This enforces that the contract persists in the next UTXO with its updated state.
+**Stateful contract** -- the `count` property is non-`readonly`, making it mutable state. By extending `StatefulSmartContract`, the compiler automatically verifies the sighash preimage at method entry and asserts that the transaction output carries the updated state at method exit. The developer only writes the business logic.
 
 ## TSOP features demonstrated
 
+- `StatefulSmartContract` for automatic preimage verification and state continuation
 - Non-`readonly` properties as mutable contract state
-- `checkPreimage()` for OP_PUSH_TX transaction introspection
-- `this.getStateScript()` to serialize the updated contract
-- `hash256()` and `extractOutputHash()` for output covenant enforcement
 - BigInt literals (`0n`) for script-level numeric operations
+- Automatic state serialization and output covenant enforcement
 
 ## Compile and use
 
@@ -27,4 +26,4 @@ Maintains an on-chain counter that can be incremented or decremented. Each call 
 tsop compile Counter.tsop.ts
 ```
 
-Deploy with an initial count value. To interact, construct a transaction whose output contains the contract with the updated count, then provide the sighash preimage as the method argument. The contract self-verifies that the output matches the expected next state.
+Deploy with an initial count value. To interact, construct a transaction whose output contains the contract with the updated count. The SDK automatically provides the sighash preimage. The contract self-verifies that the output matches the expected next state.

--- a/examples/token-ft/FungibleTokenExample.tsop.ts
+++ b/examples/token-ft/FungibleTokenExample.tsop.ts
@@ -1,6 +1,7 @@
-import { SmartContract, assert, PubKey, Sig, SigHashPreimage, checkSig, checkPreimage, hash256, extractOutputHash, ByteString } from 'tsop-lang';
+import { StatefulSmartContract, assert, checkSig } from 'tsop-lang';
+import type { PubKey, Sig } from 'tsop-lang';
 
-class SimpleFungibleToken extends SmartContract {
+class SimpleFungibleToken extends StatefulSmartContract {
   owner: PubKey;          // stateful: current token owner
   readonly supply: bigint; // immutable: total supply
 
@@ -10,15 +11,11 @@ class SimpleFungibleToken extends SmartContract {
     this.supply = supply;
   }
 
-  public transfer(sig: Sig, newOwner: PubKey, txPreimage: SigHashPreimage) {
+  public transfer(sig: Sig, newOwner: PubKey) {
     // Only current owner can transfer
     assert(checkSig(sig, this.owner));
-    assert(checkPreimage(txPreimage));
 
     // Update owner
     this.owner = newOwner;
-
-    // Ensure output contains updated contract
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 }

--- a/examples/token-ft/README.md
+++ b/examples/token-ft/README.md
@@ -10,14 +10,13 @@ Represents a fungible token with a fixed supply and a transferable owner. The cu
 
 ## Design pattern
 
-**Stateful ownership transfer** -- combines signature-based authorization (`checkSig`) with the OP_PUSH_TX pattern to enforce state transitions. The `owner` field is mutable (non-`readonly`), while `supply` is immutable (`readonly`). Each transfer produces a new UTXO with the updated owner.
+**Stateful ownership transfer** -- extends `StatefulSmartContract` and combines signature-based authorization (`checkSig`) with automatic state management. The `owner` field is mutable (non-`readonly`), while `supply` is immutable (`readonly`). Each transfer produces a new UTXO with the updated owner.
 
 ## TSOP features demonstrated
 
+- `StatefulSmartContract` for automatic preimage verification and state continuation
 - Mix of `readonly` (immutable) and mutable (stateful) properties
 - Owner-authorized state transitions via `checkSig()`
-- OP_PUSH_TX pattern for state continuity
-- `this.getStateScript()` for serializing updated contract state
 
 ## Compile and use
 

--- a/examples/token-nft/NFTExample.tsop.ts
+++ b/examples/token-nft/NFTExample.tsop.ts
@@ -1,6 +1,7 @@
-import { SmartContract, assert, PubKey, Sig, SigHashPreimage, ByteString, checkSig, checkPreimage, hash256, extractOutputHash } from 'tsop-lang';
+import { StatefulSmartContract, assert, checkSig } from 'tsop-lang';
+import type { PubKey, Sig, ByteString } from 'tsop-lang';
 
-class SimpleNFT extends SmartContract {
+class SimpleNFT extends StatefulSmartContract {
   owner: PubKey;             // stateful
   readonly tokenId: ByteString;   // immutable: unique token identifier
   readonly metadata: ByteString;  // immutable: token metadata URI/hash
@@ -12,16 +13,14 @@ class SimpleNFT extends SmartContract {
     this.metadata = metadata;
   }
 
-  public transfer(sig: Sig, newOwner: PubKey, txPreimage: SigHashPreimage) {
+  public transfer(sig: Sig, newOwner: PubKey) {
     assert(checkSig(sig, this.owner));
-    assert(checkPreimage(txPreimage));
     this.owner = newOwner;
-    assert(hash256(this.getStateScript()) === extractOutputHash(txPreimage));
   }
 
   public burn(sig: Sig) {
     // Only owner can burn
     assert(checkSig(sig, this.owner));
-    // No state continuation = token destroyed
+    // No state mutation = token destroyed
   }
 }

--- a/examples/token-nft/README.md
+++ b/examples/token-nft/README.md
@@ -7,19 +7,19 @@ A non-fungible token contract with unique identity, metadata, transfer, and burn
 Represents a unique, non-fungible token identified by a `tokenId` and associated `metadata`. The token has a single owner who can:
 
 - **Transfer** -- transfer ownership to a new public key, updating the on-chain state.
-- **Burn** -- permanently destroy the token. No state continuation occurs, meaning the UTXO is consumed without producing a successor contract output.
+- **Burn** -- permanently destroy the token. Since the burn method does not modify state, the compiler does not inject state continuation -- the UTXO is consumed without producing a successor contract output.
 
 ## Design pattern
 
-**Stateful NFT with burn path** -- the `owner` is mutable state updated via OP_PUSH_TX on transfer, while `tokenId` and `metadata` are immutable (`readonly`). The burn method intentionally omits state continuation, which effectively destroys the token by not propagating the contract to a new UTXO.
+**Stateful NFT with burn path** -- extends `StatefulSmartContract`. The `owner` is mutable state updated on transfer, while `tokenId` and `metadata` are immutable (`readonly`). The burn method intentionally omits any state mutation, so the compiler only injects preimage verification -- no state continuation. This effectively destroys the token.
 
 ## TSOP features demonstrated
 
+- `StatefulSmartContract` for automatic preimage verification and state continuation
 - `ByteString` type for arbitrary binary data (token ID, metadata)
 - Immutable identity fields (`readonly tokenId`, `readonly metadata`)
 - Stateful ownership tracking
-- Burn pattern: a public method with no state continuation
-- OP_PUSH_TX for enforced state transitions on transfer
+- Burn pattern: a public method with no state mutation (compiler auto-detects)
 
 ## Compile and use
 

--- a/packages/tsop-compiler/README.md
+++ b/packages/tsop-compiler/README.md
@@ -98,7 +98,7 @@ console.log(result.diagnostics);   // warnings and errors
 The parser:
 
 1. Creates a `ts-morph` `Project` with in-memory file system.
-2. Locates the class declaration that extends `SmartContract`.
+2. Locates the class declaration that extends `SmartContract` or `StatefulSmartContract`.
 3. Extracts property declarations, noting `readonly` vs mutable.
 4. Extracts the constructor, verifying `super(...)` call structure.
 5. Extracts method declarations with visibility and parameter types.
@@ -110,6 +110,7 @@ The output is a `ContractNode` as defined in `tsop-ir-schema`:
 interface ContractNode {
   kind: 'contract';
   name: string;
+  parentClass: 'SmartContract' | 'StatefulSmartContract';
   properties: PropertyNode[];
   constructor: MethodNode;
   methods: MethodNode[];
@@ -126,7 +127,7 @@ Expression nodes use a discriminated union on the `kind` field: `binary_expr`, `
 
 The validator checks structural constraints that the parser does not enforce:
 
-- Exactly one class extending `SmartContract` (no inheritance chains).
+- Exactly one class extending `SmartContract` or `StatefulSmartContract`.
 - No decorators anywhere.
 - No disallowed TypeScript constructs (while loops, try/catch, async, closures, etc.).
 - Constructor calls `super(...)` first, passes all properties, assigns all properties.

--- a/packages/tsop-compiler/src/__tests__/01-parse.test.ts
+++ b/packages/tsop-compiler/src/__tests__/01-parse.test.ts
@@ -704,4 +704,60 @@ describe('Pass 1: Parse', () => {
       expect(result.errors.filter(e => e.severity === 'error')).toEqual([]);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // StatefulSmartContract
+  // ---------------------------------------------------------------------------
+
+  describe('StatefulSmartContract', () => {
+    it('parses a class extending StatefulSmartContract', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment() { this.count++; }
+        }
+      `;
+      const result = parse(source);
+      expect(result.errors.filter(e => e.severity === 'error')).toEqual([]);
+      expect(result.contract).not.toBeNull();
+      expect(result.contract!.name).toBe('Counter');
+    });
+
+    it('sets parentClass to StatefulSmartContract', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment() { this.count++; }
+        }
+      `;
+      const result = parse(source);
+      expect(result.contract!.parentClass).toBe('StatefulSmartContract');
+    });
+
+    it('sets parentClass to SmartContract for regular contracts', () => {
+      const source = `
+        class P2PKH extends SmartContract {
+          readonly pk: PubKey;
+          constructor(pk: PubKey) { super(pk); this.pk = pk; }
+          public unlock(sig: Sig) { assert(checkSig(sig, this.pk)); }
+        }
+      `;
+      const result = parse(source);
+      expect(result.contract!.parentClass).toBe('SmartContract');
+    });
+
+    it('does not include txPreimage in parsed properties', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment() { this.count++; }
+        }
+      `;
+      const result = parse(source);
+      expect(result.contract!.properties.map(p => p.name)).toEqual(['count']);
+    });
+  });
 });

--- a/packages/tsop-compiler/src/__tests__/02-validate.test.ts
+++ b/packages/tsop-compiler/src/__tests__/02-validate.test.ts
@@ -491,4 +491,93 @@ describe('Pass 2: Validate', () => {
       expect(hasError(result, "Recursion detected")).toBe(false);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // StatefulSmartContract validation
+  // ---------------------------------------------------------------------------
+
+  describe('StatefulSmartContract', () => {
+    it('does not require public methods to end with assert()', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment() { this.count++; }
+        }
+      `;
+      const result = validateSource(source);
+      expect(hasError(result, "must end with an assert() call")).toBe(false);
+    });
+
+    it('still requires assert-ending for regular SmartContract public methods', () => {
+      const source = `
+        class C extends SmartContract {
+          readonly x: bigint;
+          constructor(x: bigint) { super(x); this.x = x; }
+          public m() {}
+        }
+      `;
+      const result = validateSource(source);
+      expect(hasError(result, "must end with an assert() call")).toBe(true);
+    });
+
+    it('warns when manually calling checkPreimage in StatefulSmartContract', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment(txPreimage: SigHashPreimage) {
+            assert(checkPreimage(txPreimage));
+            this.count++;
+          }
+        }
+      `;
+      const result = validateSource(source);
+      expect(result.warnings.some(w => w.message.includes('auto-injects checkPreimage'))).toBe(true);
+    });
+
+    it('warns when manually calling getStateScript in StatefulSmartContract', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment() {
+            this.count++;
+            assert(hash256(this.getStateScript()) === extractOutputHash(this.txPreimage));
+          }
+        }
+      `;
+      const result = validateSource(source);
+      expect(result.warnings.some(w => w.message.includes('auto-injects state continuation'))).toBe(true);
+    });
+
+    it('warns when StatefulSmartContract has no mutable properties', () => {
+      const source = `
+        class C extends StatefulSmartContract {
+          readonly x: bigint;
+          constructor(x: bigint) { super(x); this.x = x; }
+          public m() { assert(true); }
+        }
+      `;
+      const result = validateSource(source);
+      expect(result.warnings.some(w => w.message.includes('no mutable properties'))).toBe(true);
+    });
+
+    it('errors when txPreimage is declared as an explicit property', () => {
+      const source = `
+        class C extends StatefulSmartContract {
+          count: bigint;
+          txPreimage: SigHashPreimage;
+          constructor(count: bigint, txPreimage: SigHashPreimage) {
+            super(count, txPreimage);
+            this.count = count;
+            this.txPreimage = txPreimage;
+          }
+          public m() { this.count++; }
+        }
+      `;
+      const result = validateSource(source);
+      expect(hasError(result, "implicit property")).toBe(true);
+    });
+  });
 });

--- a/packages/tsop-compiler/src/__tests__/04-anf-lower.test.ts
+++ b/packages/tsop-compiler/src/__tests__/04-anf-lower.test.ts
@@ -500,4 +500,158 @@ describe('Pass 4: ANF Lower', () => {
       expect(superCall).toBeDefined();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // StatefulSmartContract auto-injection
+  // ---------------------------------------------------------------------------
+
+  describe('StatefulSmartContract auto-injection', () => {
+    const COUNTER_STATEFUL = `
+      class Counter extends StatefulSmartContract {
+        count: bigint;
+        constructor(count: bigint) { super(count); this.count = count; }
+        public increment() { this.count++; }
+      }
+    `;
+
+    it('injects check_preimage at the start of public methods', () => {
+      const program = lowerSource(COUNTER_STATEFUL);
+      const method = findMethod(program, 'increment');
+      const checkPreimages = bindingsOfKind(method.body, 'check_preimage');
+      expect(checkPreimages.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('injects state continuation (get_state_script + hash256 + assert) for state-mutating methods', () => {
+      const program = lowerSource(COUNTER_STATEFUL);
+      const method = findMethod(program, 'increment');
+
+      const getStateScripts = bindingsOfKind(method.body, 'get_state_script');
+      expect(getStateScripts.length).toBeGreaterThanOrEqual(1);
+
+      // Check that hash256 is called
+      const calls = bindingsOfKind(method.body, 'call');
+      const hash256Call = calls.find(b => (b.value as { func: string }).func === 'hash256');
+      expect(hash256Call).toBeDefined();
+
+      const extractOutputHashCall = calls.find(b => (b.value as { func: string }).func === 'extractOutputHash');
+      expect(extractOutputHashCall).toBeDefined();
+
+      // Final assert for state continuation
+      const asserts = bindingsOfKind(method.body, 'assert');
+      expect(asserts.length).toBeGreaterThanOrEqual(2); // checkPreimage assert + state continuation assert
+    });
+
+    it('appends txPreimage as an implicit parameter', () => {
+      const program = lowerSource(COUNTER_STATEFUL);
+      const method = findMethod(program, 'increment');
+      const preimageParam = method.params.find(p => p.name === 'txPreimage');
+      expect(preimageParam).toBeDefined();
+      expect(preimageParam!.type).toBe('SigHashPreimage');
+    });
+
+    it('does not inject state continuation for non-mutating methods', () => {
+      const source = `
+        class Auction extends StatefulSmartContract {
+          readonly auctioneer: PubKey;
+          highestBid: bigint;
+          constructor(auctioneer: PubKey, highestBid: bigint) {
+            super(auctioneer, highestBid);
+            this.auctioneer = auctioneer;
+            this.highestBid = highestBid;
+          }
+          public close(sig: Sig) {
+            assert(checkSig(sig, this.auctioneer));
+          }
+        }
+      `;
+      const program = lowerSource(source);
+      const method = findMethod(program, 'close');
+
+      // Should have check_preimage
+      const checkPreimages = bindingsOfKind(method.body, 'check_preimage');
+      expect(checkPreimages.length).toBeGreaterThanOrEqual(1);
+
+      // Should NOT have get_state_script (close does not mutate state)
+      const getStateScripts = bindingsOfKind(method.body, 'get_state_script');
+      expect(getStateScripts).toHaveLength(0);
+    });
+
+    it('injects state continuation for methods that mutate state via assignment', () => {
+      const source = `
+        class Auction extends StatefulSmartContract {
+          readonly auctioneer: PubKey;
+          highestBid: bigint;
+          constructor(auctioneer: PubKey, highestBid: bigint) {
+            super(auctioneer, highestBid);
+            this.auctioneer = auctioneer;
+            this.highestBid = highestBid;
+          }
+          public bid(amount: bigint) {
+            assert(amount > this.highestBid);
+            this.highestBid = amount;
+          }
+        }
+      `;
+      const program = lowerSource(source);
+      const method = findMethod(program, 'bid');
+
+      // Should have get_state_script (bid mutates highestBid)
+      const getStateScripts = bindingsOfKind(method.body, 'get_state_script');
+      expect(getStateScripts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('lowers this.txPreimage as load_param instead of load_prop', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          readonly deadline: bigint;
+          constructor(count: bigint, deadline: bigint) {
+            super(count, deadline);
+            this.count = count;
+            this.deadline = deadline;
+          }
+          public increment() {
+            assert(extractLocktime(this.txPreimage) < this.deadline);
+            this.count++;
+          }
+        }
+      `;
+      const program = lowerSource(source);
+      const method = findMethod(program, 'increment');
+
+      // this.txPreimage should be lowered as load_param, not load_prop
+      const loadParams = bindingsOfKind(method.body, 'load_param');
+      const txPreimageParams = loadParams.filter(
+        b => (b.value as { name: string }).name === 'txPreimage'
+      );
+      expect(txPreimageParams.length).toBeGreaterThanOrEqual(1);
+
+      // It should NOT appear as load_prop
+      const loadProps = bindingsOfKind(method.body, 'load_prop');
+      const txPreimageProps = loadProps.filter(
+        b => (b.value as { name: string }).name === 'txPreimage'
+      );
+      expect(txPreimageProps).toHaveLength(0);
+    });
+
+    it('does not affect regular SmartContract methods', () => {
+      const source = `
+        class C extends SmartContract {
+          readonly x: bigint;
+          constructor(x: bigint) { super(x); this.x = x; }
+          public m() { assert(true); }
+        }
+      `;
+      const program = lowerSource(source);
+      const method = findMethod(program, 'm');
+
+      // Regular SmartContract: no auto-injected check_preimage
+      const checkPreimages = bindingsOfKind(method.body, 'check_preimage');
+      expect(checkPreimages).toHaveLength(0);
+
+      // No txPreimage param
+      const preimageParam = method.params.find(p => p.name === 'txPreimage');
+      expect(preimageParam).toBeUndefined();
+    });
+  });
 });

--- a/packages/tsop-compiler/src/__tests__/e2e.test.ts
+++ b/packages/tsop-compiler/src/__tests__/e2e.test.ts
@@ -400,6 +400,100 @@ describe('End-to-end: compile()', () => {
   // Complex expressions
   // ---------------------------------------------------------------------------
 
+  // ---------------------------------------------------------------------------
+  // StatefulSmartContract compilation
+  // ---------------------------------------------------------------------------
+
+  describe('StatefulSmartContract compilation', () => {
+    it('compiles a StatefulSmartContract counter successfully', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment() { this.count++; }
+          public decrement() {
+            assert(this.count > 0n);
+            this.count--;
+          }
+        }
+      `;
+      const result = compile(source);
+      expect(result.success).toBe(true);
+      expect(result.anf).not.toBeNull();
+      expect(result.contract!.parentClass).toBe('StatefulSmartContract');
+    });
+
+    it('ANF has implicit txPreimage parameter for public methods', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment() { this.count++; }
+        }
+      `;
+      const result = compile(source);
+      const increment = result.anf!.methods.find(m => m.name === 'increment')!;
+      const preimageParam = increment.params.find(p => p.name === 'txPreimage');
+      expect(preimageParam).toBeDefined();
+      expect(preimageParam!.type).toBe('SigHashPreimage');
+    });
+
+    it('compiles a multi-method StatefulSmartContract with mixed mutation', () => {
+      const source = `
+        class Auction extends StatefulSmartContract {
+          readonly auctioneer: PubKey;
+          highestBidder: PubKey;
+          highestBid: bigint;
+          readonly deadline: bigint;
+
+          constructor(auctioneer: PubKey, highestBidder: PubKey, highestBid: bigint, deadline: bigint) {
+            super(auctioneer, highestBidder, highestBid, deadline);
+            this.auctioneer = auctioneer;
+            this.highestBidder = highestBidder;
+            this.highestBid = highestBid;
+            this.deadline = deadline;
+          }
+
+          public bid(bidder: PubKey, bidAmount: bigint) {
+            assert(bidAmount > this.highestBid);
+            assert(extractLocktime(this.txPreimage) < this.deadline);
+            this.highestBidder = bidder;
+            this.highestBid = bidAmount;
+          }
+
+          public close(sig: Sig) {
+            assert(checkSig(sig, this.auctioneer));
+            assert(extractLocktime(this.txPreimage) >= this.deadline);
+          }
+        }
+      `;
+      const result = compile(source);
+      expect(result.success).toBe(true);
+
+      // Both methods should be in the ANF
+      const bid = result.anf!.methods.find(m => m.name === 'bid')!;
+      const close = result.anf!.methods.find(m => m.name === 'close')!;
+      expect(bid).toBeDefined();
+      expect(close).toBeDefined();
+      expect(bid.isPublic).toBe(true);
+      expect(close.isPublic).toBe(true);
+    });
+
+    it('produces hex script output for StatefulSmartContract', () => {
+      const source = `
+        class Counter extends StatefulSmartContract {
+          count: bigint;
+          constructor(count: bigint) { super(count); this.count = count; }
+          public increment() { this.count++; }
+        }
+      `;
+      const result = compile(source);
+      expect(result.success).toBe(true);
+      expect(result.artifact).toBeDefined();
+      expect(result.artifact!.script.length).toBeGreaterThan(0);
+    });
+  });
+
   describe('complex expression compilation', () => {
     it('compiles nested binary expressions', () => {
       const source = `

--- a/packages/tsop-compiler/src/artifact/assembler.ts
+++ b/packages/tsop-compiler/src/artifact/assembler.ts
@@ -147,11 +147,20 @@ function extractABI(contract: ContractNode): ABI {
   const constructorParams: ABIParam[] = contract.constructor.params.map(paramToABI);
 
   // Methods
-  const methods: ABIMethod[] = contract.methods.map(method => ({
-    name: method.name,
-    params: method.params.map(paramToABI),
-    isPublic: method.visibility === 'public',
-  }));
+  const methods: ABIMethod[] = contract.methods.map(method => {
+    const params = method.params.map(paramToABI);
+
+    // For StatefulSmartContract, public methods have an implicit txPreimage param
+    if (contract.parentClass === 'StatefulSmartContract' && method.visibility === 'public') {
+      params.push({ name: 'txPreimage', type: 'SigHashPreimage' });
+    }
+
+    return {
+      name: method.name,
+      params,
+      isPublic: method.visibility === 'public',
+    };
+  });
 
   return {
     constructor: { params: constructorParams },

--- a/packages/tsop-compiler/src/ir/tsop-ast.ts
+++ b/packages/tsop-compiler/src/ir/tsop-ast.ts
@@ -59,6 +59,7 @@ export type TypeNode = PrimitiveTypeNode | FixedArrayTypeNode | CustomTypeNode;
 export interface ContractNode {
   kind: 'contract';
   name: string;
+  parentClass: 'SmartContract' | 'StatefulSmartContract';
   properties: PropertyNode[];
   constructor: MethodNode;
   methods: MethodNode[];

--- a/packages/tsop-compiler/src/passes/01-parse.ts
+++ b/packages/tsop-compiler/src/passes/01-parse.ts
@@ -65,15 +65,17 @@ export function parse(source: string, fileName?: string): ParseResult {
 
   const sourceFile = project.createSourceFile(file, source);
 
-  // Find the class that extends SmartContract
+  // Find the class that extends SmartContract or StatefulSmartContract
+  const VALID_BASE_CLASSES = new Set(['SmartContract', 'StatefulSmartContract']);
   const classes = sourceFile.getClasses();
   let contractClass: ClassDeclaration | undefined;
+  let detectedParentClass: 'SmartContract' | 'StatefulSmartContract' = 'SmartContract';
 
   for (const cls of classes) {
     const ext = cls.getExtends();
     if (ext) {
       const baseText = ext.getExpression().getText();
-      if (baseText === 'SmartContract') {
+      if (VALID_BASE_CLASSES.has(baseText)) {
         if (contractClass) {
           errors.push(makeDiagnostic(
             'Only one SmartContract subclass is allowed per file',
@@ -82,13 +84,14 @@ export function parse(source: string, fileName?: string): ParseResult {
           ));
         }
         contractClass = cls;
+        detectedParentClass = baseText as 'SmartContract' | 'StatefulSmartContract';
       }
     }
   }
 
   if (!contractClass) {
     errors.push(makeDiagnostic(
-      'No class extending SmartContract found',
+      'No class extending SmartContract or StatefulSmartContract found',
       'error',
       { file, line: 1, column: 0 },
     ));
@@ -127,6 +130,7 @@ export function parse(source: string, fileName?: string): ParseResult {
   const contract: ContractNode = {
     kind: 'contract',
     name: contractName,
+    parentClass: detectedParentClass,
     properties,
     constructor: constructorNode,
     methods,

--- a/packages/tsop-compiler/src/passes/02-validate.ts
+++ b/packages/tsop-compiler/src/passes/02-validate.ts
@@ -64,6 +64,27 @@ const VALID_PRIMITIVE_TYPES = new Set<string>([
 function validateProperties(ctx: ValidationContext): void {
   for (const prop of ctx.contract.properties) {
     validatePropertyType(prop.type, prop.sourceLocation, ctx);
+
+    // txPreimage is an implicit property of StatefulSmartContract
+    if (ctx.contract.parentClass === 'StatefulSmartContract' && prop.name === 'txPreimage') {
+      ctx.errors.push(makeDiagnostic(
+        `'txPreimage' is an implicit property of StatefulSmartContract and must not be declared`,
+        'error',
+        prop.sourceLocation,
+      ));
+    }
+  }
+
+  // Warn if StatefulSmartContract has no mutable properties
+  if (ctx.contract.parentClass === 'StatefulSmartContract') {
+    const hasMutableProps = ctx.contract.properties.some(p => !p.readonly);
+    if (!hasMutableProps) {
+      ctx.warnings.push(makeDiagnostic(
+        'StatefulSmartContract has no mutable properties; consider using SmartContract instead',
+        'warning',
+        ctx.contract.constructor.sourceLocation,
+      ));
+    }
   }
 }
 
@@ -206,8 +227,9 @@ function validateMethod(method: MethodNode, ctx: ValidationContext): void {
     }
   }
 
-  // Public methods must end with an assert() call
-  if (method.visibility === 'public') {
+  // Public methods must end with an assert() call (unless StatefulSmartContract,
+  // where the compiler auto-injects the final assert)
+  if (method.visibility === 'public' && ctx.contract.parentClass === 'SmartContract') {
     if (!endsWithAssert(method.body)) {
       ctx.errors.push(makeDiagnostic(
         `Public method '${method.name}' must end with an assert() call`,
@@ -215,6 +237,11 @@ function validateMethod(method: MethodNode, ctx: ValidationContext): void {
         method.sourceLocation,
       ));
     }
+  }
+
+  // Warn on manual preimage boilerplate in StatefulSmartContract
+  if (ctx.contract.parentClass === 'StatefulSmartContract' && method.visibility === 'public') {
+    warnManualPreimageUsage(method, ctx);
   }
 
   // Validate all statements in method body
@@ -559,4 +586,105 @@ function checkNoNumberType(
   // 'number' would not be a PrimitiveTypeName in TSOP (it's excluded from
   // the type union), so this is mainly a sanity check. If we ever see it
   // via custom_type, we'd catch it elsewhere.
+}
+
+// ---------------------------------------------------------------------------
+// StatefulSmartContract: warn on manual preimage boilerplate
+// ---------------------------------------------------------------------------
+
+function warnManualPreimageUsage(method: MethodNode, ctx: ValidationContext): void {
+  walkExpressionsInBody(method.body, (expr) => {
+    // Detect manual checkPreimage(...)
+    if (expr.kind === 'call_expr' &&
+        expr.callee.kind === 'identifier' &&
+        expr.callee.name === 'checkPreimage') {
+      ctx.warnings.push(makeDiagnostic(
+        `StatefulSmartContract auto-injects checkPreimage(); calling it manually in '${method.name}' will cause a duplicate verification`,
+        'warning',
+        method.sourceLocation,
+      ));
+    }
+    // Detect manual this.getStateScript()
+    if (expr.kind === 'call_expr' &&
+        expr.callee.kind === 'property_access' &&
+        expr.callee.property === 'getStateScript') {
+      ctx.warnings.push(makeDiagnostic(
+        `StatefulSmartContract auto-injects state continuation; calling getStateScript() manually in '${method.name}' is redundant`,
+        'warning',
+        method.sourceLocation,
+      ));
+    }
+  });
+}
+
+function walkExpressionsInBody(
+  stmts: Statement[],
+  visitor: (expr: Expression) => void,
+): void {
+  for (const stmt of stmts) {
+    walkExpressionsInStatement(stmt, visitor);
+  }
+}
+
+function walkExpressionsInStatement(
+  stmt: Statement,
+  visitor: (expr: Expression) => void,
+): void {
+  switch (stmt.kind) {
+    case 'expression_statement':
+      walkExpr(stmt.expression, visitor);
+      break;
+    case 'variable_decl':
+      walkExpr(stmt.init, visitor);
+      break;
+    case 'assignment':
+      walkExpr(stmt.target, visitor);
+      walkExpr(stmt.value, visitor);
+      break;
+    case 'if_statement':
+      walkExpr(stmt.condition, visitor);
+      walkExpressionsInBody(stmt.then, visitor);
+      if (stmt.else) walkExpressionsInBody(stmt.else, visitor);
+      break;
+    case 'for_statement':
+      walkExpr(stmt.condition, visitor);
+      walkExpressionsInBody(stmt.body, visitor);
+      break;
+    case 'return_statement':
+      if (stmt.value) walkExpr(stmt.value, visitor);
+      break;
+  }
+}
+
+function walkExpr(expr: Expression, visitor: (expr: Expression) => void): void {
+  visitor(expr);
+  switch (expr.kind) {
+    case 'binary_expr':
+      walkExpr(expr.left, visitor);
+      walkExpr(expr.right, visitor);
+      break;
+    case 'unary_expr':
+      walkExpr(expr.operand, visitor);
+      break;
+    case 'call_expr':
+      walkExpr(expr.callee, visitor);
+      for (const arg of expr.args) walkExpr(arg, visitor);
+      break;
+    case 'member_expr':
+      walkExpr(expr.object, visitor);
+      break;
+    case 'ternary_expr':
+      walkExpr(expr.condition, visitor);
+      walkExpr(expr.consequent, visitor);
+      walkExpr(expr.alternate, visitor);
+      break;
+    case 'index_access':
+      walkExpr(expr.object, visitor);
+      walkExpr(expr.index, visitor);
+      break;
+    case 'increment_expr':
+    case 'decrement_expr':
+      walkExpr(expr.operand, visitor);
+      break;
+  }
 }

--- a/packages/tsop-compiler/src/passes/03-typecheck.ts
+++ b/packages/tsop-compiler/src/passes/03-typecheck.ts
@@ -231,6 +231,11 @@ class TypeChecker {
       this.propTypes.set(prop.name, typeNodeToTType(prop.type));
     }
 
+    // For StatefulSmartContract, add the implicit txPreimage property
+    if (contract.parentClass === 'StatefulSmartContract') {
+      this.propTypes.set('txPreimage', 'SigHashPreimage');
+    }
+
     // Build method signature map (for this.method() calls)
     this.methodSigs = new Map();
     for (const method of contract.methods) {

--- a/packages/tsop-compiler/src/passes/04-anf-lower.ts
+++ b/packages/tsop-compiler/src/passes/04-anf-lower.ts
@@ -81,13 +81,50 @@ function lowerMethods(contract: ContractNode): ANFMethod[] {
   // Lower each method
   for (const method of contract.methods) {
     const methodCtx = new LoweringContext(contract);
-    lowerStatements(method.body, methodCtx);
-    result.push({
-      name: method.name,
-      params: lowerParams(method.params),
-      body: methodCtx.bindings,
-      isPublic: method.visibility === 'public',
-    });
+
+    if (contract.parentClass === 'StatefulSmartContract' && method.visibility === 'public') {
+      // Register txPreimage as an implicit parameter
+      methodCtx.addParam('txPreimage');
+
+      // Inject checkPreimage(txPreimage) at the start
+      const preimageRef = methodCtx.emit({ kind: 'load_param', name: 'txPreimage' });
+      const checkResult = methodCtx.emit({ kind: 'check_preimage', preimage: preimageRef });
+      methodCtx.emit({ kind: 'assert', value: checkResult });
+
+      // Lower the developer's method body
+      lowerStatements(method.body, methodCtx);
+
+      // If the method mutates state, inject state continuation assertion at the end
+      if (methodMutatesState(method, contract)) {
+        const stateScriptRef = methodCtx.emit({ kind: 'get_state_script' });
+        const hashRef = methodCtx.emit({ kind: 'call', func: 'hash256', args: [stateScriptRef] });
+        const preimageRef2 = methodCtx.emit({ kind: 'load_param', name: 'txPreimage' });
+        const outputHashRef = methodCtx.emit({ kind: 'call', func: 'extractOutputHash', args: [preimageRef2] });
+        const eqRef = methodCtx.emit({ kind: 'bin_op', op: '===', left: hashRef, right: outputHashRef, result_type: 'bytes' });
+        methodCtx.emit({ kind: 'assert', value: eqRef });
+      }
+
+      // Append implicit txPreimage param to the method's param list
+      const augmentedParams: ParamNode[] = [
+        ...method.params,
+        { kind: 'param', name: 'txPreimage', type: { kind: 'primitive_type', name: 'SigHashPreimage' } },
+      ];
+
+      result.push({
+        name: method.name,
+        params: lowerParams(augmentedParams),
+        body: methodCtx.bindings,
+        isPublic: true,
+      });
+    } else {
+      lowerStatements(method.body, methodCtx);
+      result.push({
+        name: method.name,
+        params: lowerParams(method.params),
+        body: methodCtx.bindings,
+        isPublic: method.visibility === 'public',
+      });
+    }
   }
 
   return result;
@@ -400,6 +437,10 @@ function lowerExprToRef(expr: Expression, ctx: LoweringContext): string {
       return lowerIdentifier(expr, ctx);
 
     case 'property_access':
+      // this.txPreimage in StatefulSmartContract -> load_param (it's an implicit param, not a stored property)
+      if (ctx.isParam(expr.property)) {
+        return ctx.emit({ kind: 'load_param', name: expr.property });
+      }
       // this.x -> load_prop
       return ctx.emit({ kind: 'load_prop', name: expr.property });
 
@@ -741,4 +782,59 @@ function typeNodeToString(node: TypeNode): string {
     case 'custom_type':
       return node.name;
   }
+}
+
+// ---------------------------------------------------------------------------
+// State mutation analysis for StatefulSmartContract
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether a method mutates any mutable (non-readonly) property.
+ * Conservative: if ANY code path can mutate state, returns true.
+ */
+function methodMutatesState(
+  method: { body: Statement[] },
+  contract: ContractNode,
+): boolean {
+  const mutablePropNames = new Set(
+    contract.properties.filter(p => !p.readonly).map(p => p.name),
+  );
+  if (mutablePropNames.size === 0) return false;
+  return bodyMutatesState(method.body, mutablePropNames);
+}
+
+function bodyMutatesState(stmts: Statement[], mutableProps: Set<string>): boolean {
+  for (const stmt of stmts) {
+    if (stmtMutatesState(stmt, mutableProps)) return true;
+  }
+  return false;
+}
+
+function stmtMutatesState(stmt: Statement, mutableProps: Set<string>): boolean {
+  switch (stmt.kind) {
+    case 'assignment':
+      if (stmt.target.kind === 'property_access' && mutableProps.has(stmt.target.property)) {
+        return true;
+      }
+      return false;
+    case 'expression_statement':
+      return exprMutatesState(stmt.expression, mutableProps);
+    case 'if_statement':
+      return bodyMutatesState(stmt.then, mutableProps) ||
+             (stmt.else ? bodyMutatesState(stmt.else, mutableProps) : false);
+    case 'for_statement':
+      return stmtMutatesState(stmt.update, mutableProps) ||
+             bodyMutatesState(stmt.body, mutableProps);
+    default:
+      return false;
+  }
+}
+
+function exprMutatesState(expr: Expression, mutableProps: Set<string>): boolean {
+  if (expr.kind === 'increment_expr' || expr.kind === 'decrement_expr') {
+    if (expr.operand.kind === 'property_access' && mutableProps.has(expr.operand.property)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/tsop-ir-schema/src/tsop-ast.ts
+++ b/packages/tsop-ir-schema/src/tsop-ast.ts
@@ -58,6 +58,7 @@ export type TypeNode = PrimitiveTypeNode | FixedArrayTypeNode | CustomTypeNode;
 export interface ContractNode {
   kind: 'contract';
   name: string;
+  parentClass: 'SmartContract' | 'StatefulSmartContract';
   properties: PropertyNode[];
   constructor: MethodNode;
   methods: MethodNode[];

--- a/packages/tsop-lang/README.md
+++ b/packages/tsop-lang/README.md
@@ -182,20 +182,35 @@ Supported lengths: 0-16 have direct tuple definitions. Lengths >16 use a recursi
 
 ---
 
-## Preimage Utilities for Stateful Contracts
+## Stateful Contracts
 
-For contracts that use the OP_PUSH_TX pattern:
+Extend `StatefulSmartContract` for contracts with mutable state. The compiler automatically handles preimage verification and state continuation:
+
+```typescript
+import { StatefulSmartContract, assert, extractLocktime } from 'tsop-lang';
+
+class Counter extends StatefulSmartContract {
+  count: bigint;
+  constructor(count: bigint) { super(count); this.count = count; }
+
+  public increment() {
+    this.count++;
+  }
+}
+```
+
+Access preimage fields via `this.txPreimage`:
 
 | Function | Signature | Description |
 |---|---|---|
-| `checkPreimage` | `(preimage: SigHashPreimage) => boolean` | Verify sighash preimage matches transaction |
 | `extractOutputHash` | `(preimage: SigHashPreimage) => Sha256` | Extract the output hash from preimage |
 | `extractLocktime` | `(preimage: SigHashPreimage) => bigint` | Extract locktime from preimage |
-
-Import from the main module:
+| `extractAmount` | `(preimage: SigHashPreimage) => bigint` | Extract input amount from preimage |
+| `extractVersion` | `(preimage: SigHashPreimage) => bigint` | Extract tx version from preimage |
 
 ```typescript
-import { checkPreimage, extractOutputHash } from 'tsop-lang';
+// Example: enforce a deadline
+assert(extractLocktime(this.txPreimage) >= this.deadline);
 ```
 
 ---

--- a/packages/tsop-lang/src/index.ts
+++ b/packages/tsop-lang/src/index.ts
@@ -10,7 +10,7 @@
 // private, readonly, abstract) provide all the expressiveness needed.
 // ---------------------------------------------------------------------------
 
-import type { ByteString, Addr } from './types.js';
+import type { ByteString, Addr, SigHashPreimage as SigHashPreimageType } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Re-exports — types
@@ -184,4 +184,59 @@ export abstract class SmartContract {
       'SmartContract.buildP2PKH() cannot be called at runtime — compile this contract.',
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// StatefulSmartContract base class
+// ---------------------------------------------------------------------------
+
+/**
+ * Base class for stateful TSOP smart contracts.
+ *
+ * Extends {@link SmartContract} with automatic transaction preimage
+ * verification and state continuation. The compiler injects two things
+ * into every public method:
+ *
+ * 1. **Preimage check** — `assert(checkPreimage(txPreimage))` at method
+ *    entry, verifying the sighash preimage is valid for the current
+ *    spending transaction.
+ *
+ * 2. **State continuation** — for methods that modify mutable (non-readonly)
+ *    properties, `assert(hash256(this.getStateScript()) ===
+ *    extractOutputHash(txPreimage))` at method exit, ensuring the
+ *    spending transaction carries the updated state forward.
+ *
+ * Contract methods can access preimage fields via the implicit
+ * `this.txPreimage` property and the `extract*` helpers:
+ *
+ * ```ts
+ * import { StatefulSmartContract, assert, extractLocktime } from 'tsop-lang';
+ * import type { PubKey, Sig } from 'tsop-lang';
+ *
+ * class Counter extends StatefulSmartContract {
+ *   count: bigint;
+ *
+ *   constructor(count: bigint) {
+ *     super(count);
+ *     this.count = count;
+ *   }
+ *
+ *   public increment() {
+ *     this.count++;
+ *   }
+ * }
+ * ```
+ */
+export abstract class StatefulSmartContract extends SmartContract {
+  /**
+   * The sighash preimage for the current spending transaction.
+   *
+   * Automatically verified by the compiler at method entry via
+   * `checkPreimage()`. Use the `extract*` helpers to read fields:
+   *
+   * ```ts
+   * assert(extractLocktime(this.txPreimage) >= this.deadline);
+   * ```
+   */
+  protected readonly txPreimage!: SigHashPreimageType;
 }

--- a/packages/tsop-testing/src/__tests__/interpreter.test.ts
+++ b/packages/tsop-testing/src/__tests__/interpreter.test.ts
@@ -66,6 +66,7 @@ function makeContract(methods: MethodNode[]): ContractNode {
   return {
     kind: 'contract',
     name: 'TestContract',
+    parentClass: 'SmartContract',
     properties: [],
     constructor: makeMethod('constructor', [], [], 'public'),
     methods,

--- a/spec/grammar.md
+++ b/spec/grammar.md
@@ -58,18 +58,24 @@ ImportSpecifier
 
 ```ebnf
 ContractDeclaration
-    = [ 'export' ] 'class' Identifier 'extends' 'SmartContract' '{'
+    = [ 'export' ] 'class' Identifier 'extends' BaseClass '{'
           { PropertyDeclaration }
           ConstructorDeclaration
           { MethodDeclaration }
       '}'
+    ;
+
+BaseClass
+    = 'SmartContract'
+    | 'StatefulSmartContract'
     ;
 ```
 
 ### Rules
 
 - Exactly one class per file.
-- The class MUST extend `SmartContract` directly (no intermediate base classes).
+- The class MUST extend `SmartContract` (stateless) or `StatefulSmartContract` (stateful).
+- `StatefulSmartContract` automatically handles preimage verification and state continuation for public methods.
 - Decorators are **disallowed**.
 - Generic type parameters on the class are **disallowed**.
 
@@ -86,7 +92,7 @@ PropertyDeclaration
 ### Semantics
 
 - **`readonly`** properties are immutable. They are set in the constructor and cannot be reassigned. They are embedded in the locking script at deployment time.
-- **Non-`readonly`** properties are stateful. They can be modified within public methods and their new values are propagated across transactions via `OP_PUSH_TX`.
+- **Non-`readonly`** properties are stateful. They can be modified within public methods and their new values are propagated across transactions via `OP_PUSH_TX`. Contracts with mutable properties should extend `StatefulSmartContract`, which automatically handles preimage verification and state continuation.
 - Properties MUST NOT have initializers at the declaration site; all initialization happens in the constructor.
 - Access modifiers (`public`, `private`, `protected`) on properties are **optional** but have no semantic effect in TSOP -- all properties are accessible within the contract.
 

--- a/spec/type-system.md
+++ b/spec/type-system.md
@@ -441,7 +441,7 @@ const val: bigint = matrix[0n][1n];  // 2n
 ### 9.4 Stateful Contract Types
 
 ```typescript
-export class Counter extends SmartContract {
+export class Counter extends StatefulSmartContract {
     counter: bigint;  // mutable -- state is carried across transactions
 
     constructor(counter: bigint) {
@@ -449,9 +449,9 @@ export class Counter extends SmartContract {
         this.counter = counter;
     }
 
-    public increment(amount: bigint, preimage: SigHashPreimage): void {
+    public increment(amount: bigint): void {
         this.counter += amount;
-        assert(this.checkPreimage(preimage));  // verifies new state
+        // Compiler auto-injects: checkPreimage at entry, state continuation at exit
     }
 }
 ```


### PR DESCRIPTION
This pull request introduces first-class support for stateful smart contracts by adding a new `StatefulSmartContract` base class and updating both the TypeScript examples and the Go/Rust compilers to handle automatic state continuation and preimage verification. The changes eliminate the need for developers to manually handle sighash preimage logic and state propagation in contract methods, making stateful contract development easier and less error-prone.

**Language-level changes:**

* Updated the documentation and contract examples in `README.md` to use `StatefulSmartContract` for stateful contracts, and clarified that preimage verification and state continuation are now handled automatically by the compiler. Developers can access preimage fields via `this.txPreimage` if needed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L320-R344) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L354-L358)

**Go compiler enhancements:**

* Added parsing and tracking of the `ParentClass` (`SmartContract` vs. `StatefulSmartContract`) in AST nodes, and updated the parser to recognize both base classes. [[1]](diffhunk://#diff-1e52218f7e5ace38b5591f049c4a2b381f96be306a5bc839d09003e190ebe31dR54) [[2]](diffhunk://#diff-b92472d00660b86297dfb804afddf734e5d1baa67873071a2506cf3e9ac05400L42-R42) [[3]](diffhunk://#diff-b92472d00660b86297dfb804afddf734e5d1baa67873071a2506cf3e9ac05400L131-R138) [[4]](diffhunk://#diff-b92472d00660b86297dfb804afddf734e5d1baa67873071a2506cf3e9ac05400R196)
* Modified the ANF lowering logic to automatically inject preimage verification and state continuation assertions at the entry and exit of public methods in `StatefulSmartContract` subclasses. Also, the implicit `txPreimage` parameter is registered and handled in method contexts and property access logic. [[1]](diffhunk://#diff-7d3607bb72492a82077f92a5ce5d3c9f07d3a0652d43e7b6ee02703fa31b10f3R136-R171) [[2]](diffhunk://#diff-7d3607bb72492a82077f92a5ce5d3c9f07d3a0652d43e7b6ee02703fa31b10f3R180) [[3]](diffhunk://#diff-7d3607bb72492a82077f92a5ce5d3c9f07d3a0652d43e7b6ee02703fa31b10f3R211-R218) [[4]](diffhunk://#diff-7d3607bb72492a82077f92a5ce5d3c9f07d3a0652d43e7b6ee02703fa31b10f3R251-R260) [[5]](diffhunk://#diff-7d3607bb72492a82077f92a5ce5d3c9f07d3a0652d43e7b6ee02703fa31b10f3L248-R312) [[6]](diffhunk://#diff-7d3607bb72492a82077f92a5ce5d3c9f07d3a0652d43e7b6ee02703fa31b10f3R509-R512) [[7]](diffhunk://#diff-7d3607bb72492a82077f92a5ce5d3c9f07d3a0652d43e7b6ee02703fa31b10f3L511-R572)
* Added state mutation analysis to determine whether a method mutates contract state, ensuring that state continuation checks are only injected when necessary.
* Updated the type checker to recognize the implicit `txPreimage` property for stateful contracts.
* Relaxed the validator requirement for public methods to end with `assert()` if the contract is stateful, since the compiler now auto-injects the final assertion.

**Rust compiler enhancements:**

* Mirrored the Go compiler changes: added support for tracking the parent class, injected preimage verification and state continuation assertions in public methods of `StatefulSmartContract` subclasses, and handled the implicit `txPreimage` parameter throughout the lowering and property access logic. [[1]](diffhunk://#diff-9b20a536f5f21b6655cc3b2209eceabb7f80407d063541c3ff5db17e279159dcR80-R137) [[2]](diffhunk://#diff-9b20a536f5f21b6655cc3b2209eceabb7f80407d063541c3ff5db17e279159dcR146) [[3]](diffhunk://#diff-9b20a536f5f21b6655cc3b2209eceabb7f80407d063541c3ff5db17e279159dcR175) [[4]](diffhunk://#diff-9b20a536f5f21b6655cc3b2209eceabb7f80407d063541c3ff5db17e279159dcR185) [[5]](diffhunk://#diff-9b20a536f5f21b6655cc3b2209eceabb7f80407d063541c3ff5db17e279159dcR215-R223) [[6]](diffhunk://#diff-9b20a536f5f21b6655cc3b2209eceabb7f80407d063541c3ff5db17e279159dcL168-R242) [[7]](diffhunk://#diff-9b20a536f5f21b6655cc3b2209eceabb7f80407d063541c3ff5db17e279159dcR470-R475) [[8]](diffhunk://#diff-9b20a536f5f21b6655cc3b2209eceabb7f80407d063541c3ff5db17e279159dcL445-R527)