### PR TITLE
feat: add PriceBet webapp, regtest demo, and signer fix

### DIFF
--- a/end2end-example/go/cmd/dump-compiled/main.go
+++ b/end2end-example/go/cmd/dump-compiled/main.go
@@ -454,11 +454,11 @@ Inside cancel(aliceSig, bobSig):
 │  TX 1: FUNDING (creates the bet UTXO)                          │
 ├─────────────────────────────────────────────────────────────────┤
 │  Inputs:                                                        │
-│    [0] Alice funds (e.g. 0.5 BSV)                               │
-│    [1] Bob funds   (e.g. 0.5 BSV)                               │
+│    [0] Alice funds (1 BSV)                                      │
+│    [1] Bob funds   (1 BSV)                                      │
 │  Outputs:                                                       │
 │    [0] PriceBet UTXO                                            │
-│        satoshis:       100,000,000  (1 BSV combined)            │
+│        satoshis:       200,000,000  (2 BSV combined)            │
 │        locking script: <compiled PriceBet>  (%d bytes)          │
 └─────────────────────────────────────────────────────────────────┘
 

--- a/end2end-example/ts/regtest-demo.ts
+++ b/end2end-example/ts/regtest-demo.ts
@@ -1,0 +1,708 @@
+/**
+ * PriceBet Regtest Interactive Demo
+ *
+ * Walks through the complete lifecycle of a Rúnar smart contract on a real
+ * BSV regtest node: key generation, funding, compilation, deployment, and
+ * spending (cancel path with 2-of-2 ECDSA signatures).
+ *
+ * Prerequisites:
+ *   - BSV regtest node running on localhost:18332
+ *   - Node wallet loaded and funded (mine some blocks first)
+ *   - pnpm install && pnpm run build
+ *
+ * Run:
+ *   npx tsx end2end-example/ts/regtest-demo.ts
+ *
+ * Environment variables:
+ *   RPC_URL   - JSON-RPC endpoint (default: http://localhost:18332)
+ *   RPC_USER  - RPC username (default: rpc)
+ *   RPC_PASS  - RPC password (default: rpc)
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createInterface } from 'node:readline';
+import { randomBytes, createHash } from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { compile } from '../../packages/runar-compiler/src/index.js';
+import { LocalSigner } from '../../packages/runar-sdk/src/signers/local.js';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Configuration
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const RPC_URL  = process.env.RPC_URL  ?? 'http://localhost:18332';
+const RPC_USER = process.env.RPC_USER ?? 'bitcoin';
+const RPC_PASS = process.env.RPC_PASS ?? 'bitcoin';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ANSI colors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const C = {
+  reset:   '\x1b[0m',
+  bold:    '\x1b[1m',
+  dim:     '\x1b[2m',
+  cyan:    '\x1b[36m',
+  green:   '\x1b[32m',
+  yellow:  '\x1b[33m',
+  red:     '\x1b[31m',
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Display helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function banner(step: number, title: string): void {
+  console.log();
+  console.log(`${C.cyan}${'═'.repeat(72)}${C.reset}`);
+  console.log(`${C.cyan}${C.bold}  Step ${step}: ${title}${C.reset}`);
+  console.log(`${C.cyan}${'═'.repeat(72)}${C.reset}`);
+  console.log();
+}
+
+function label(name: string, value: string): void {
+  console.log(`  ${C.dim}${name.padEnd(22)}${C.reset} ${value}`);
+}
+
+function ok(msg: string): void {
+  console.log(`  ${C.green}✓${C.reset} ${msg}`);
+}
+
+function heading(msg: string): void {
+  console.log(`\n  ${C.bold}${msg}${C.reset}`);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Interactive pause (readline)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+function pause(prompt = 'Press Enter to continue...'): Promise<void> {
+  return new Promise(resolve => {
+    rl.question(`\n  ${C.dim}${prompt}${C.reset}`, () => resolve());
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Crypto helpers (Node.js native — no @bsv/sdk dependency)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function sha256(data: Buffer): Buffer {
+  return createHash('sha256').update(data).digest();
+}
+
+function hash256(data: Buffer): Buffer {
+  return sha256(sha256(data));
+}
+
+function hash160(data: Buffer): Buffer {
+  return createHash('ripemd160').update(sha256(data)).digest();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Base58Check encoding (for testnet/regtest addresses)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const BASE58_CHARS = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function base58Encode(data: Buffer): string {
+  let zeros = 0;
+  for (const b of data) {
+    if (b === 0) zeros++;
+    else break;
+  }
+
+  let n = BigInt('0x' + data.toString('hex'));
+  let result = '';
+  while (n > 0n) {
+    result = BASE58_CHARS[Number(n % 58n)] + result;
+    n /= 58n;
+  }
+
+  return '1'.repeat(zeros) + result;
+}
+
+function toBase58Check(payload: Buffer, version: number): string {
+  const versioned = Buffer.concat([Buffer.from([version]), payload]);
+  const checksum = hash256(versioned).subarray(0, 4);
+  return base58Encode(Buffer.concat([versioned, checksum]));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Hex / byte utilities
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function hexToBytes(hex: string): Buffer {
+  return Buffer.from(hex, 'hex');
+}
+
+function bytesToHex(buf: Buffer | Uint8Array): string {
+  return Buffer.from(buf).toString('hex');
+}
+
+function reverseHex(hex: string): string {
+  const pairs: string[] = [];
+  for (let i = 0; i < hex.length; i += 2) {
+    pairs.push(hex.slice(i, i + 2));
+  }
+  return pairs.reverse().join('');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Bitcoin wire format helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function toLittleEndian32(n: number): string {
+  const buf = Buffer.alloc(4);
+  buf.writeUInt32LE(n >>> 0);
+  return buf.toString('hex');
+}
+
+function toLittleEndian64(n: number): string {
+  const lo = n & 0xffffffff;
+  const hi = Math.floor(n / 0x100000000) & 0xffffffff;
+  return toLittleEndian32(lo) + toLittleEndian32(hi);
+}
+
+function encodeVarInt(n: number): string {
+  if (n < 0xfd) return n.toString(16).padStart(2, '0');
+  if (n <= 0xffff) {
+    const buf = Buffer.alloc(2);
+    buf.writeUInt16LE(n);
+    return 'fd' + buf.toString('hex');
+  }
+  if (n <= 0xffffffff) return 'fe' + toLittleEndian32(n);
+  return 'ff' + toLittleEndian64(n);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Raw transaction builder
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface TxInput {
+  prevTxid: string;     // hex, normal byte order
+  prevVout: number;
+  scriptSig: string;    // hex, empty string for unsigned
+  sequence: number;
+}
+
+interface TxOutput {
+  satoshis: number;
+  script: string;       // hex locking script
+}
+
+function buildRawTx(inputs: TxInput[], outputs: TxOutput[]): string {
+  let tx = '';
+
+  tx += toLittleEndian32(1);                        // version
+  tx += encodeVarInt(inputs.length);
+
+  for (const inp of inputs) {
+    tx += reverseHex(inp.prevTxid);                 // txid in internal byte order
+    tx += toLittleEndian32(inp.prevVout);
+    tx += encodeVarInt(inp.scriptSig.length / 2);
+    if (inp.scriptSig.length > 0) tx += inp.scriptSig;
+    tx += toLittleEndian32(inp.sequence);
+  }
+
+  tx += encodeVarInt(outputs.length);
+
+  for (const out of outputs) {
+    tx += toLittleEndian64(out.satoshis);
+    tx += encodeVarInt(out.script.length / 2);
+    tx += out.script;
+  }
+
+  tx += toLittleEndian32(0);                        // locktime
+
+  return tx;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Script encoding (for building unlocking scripts)
+// Replicated from packages/runar-sdk/src/contract.ts for self-containment.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function encodeScriptNumber(n: bigint): string {
+  if (n === 0n) return '00';
+  if (n >= 1n && n <= 16n) return (0x50 + Number(n)).toString(16);
+  if (n === -1n) return '4f';
+
+  const negative = n < 0n;
+  let absVal = negative ? -n : n;
+  const bytes: number[] = [];
+
+  while (absVal > 0n) {
+    bytes.push(Number(absVal & 0xffn));
+    absVal >>= 8n;
+  }
+
+  if ((bytes[bytes.length - 1]! & 0x80) !== 0) {
+    bytes.push(negative ? 0x80 : 0x00);
+  } else if (negative) {
+    bytes[bytes.length - 1]! |= 0x80;
+  }
+
+  const hex = bytes.map(b => b.toString(16).padStart(2, '0')).join('');
+  return encodePushDataHex(hex);
+}
+
+function encodePushDataHex(dataHex: string): string {
+  if (dataHex.length === 0) return '00';
+  const len = dataHex.length / 2;
+
+  if (len <= 75) return len.toString(16).padStart(2, '0') + dataHex;
+  if (len <= 0xff) return '4c' + len.toString(16).padStart(2, '0') + dataHex;
+  if (len <= 0xffff) {
+    const lo = (len & 0xff).toString(16).padStart(2, '0');
+    const hi = ((len >> 8) & 0xff).toString(16).padStart(2, '0');
+    return '4d' + lo + hi + dataHex;
+  }
+  const b0 = (len & 0xff).toString(16).padStart(2, '0');
+  const b1 = ((len >> 8) & 0xff).toString(16).padStart(2, '0');
+  const b2 = ((len >> 16) & 0xff).toString(16).padStart(2, '0');
+  const b3 = ((len >> 24) & 0xff).toString(16).padStart(2, '0');
+  return '4e' + b0 + b1 + b2 + b3 + dataHex;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// P2PKH helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function pubKeyHashFrom(compressedPubKeyHex: string): Buffer {
+  return hash160(hexToBytes(compressedPubKeyHex));
+}
+
+function buildP2PKHScript(pubKeyHash: Buffer): string {
+  return '76a914' + bytesToHex(pubKeyHash) + '88ac';
+}
+
+function toTestnetAddress(pubKeyHash: Buffer): string {
+  return toBase58Check(pubKeyHash, 0x6f);   // 0x6f = testnet/regtest
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// JSON-RPC helper
+// ═══════════════════════════════════════════════════════════════════════════════
+
+let rpcId = 1;
+
+async function rpc(method: string, params: unknown[] = []): Promise<unknown> {
+  const body = JSON.stringify({ jsonrpc: '1.0', id: rpcId++, method, params });
+  const auth = Buffer.from(`${RPC_USER}:${RPC_PASS}`).toString('base64');
+
+  const res = await fetch(RPC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Basic ${auth}`,
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`RPC ${method} failed (HTTP ${res.status}): ${text}`);
+  }
+
+  const json = await res.json() as { result: unknown; error: { message: string } | null };
+  if (json.error) throw new Error(`RPC ${method}: ${json.error.message}`);
+  return json.result;
+}
+
+async function mine(nBlocks = 1): Promise<void> {
+  try {
+    await rpc('generate', [nBlocks]);
+  } catch {
+    const addr = await rpc('getnewaddress') as string;
+    await rpc('generatetoaddress', [nBlocks, addr]);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// UTXO lookup: find the output matching a known P2PKH script in a TX
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface FoundUtxo {
+  txid: string;
+  vout: number;
+  satoshis: number;
+  script: string;
+}
+
+async function findUtxo(txid: string, expectedScript: string): Promise<FoundUtxo> {
+  const tx = await rpc('getrawtransaction', [txid, true]) as {
+    vout: Array<{ value: number; n: number; scriptPubKey: { hex: string } }>;
+  };
+
+  for (const v of tx.vout) {
+    if (v.scriptPubKey.hex === expectedScript) {
+      return {
+        txid,
+        vout: v.n,
+        satoshis: Math.round(v.value * 1e8),
+        script: v.scriptPubKey.hex,
+      };
+    }
+  }
+
+  throw new Error(`No output matching expected script in TX ${txid}`);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Main demo
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function main(): Promise<void> {
+  console.log(`\n${C.cyan}${C.bold}`);
+  console.log('  ┌────────────────────────────────────────────────────────────────┐');
+  console.log('  │           PriceBet Regtest Interactive Demo                    │');
+  console.log('  │                                                                │');
+  console.log('  │  Deploys a Rúnar smart contract to a real BSV regtest node     │');
+  console.log('  │  and spends it using the cancel path (2-of-2 ECDSA).          │');
+  console.log('  └────────────────────────────────────────────────────────────────┘');
+  console.log(`${C.reset}`);
+
+  label('RPC endpoint', RPC_URL);
+  label('RPC user', RPC_USER);
+
+  try {
+    const info = await rpc('getblockchaininfo') as { chain: string; blocks: number };
+    label('Network', info.chain);
+    label('Block height', String(info.blocks));
+
+    if (info.chain !== 'regtest') {
+      console.log(`\n  ${C.red}Not connected to regtest (chain=${info.chain}). Aborting.${C.reset}`);
+      process.exit(1);
+    }
+    ok('Connected to regtest node');
+  } catch (e) {
+    console.log(`\n  ${C.red}Cannot connect to BSV regtest node at ${RPC_URL}${C.reset}`);
+    console.log(`  ${C.dim}Make sure the node is running and RPC credentials are correct.${C.reset}`);
+    console.log(`  ${C.dim}Set RPC_URL, RPC_USER, RPC_PASS environment variables if needed.${C.reset}`);
+    if (e instanceof Error) console.log(`  ${C.dim}${e.message}${C.reset}`);
+    process.exit(1);
+  }
+
+  await pause();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Step 1: Generate Key Pairs
+  // ─────────────────────────────────────────────────────────────────────────
+
+  banner(1, 'Generate Key Pairs');
+  console.log('  Creating fresh secp256k1 key pairs for Alice and Bob.');
+  console.log('  These will sign real on-chain transactions.\n');
+
+  const alicePrivHex = randomBytes(32).toString('hex');
+  const bobPrivHex   = randomBytes(32).toString('hex');
+
+  const aliceSigner = new LocalSigner(alicePrivHex);
+  const bobSigner   = new LocalSigner(bobPrivHex);
+
+  const alicePubKey = await aliceSigner.getPublicKey();
+  const bobPubKey   = await bobSigner.getPublicKey();
+
+  const alicePKH    = pubKeyHashFrom(alicePubKey);
+  const bobPKH      = pubKeyHashFrom(bobPubKey);
+  const aliceAddr   = toTestnetAddress(alicePKH);
+  const bobAddr     = toTestnetAddress(bobPKH);
+  const aliceP2PKH  = buildP2PKHScript(alicePKH);
+  const bobP2PKH    = buildP2PKHScript(bobPKH);
+
+  heading('Alice');
+  label('Private key', alicePrivHex);
+  label('Public key', alicePubKey);
+  label('Address (regtest)', aliceAddr);
+
+  heading('Bob');
+  label('Private key', bobPrivHex);
+  label('Public key', bobPubKey);
+  label('Address (regtest)', bobAddr);
+
+  await pause();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Step 2: Fund Wallets
+  // ─────────────────────────────────────────────────────────────────────────
+
+  banner(2, 'Fund Wallets');
+  console.log('  Sending 1 BSV to each party from the regtest node wallet.\n');
+
+  const aliceFundTxid = await rpc('sendtoaddress', [aliceAddr, 1.0]) as string;
+  ok(`Sent 1 BSV to Alice  txid: ${aliceFundTxid}`);
+
+  const bobFundTxid = await rpc('sendtoaddress', [bobAddr, 1.0]) as string;
+  ok(`Sent 1 BSV to Bob    txid: ${bobFundTxid}`);
+
+  heading('Mining a block to confirm');
+  await mine(1);
+  ok('Block mined');
+
+  heading('Locating UTXOs');
+  const aliceUtxo = await findUtxo(aliceFundTxid, aliceP2PKH);
+  const bobUtxo   = await findUtxo(bobFundTxid, bobP2PKH);
+
+  label('Alice UTXO', `${aliceUtxo.txid}:${aliceUtxo.vout}  ${aliceUtxo.satoshis} sats`);
+  label('Bob UTXO',   `${bobUtxo.txid}:${bobUtxo.vout}  ${bobUtxo.satoshis} sats`);
+
+  await pause();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Step 3: Compile the PriceBet Contract
+  // ─────────────────────────────────────────────────────────────────────────
+
+  banner(3, 'Compile PriceBet Contract');
+  console.log('  Compiling with real public keys baked into the locking script.');
+  console.log('  Oracle key and strike price are arbitrary (we use the cancel path).\n');
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(__dirname, 'PriceBet.runar.ts'), 'utf8');
+
+  const ORACLE_PK = 12345n;
+  const STRIKE    = 50000n;
+
+  const result = compile(source, {
+    fileName: 'PriceBet.runar.ts',
+    constructorArgs: {
+      alicePubKey:  alicePubKey,
+      bobPubKey:    bobPubKey,
+      oraclePubKey: ORACLE_PK,
+      strikePrice:  STRIKE,
+    },
+  });
+
+  if (!result.success || !result.scriptHex) {
+    console.log(`\n  ${C.red}Compilation failed:${C.reset}`);
+    for (const d of result.diagnostics) console.log(`    [${d.severity}] ${d.message}`);
+    process.exit(1);
+  }
+
+  const lockingScript = result.scriptHex;
+  const scriptAsm     = result.scriptAsm!;
+
+  ok('Compilation successful');
+  label('Script size', `${lockingScript.length / 2} bytes`);
+  label('Methods', 'settle (index 0), cancel (index 1)');
+
+  heading('ASM preview (first 10 opcodes)');
+  const asmParts = scriptAsm.split(' ');
+  for (let i = 0; i < Math.min(10, asmParts.length); i++) {
+    console.log(`    ${String(i + 1).padStart(3)}: ${asmParts[i]}`);
+  }
+  if (asmParts.length > 10) console.log(`    ... (${asmParts.length - 10} more)`);
+
+  heading('Locking script hex');
+  console.log(`    ${lockingScript}`);
+
+  await pause();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Step 4: Deploy Contract (Funding TX)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  banner(4, 'Deploy Contract (Funding TX)');
+  console.log('  Building a TX that creates the PriceBet UTXO on-chain.');
+  console.log('  Alice and Bob each contribute 1 BSV — the full 2 BSV goes to the bet.\n');
+
+  const CONTRACT_SATS = 200_000_000;  // 2 BSV (1 BSV from each party)
+
+  heading('Transaction layout');
+  label('Input  0', `Alice UTXO (${aliceUtxo.satoshis} sats)`);
+  label('Input  1', `Bob UTXO (${bobUtxo.satoshis} sats)`);
+  label('Output 0', `PriceBet locking script (${CONTRACT_SATS} sats)`);
+  label('Fee', '0 sats');
+
+  const fundOutputs: TxOutput[] = [
+    { satoshis: CONTRACT_SATS, script: lockingScript },
+  ];
+
+  // Build unsigned TX (empty scriptSigs)
+  const unsignedFundTx = buildRawTx(
+    [
+      { prevTxid: aliceUtxo.txid, prevVout: aliceUtxo.vout, scriptSig: '', sequence: 0xffffffff },
+      { prevTxid: bobUtxo.txid,   prevVout: bobUtxo.vout,   scriptSig: '', sequence: 0xffffffff },
+    ],
+    fundOutputs,
+  );
+
+  heading('Signing (BIP-143 / SIGHASH_ALL|FORKID)');
+
+  // Alice signs input 0 (her P2PKH UTXO)
+  const aliceFundSig = await aliceSigner.sign(
+    unsignedFundTx, 0, aliceUtxo.script, aliceUtxo.satoshis,
+  );
+  ok(`Alice signed input 0 (${aliceFundSig.length / 2} bytes)`);
+
+  // Bob signs input 1 (his P2PKH UTXO)
+  const bobFundSig = await bobSigner.sign(
+    unsignedFundTx, 1, bobUtxo.script, bobUtxo.satoshis,
+  );
+  ok(`Bob signed input 1 (${bobFundSig.length / 2} bytes)`);
+
+  // Build P2PKH unlocking scripts: <sig> <pubkey>
+  const aliceUnlock = encodePushDataHex(aliceFundSig) + encodePushDataHex(alicePubKey);
+  const bobUnlock   = encodePushDataHex(bobFundSig)   + encodePushDataHex(bobPubKey);
+
+  // Rebuild TX with real scriptSigs
+  const signedFundTx = buildRawTx(
+    [
+      { prevTxid: aliceUtxo.txid, prevVout: aliceUtxo.vout, scriptSig: aliceUnlock, sequence: 0xffffffff },
+      { prevTxid: bobUtxo.txid,   prevVout: bobUtxo.vout,   scriptSig: bobUnlock,   sequence: 0xffffffff },
+    ],
+    fundOutputs,
+  );
+
+  heading('Broadcasting');
+  label('Signed TX size', `${signedFundTx.length / 2} bytes`);
+
+  heading('Complete transaction hex');
+  console.log(`    ${signedFundTx}`);
+
+  const contractTxid = await rpc('sendrawtransaction', [signedFundTx]) as string;
+  ok(`Funding TX accepted: ${contractTxid}`);
+
+  await mine(1);
+  ok('Block mined — contract UTXO confirmed');
+
+  const contractTxInfo = await rpc('getrawtransaction', [contractTxid, true]) as {
+    confirmations: number; size: number;
+  };
+  label('Confirmations', String(contractTxInfo.confirmations));
+  label('Contract UTXO', `${contractTxid}:0  ${CONTRACT_SATS} sats`);
+
+  await pause();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Step 5: Spend Contract (Cancel TX)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  banner(5, 'Spend Contract (Cancel TX)');
+  console.log('  Both Alice and Bob agree to cancel. They each sign the spending TX.');
+  console.log('  The unlocking script pushes: <aliceSig> <bobSig> <1>');
+  console.log('  where 1 is the method selector for cancel().\n');
+
+  const aliceRefund = 100_000_000;  // 1 BSV back to Alice
+  const bobRefund   = 100_000_000;  // 1 BSV back to Bob
+
+  heading('Transaction layout');
+  label('Input  0', `PriceBet UTXO (${CONTRACT_SATS} sats)`);
+  label('Output 0', `Alice P2PKH (${aliceRefund} sats)`);
+  label('Output 1', `Bob P2PKH (${bobRefund} sats)`);
+  label('Fee', '0 sats');
+
+  const cancelOutputs: TxOutput[] = [
+    { satoshis: aliceRefund, script: aliceP2PKH },
+    { satoshis: bobRefund,   script: bobP2PKH },
+  ];
+
+  // Build unsigned TX (empty scriptSig — BIP-143 doesn't include it)
+  const unsignedCancelTx = buildRawTx(
+    [{ prevTxid: contractTxid, prevVout: 0, scriptSig: '', sequence: 0xffffffff }],
+    cancelOutputs,
+  );
+
+  heading('Signing (both parties sign the same sighash for input 0)');
+  console.log(`  ${C.dim}subscript = PriceBet locking script (${lockingScript.length / 2} bytes)${C.reset}`);
+  console.log(`  ${C.dim}value     = ${CONTRACT_SATS} satoshis${C.reset}\n`);
+
+  const aliceCancelSig = await aliceSigner.sign(
+    unsignedCancelTx, 0, lockingScript, CONTRACT_SATS,
+  );
+  ok(`Alice signed (${aliceCancelSig.length / 2} bytes DER+hashtype)`);
+
+  const bobCancelSig = await bobSigner.sign(
+    unsignedCancelTx, 0, lockingScript, CONTRACT_SATS,
+  );
+  ok(`Bob signed (${bobCancelSig.length / 2} bytes DER+hashtype)`);
+
+  // Build unlocking script: <aliceSig> <bobSig> <1>
+  // Parameter order matches cancel(aliceSig, bobSig); selector 1 on top.
+  const cancelUnlock =
+    encodePushDataHex(aliceCancelSig) +
+    encodePushDataHex(bobCancelSig) +
+    encodeScriptNumber(1n);           // OP_1 (method selector for cancel)
+
+  label('Unlocking script', `${cancelUnlock.length / 2} bytes`);
+
+  heading('Script execution trace (cancel path)');
+  console.log('    Stack after scriptSig:       [ aliceSig, bobSig, 1 ]');
+  console.log('    OP_DUP OP_0 OP_NUMEQUAL:     [ ..., false ]  (1 != 0)');
+  console.log('    OP_IF → OP_ELSE (cancel):    [ aliceSig, bobSig, 1 ]');
+  console.log('    OP_DROP:                      [ aliceSig, bobSig ]');
+  console.log('    OP_SWAP:                      [ bobSig, aliceSig ]');
+  console.log(`    push <alicePK> CHECKSIGVERIFY [ bobSig ]              ${C.green}✓${C.reset}`);
+  console.log(`    push <bobPK>   CHECKSIG       [ true ]               ${C.green}✓${C.reset}`);
+
+  // Rebuild TX with the real unlocking script
+  const signedCancelTx = buildRawTx(
+    [{ prevTxid: contractTxid, prevVout: 0, scriptSig: cancelUnlock, sequence: 0xffffffff }],
+    cancelOutputs,
+  );
+
+  heading('Broadcasting');
+  label('Signed TX size', `${signedCancelTx.length / 2} bytes`);
+
+  const cancelTxid = await rpc('sendrawtransaction', [signedCancelTx]) as string;
+  ok(`Cancel TX accepted: ${cancelTxid}`);
+
+  await mine(1);
+  ok('Block mined — refunds confirmed');
+
+  const cancelTxInfo = await rpc('getrawtransaction', [cancelTxid, true]) as {
+    confirmations: number; size: number;
+  };
+  label('Confirmations', String(cancelTxInfo.confirmations));
+
+  await pause();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Step 6: Verify On-Chain State
+  // ─────────────────────────────────────────────────────────────────────────
+
+  banner(6, 'Verify On-Chain State');
+
+  heading('Transaction chain');
+  console.log();
+  console.log('    Faucet');
+  console.log('      ├─ 1 BSV → Alice    txid: ' + aliceFundTxid);
+  console.log('      └─ 1 BSV → Bob      txid: ' + bobFundTxid);
+  console.log('              ↓');
+  console.log(`    ${C.cyan}Funding TX${C.reset}  (Alice + Bob → PriceBet UTXO)`);
+  console.log('      txid: ' + contractTxid);
+  console.log('      output 0: PriceBet locking script  ' + CONTRACT_SATS + ' sats');
+  console.log('              ↓');
+  console.log(`    ${C.green}Cancel TX${C.reset}   (PriceBet → Alice + Bob refunds)`);
+  console.log('      txid: ' + cancelTxid);
+
+  const verifyTx = await rpc('getrawtransaction', [cancelTxid, true]) as {
+    vout: Array<{ value: number; n: number; scriptPubKey: { hex: string } }>;
+  };
+
+  for (const v of verifyTx.vout) {
+    const who = v.scriptPubKey.hex === aliceP2PKH ? 'Alice' :
+                v.scriptPubKey.hex === bobP2PKH   ? 'Bob' : 'Unknown';
+    const sats = Math.round(v.value * 1e8);
+    console.log(`      output ${v.n}: ${who.padEnd(6)} P2PKH            ${sats} sats`);
+  }
+
+  console.log();
+  console.log(`  ${C.green}${C.bold}${'─'.repeat(62)}${C.reset}`);
+  console.log(`  ${C.green}${C.bold}  Demo complete!${C.reset}`);
+  console.log(`  ${C.green}${C.bold}  PriceBet was deployed and spent on a real BSV regtest node.${C.reset}`);
+  console.log(`  ${C.green}${C.bold}  Cancel path: 2-of-2 ECDSA signatures verified by Bitcoin Script.${C.reset}`);
+  console.log(`  ${C.green}${C.bold}${'─'.repeat(62)}${C.reset}`);
+  console.log();
+
+  rl.close();
+  try { execSync('afplay /System/Library/Sounds/Submarine.aiff', { stdio: 'ignore' }); } catch {}
+}
+
+main().catch(err => {
+  console.error(`\n${C.red}Fatal: ${err.message ?? err}${C.reset}`);
+  rl.close();
+  process.exit(1);
+});

--- a/end2end-example/webapp/bitcoin.go
+++ b/end2end-example/webapp/bitcoin.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync/atomic"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	sighash "github.com/bsv-blockchain/go-sdk/transaction/sighash"
+	"github.com/bsv-blockchain/go-sdk/transaction/template/p2pkh"
+)
+
+var rpcID atomic.Int64
+
+func rpcURL() string {
+	if v := os.Getenv("RPC_URL"); v != "" {
+		return v
+	}
+	return "http://localhost:18332"
+}
+
+func rpcUser() string {
+	if v := os.Getenv("RPC_USER"); v != "" {
+		return v
+	}
+	return "bitcoin"
+}
+
+func rpcPass() string {
+	if v := os.Getenv("RPC_PASS"); v != "" {
+		return v
+	}
+	return "bitcoin"
+}
+
+type rpcRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int64       `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func rpcCall(method string, params ...interface{}) (json.RawMessage, error) {
+	if params == nil {
+		params = []interface{}{}
+	}
+
+	body, _ := json.Marshal(rpcRequest{
+		JSONRPC: "1.0",
+		ID:      rpcID.Add(1),
+		Method:  method,
+		Params:  params,
+	})
+
+	req, _ := http.NewRequest("POST", rpcURL(), bytes.NewReader(body))
+	req.SetBasicAuth(rpcUser(), rpcPass())
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("RPC %s: %w", method, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("RPC %s HTTP %d: %s", method, resp.StatusCode, string(respBody))
+	}
+
+	var rpcResp rpcResponse
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+		return nil, fmt.Errorf("RPC %s: bad JSON: %w", method, err)
+	}
+
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("RPC %s: %s", method, rpcResp.Error.Message)
+	}
+
+	return rpcResp.Result, nil
+}
+
+func mine(nBlocks int) error {
+	_, err := rpcCall("generate", nBlocks)
+	if err != nil {
+		addr, err2 := rpcCall("getnewaddress")
+		if err2 != nil {
+			return fmt.Errorf("mine: %w", err)
+		}
+		var addrStr string
+		json.Unmarshal(addr, &addrStr)
+		_, err = rpcCall("generatetoaddress", nBlocks, addrStr)
+	}
+	return err
+}
+
+type UTXO struct {
+	Txid     string
+	Vout     uint32
+	Satoshis uint64
+	Script   string
+}
+
+type Wallet struct {
+	PrivKey   *ec.PrivateKey
+	PubKey    *ec.PublicKey
+	PubKeyHex string
+	Address   string
+	P2PKH     string
+	Balance   int64
+}
+
+func newWallet() (*Wallet, error) {
+	privKey, err := ec.NewPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey := privKey.PubKey()
+	pubKeyHex := hex.EncodeToString(pubKey.Compressed())
+
+	addr, err := script.NewAddressFromPublicKey(pubKey, false)
+	if err != nil {
+		return nil, err
+	}
+
+	pkh := crypto.Hash160(pubKey.Compressed())
+	p2pkh := "76a914" + hex.EncodeToString(pkh) + "88ac"
+
+	return &Wallet{
+		PrivKey:   privKey,
+		PubKey:    pubKey,
+		PubKeyHex: pubKeyHex,
+		Address:   addr.AddressString,
+		P2PKH:     p2pkh,
+		Balance:   0,
+	}, nil
+}
+
+func fundWallet(address string, btcAmount float64) (string, error) {
+	result, err := rpcCall("sendtoaddress", address, btcAmount)
+	if err != nil {
+		return "", err
+	}
+	var txid string
+	json.Unmarshal(result, &txid)
+	return txid, nil
+}
+
+func findUTXO(txid, expectedScript string) (*UTXO, error) {
+	result, err := rpcCall("getrawtransaction", txid, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var tx struct {
+		Vout []struct {
+			Value        float64 `json:"value"`
+			N            uint32  `json:"n"`
+			ScriptPubKey struct {
+				Hex string `json:"hex"`
+			} `json:"scriptPubKey"`
+		} `json:"vout"`
+	}
+	json.Unmarshal(result, &tx)
+
+	for _, v := range tx.Vout {
+		if v.ScriptPubKey.Hex == expectedScript {
+			sats := uint64(v.Value*1e8 + 0.5)
+			return &UTXO{
+				Txid:     txid,
+				Vout:     v.N,
+				Satoshis: sats,
+				Script:   v.ScriptPubKey.Hex,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no output matching script in TX %s", txid)
+}
+
+func buildFundingTx(alice, bob *Wallet, aliceUTXO, bobUTXO *UTXO, lockingScriptHex string, contractSats uint64) (string, error) {
+	tx := transaction.NewTransaction()
+
+	aliceUnlocker, err := p2pkh.Unlock(alice.PrivKey, nil)
+	if err != nil {
+		return "", fmt.Errorf("alice unlocker: %w", err)
+	}
+	if err := tx.AddInputFrom(aliceUTXO.Txid, aliceUTXO.Vout, aliceUTXO.Script, aliceUTXO.Satoshis, aliceUnlocker); err != nil {
+		return "", fmt.Errorf("add alice input: %w", err)
+	}
+
+	bobUnlocker, err := p2pkh.Unlock(bob.PrivKey, nil)
+	if err != nil {
+		return "", fmt.Errorf("bob unlocker: %w", err)
+	}
+	if err := tx.AddInputFrom(bobUTXO.Txid, bobUTXO.Vout, bobUTXO.Script, bobUTXO.Satoshis, bobUnlocker); err != nil {
+		return "", fmt.Errorf("add bob input: %w", err)
+	}
+
+	lockScript, err := script.NewFromHex(lockingScriptHex)
+	if err != nil {
+		return "", fmt.Errorf("parse lock script: %w", err)
+	}
+	tx.AddOutput(&transaction.TransactionOutput{
+		Satoshis:      contractSats,
+		LockingScript: lockScript,
+	})
+
+	changeSats := aliceUTXO.Satoshis + bobUTXO.Satoshis - contractSats
+	if changeSats > 546 {
+		aliceChangeScript, _ := script.NewFromHex(alice.P2PKH)
+		tx.AddOutput(&transaction.TransactionOutput{
+			Satoshis:      changeSats / 2,
+			LockingScript: aliceChangeScript,
+		})
+		bobChangeScript, _ := script.NewFromHex(bob.P2PKH)
+		tx.AddOutput(&transaction.TransactionOutput{
+			Satoshis:      changeSats - changeSats/2,
+			LockingScript: bobChangeScript,
+		})
+	}
+
+	if err := tx.Sign(); err != nil {
+		return "", fmt.Errorf("sign funding tx: %w", err)
+	}
+
+	return tx.String(), nil
+}
+
+func buildSpendingTx(alice, bob *Wallet, contractUTXO *UTXO, winnerP2PKH string, contractSats uint64) (string, error) {
+	tx := transaction.NewTransaction()
+
+	if err := tx.AddInputFrom(contractUTXO.Txid, contractUTXO.Vout, contractUTXO.Script, contractSats, nil); err != nil {
+		return "", fmt.Errorf("add contract input: %w", err)
+	}
+
+	winnerScript, err := script.NewFromHex(winnerP2PKH)
+	if err != nil {
+		return "", fmt.Errorf("parse winner script: %w", err)
+	}
+	tx.AddOutput(&transaction.TransactionOutput{
+		Satoshis:      contractSats,
+		LockingScript: winnerScript,
+	})
+
+	sigHash, err := tx.CalcInputSignatureHash(0, sighash.AllForkID)
+	if err != nil {
+		return "", fmt.Errorf("calc sighash: %w", err)
+	}
+
+	aliceSig, err := alice.PrivKey.Sign(sigHash)
+	if err != nil {
+		return "", fmt.Errorf("alice sign: %w", err)
+	}
+	aliceSigBytes := append(aliceSig.Serialize(), byte(sighash.AllForkID))
+
+	bobSig, err := bob.PrivKey.Sign(sigHash)
+	if err != nil {
+		return "", fmt.Errorf("bob sign: %w", err)
+	}
+	bobSigBytes := append(bobSig.Serialize(), byte(sighash.AllForkID))
+
+	unlockScript := &script.Script{}
+	_ = unlockScript.AppendPushData(aliceSigBytes)
+	_ = unlockScript.AppendPushData(bobSigBytes)
+	_ = unlockScript.AppendOpcodes(script.Op1)
+
+	tx.Inputs[0].UnlockingScript = unlockScript
+
+	return tx.String(), nil
+}
+
+func broadcastTx(txHex string) (string, error) {
+	result, err := rpcCall("sendrawtransaction", txHex)
+	if err != nil {
+		return "", err
+	}
+	var txid string
+	json.Unmarshal(result, &txid)
+	return txid, nil
+}
+
+func findAllUTXOs(txid, expectedScript string) ([]*UTXO, error) {
+	result, err := rpcCall("getrawtransaction", txid, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var tx struct {
+		Vout []struct {
+			Value        float64 `json:"value"`
+			N            uint32  `json:"n"`
+			ScriptPubKey struct {
+				Hex string `json:"hex"`
+			} `json:"scriptPubKey"`
+		} `json:"vout"`
+	}
+	json.Unmarshal(result, &tx)
+
+	var utxos []*UTXO
+	for _, v := range tx.Vout {
+		if v.ScriptPubKey.Hex == expectedScript {
+			sats := uint64(v.Value*1e8 + 0.5)
+			utxos = append(utxos, &UTXO{
+				Txid:     txid,
+				Vout:     v.N,
+				Satoshis: sats,
+				Script:   v.ScriptPubKey.Hex,
+			})
+		}
+	}
+	return utxos, nil
+}
+

--- a/end2end-example/webapp/compiler.go
+++ b/end2end-example/webapp/compiler.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/icellan/runar/compilers/go/codegen"
+	"github.com/icellan/runar/compilers/go/frontend"
+)
+
+func compilePriceBet(alicePubKeyHex, bobPubKeyHex string, threshold int) (scriptHex string, scriptAsm string, err error) {
+	source, err := readContractSource()
+	if err != nil {
+		return "", "", fmt.Errorf("read contract: %w", err)
+	}
+
+	parseResult := frontend.ParseSource(source, "PriceBet.runar.ts")
+	if len(parseResult.Errors) > 0 {
+		return "", "", fmt.Errorf("parse: %v", parseResult.Errors)
+	}
+
+	validResult := frontend.Validate(parseResult.Contract)
+	if len(validResult.Errors) > 0 {
+		return "", "", fmt.Errorf("validate: %v", validResult.Errors)
+	}
+
+	tcResult := frontend.TypeCheck(parseResult.Contract)
+	if len(tcResult.Errors) > 0 {
+		return "", "", fmt.Errorf("typecheck: %v", tcResult.Errors)
+	}
+
+	program := frontend.LowerToANF(parseResult.Contract)
+
+	for i := range program.Properties {
+		switch program.Properties[i].Name {
+		case "alicePubKey":
+			program.Properties[i].InitialValue = alicePubKeyHex
+		case "bobPubKey":
+			program.Properties[i].InitialValue = bobPubKeyHex
+		case "oraclePubKey":
+			program.Properties[i].InitialValue = float64(12345)
+		case "strikePrice":
+			program.Properties[i].InitialValue = float64(threshold)
+		}
+	}
+
+	stackMethods, err := codegen.LowerToStack(program)
+	if err != nil {
+		return "", "", fmt.Errorf("stack lower: %w", err)
+	}
+
+	emitResult, err := codegen.Emit(stackMethods)
+	if err != nil {
+		return "", "", fmt.Errorf("emit: %w", err)
+	}
+
+	return emitResult.ScriptHex, emitResult.ScriptAsm, nil
+}
+
+func readContractSource() ([]byte, error) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(thisFile)
+
+	candidates := []string{
+		filepath.Join(dir, "..", "ts", "PriceBet.runar.ts"),
+		filepath.Join(dir, "PriceBet.runar.ts"),
+	}
+
+	for _, path := range candidates {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return data, nil
+		}
+	}
+
+	return nil, fmt.Errorf("PriceBet.runar.ts not found (tried %v)", candidates)
+}

--- a/end2end-example/webapp/go.mod
+++ b/end2end-example/webapp/go.mod
@@ -1,0 +1,16 @@
+module runar-webapp
+
+go 1.26
+
+require (
+	github.com/bsv-blockchain/go-sdk v1.2.18
+	github.com/icellan/runar/compilers/go v0.0.0
+)
+
+require (
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
+)
+
+replace github.com/icellan/runar/compilers/go => ../../compilers/go

--- a/end2end-example/webapp/go.sum
+++ b/end2end-example/webapp/go.sum
@@ -1,0 +1,16 @@
+github.com/bsv-blockchain/go-sdk v1.2.18 h1:JFl8TNM7lf80CslrXjlungDOyuvL9COzond9BOR81Us=
+github.com/bsv-blockchain/go-sdk v1.2.18/go.mod h1:QWYwia7QSPB8+sLWyVldsIg0wPPzvEmXL5wGAT0dgaA=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/end2end-example/webapp/main.go
+++ b/end2end-example/webapp/main.go
@@ -1,0 +1,457 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+const contractSats = 20000
+
+type RoundResult struct {
+	Round     int    `json:"round"`
+	Threshold int    `json:"threshold"`
+	Oracle    int    `json:"oracle"`
+	AliceBet  string `json:"aliceBet"`
+	BobBet    string `json:"bobBet"`
+	Winner    string `json:"winner"`
+	DeployTx  string `json:"deployTx"`
+	SpendTx   string `json:"spendTx"`
+}
+
+type GameState struct {
+	mu sync.Mutex
+
+	Alice   *Wallet `json:"-"`
+	Bob     *Wallet `json:"-"`
+	Inited  bool    `json:"inited"`
+	Phase   string  `json:"phase"`
+	Round   int     `json:"round"`
+	History []RoundResult `json:"history"`
+
+	Threshold     int    `json:"threshold"`
+	AliceBet      string `json:"aliceBet"`
+	BobBet        string `json:"bobBet"`
+	LockingScript string `json:"-"`
+	ContractTxid  string `json:"contractTxid"`
+	ContractVout  uint32 `json:"-"`
+
+	AlicePubKey string `json:"alicePubKey"`
+	BobPubKey   string `json:"bobPubKey"`
+	AliceAddr   string `json:"aliceAddr"`
+	BobAddr     string `json:"bobAddr"`
+	AliceBalance int64 `json:"aliceBalance"`
+	BobBalance   int64 `json:"bobBalance"`
+
+	AliceUTXO *UTXO `json:"-"`
+	BobUTXO   *UTXO `json:"-"`
+
+	Log []LogEntry `json:"log"`
+}
+
+type LogEntry struct {
+	Message string `json:"message"`
+	Txid    string `json:"txid,omitempty"`
+	Type    string `json:"type"`
+}
+
+var game = &GameState{Phase: "init"}
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/init", handleInit)
+	mux.HandleFunc("/api/state", handleState)
+	mux.HandleFunc("/api/round/new", handleNewRound)
+	mux.HandleFunc("/api/round/bet", handleBet)
+	mux.HandleFunc("/api/round/reveal", handleReveal)
+
+	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		http.ServeFile(w, r, "static/index.html")
+	})
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Printf("PriceBet webapp listening on :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, mux))
+}
+
+func jsonResponse(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(data)
+}
+
+func jsonError(w http.ResponseWriter, msg string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+func handleInit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonError(w, "POST only", 405)
+		return
+	}
+
+	game.mu.Lock()
+	defer game.mu.Unlock()
+
+	alice, err := newWallet()
+	if err != nil {
+		jsonError(w, fmt.Sprintf("create alice wallet: %v", err), 500)
+		return
+	}
+
+	bob, err := newWallet()
+	if err != nil {
+		jsonError(w, fmt.Sprintf("create bob wallet: %v", err), 500)
+		return
+	}
+
+	game.Alice = alice
+	game.Bob = bob
+	game.AlicePubKey = alice.PubKeyHex
+	game.BobPubKey = bob.PubKeyHex
+	game.AliceAddr = alice.Address
+	game.BobAddr = bob.Address
+	game.History = nil
+	game.Log = nil
+	game.Round = 0
+	game.Phase = "funding"
+
+	aliceTxid, err := fundWallet(alice.Address, 10.0)
+	if err != nil {
+		jsonError(w, fmt.Sprintf("fund alice: %v", err), 500)
+		return
+	}
+	game.Log = append(game.Log, LogEntry{
+		Message: "Alice funded: 10 BTC",
+		Txid:    aliceTxid,
+		Type:    "fund",
+	})
+
+	bobTxid, err := fundWallet(bob.Address, 10.0)
+	if err != nil {
+		jsonError(w, fmt.Sprintf("fund bob: %v", err), 500)
+		return
+	}
+	game.Log = append(game.Log, LogEntry{
+		Message: "Bob funded: 10 BTC",
+		Txid:    bobTxid,
+		Type:    "fund",
+	})
+
+	if err := mine(1); err != nil {
+		jsonError(w, fmt.Sprintf("mine: %v", err), 500)
+		return
+	}
+
+	aliceUTXO, err := findUTXO(aliceTxid, alice.P2PKH)
+	if err != nil {
+		jsonError(w, fmt.Sprintf("find alice utxo: %v", err), 500)
+		return
+	}
+	game.AliceUTXO = aliceUTXO
+	game.Alice.Balance = int64(aliceUTXO.Satoshis)
+
+	bobUTXO, err := findUTXO(bobTxid, bob.P2PKH)
+	if err != nil {
+		jsonError(w, fmt.Sprintf("find bob utxo: %v", err), 500)
+		return
+	}
+	game.BobUTXO = bobUTXO
+	game.Bob.Balance = int64(bobUTXO.Satoshis)
+
+	game.AliceBalance = game.Alice.Balance
+	game.BobBalance = game.Bob.Balance
+	game.Inited = true
+	game.Phase = "ready"
+
+	jsonResponse(w, game)
+}
+
+func handleState(w http.ResponseWriter, r *http.Request) {
+	game.mu.Lock()
+	defer game.mu.Unlock()
+	jsonResponse(w, game)
+}
+
+func handleNewRound(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonError(w, "POST only", 405)
+		return
+	}
+
+	game.mu.Lock()
+	defer game.mu.Unlock()
+
+	if !game.Inited {
+		jsonError(w, "game not initialized", 400)
+		return
+	}
+
+	if game.Phase != "ready" && game.Phase != "complete" {
+		jsonError(w, "not ready for new round (phase: "+game.Phase+")", 400)
+		return
+	}
+
+	game.Round++
+	game.Threshold = rand.Intn(100) + 1
+	game.AliceBet = ""
+	game.BobBet = ""
+	game.LockingScript = ""
+	game.ContractTxid = ""
+	game.Phase = "betting"
+
+	game.Log = append(game.Log, LogEntry{
+		Message: fmt.Sprintf("Round %d: Threshold = %d", game.Round, game.Threshold),
+		Type:    "round",
+	})
+
+	jsonResponse(w, game)
+}
+
+func handleBet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonError(w, "POST only", 405)
+		return
+	}
+
+	var req struct {
+		Player string `json:"player"`
+		Choice string `json:"choice"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "bad request", 400)
+		return
+	}
+
+	if req.Choice != "over" && req.Choice != "under" {
+		jsonError(w, "choice must be 'over' or 'under'", 400)
+		return
+	}
+
+	game.mu.Lock()
+	defer game.mu.Unlock()
+
+	if game.Phase != "betting" {
+		jsonError(w, "not in betting phase", 400)
+		return
+	}
+
+	switch req.Player {
+	case "alice":
+		if game.AliceBet != "" {
+			jsonError(w, "alice already bet", 400)
+			return
+		}
+		game.AliceBet = req.Choice
+		if game.BobBet == "" {
+			if req.Choice == "over" {
+				game.BobBet = "under"
+			} else {
+				game.BobBet = "over"
+			}
+		}
+	case "bob":
+		if game.BobBet != "" {
+			jsonError(w, "bob already bet", 400)
+			return
+		}
+		game.BobBet = req.Choice
+		if game.AliceBet == "" {
+			if req.Choice == "over" {
+				game.AliceBet = "under"
+			} else {
+				game.AliceBet = "over"
+			}
+		}
+	default:
+		jsonError(w, "player must be 'alice' or 'bob'", 400)
+		return
+	}
+
+	if game.AliceBet != "" && game.BobBet != "" {
+		if err := deployContract(); err != nil {
+			jsonError(w, fmt.Sprintf("deploy contract: %v", err), 500)
+			return
+		}
+	}
+
+	jsonResponse(w, game)
+}
+
+func deployContract() error {
+	scriptHex, _, err := compilePriceBet(game.Alice.PubKeyHex, game.Bob.PubKeyHex, game.Threshold)
+	if err != nil {
+		return fmt.Errorf("compile: %w", err)
+	}
+	game.LockingScript = scriptHex
+
+	aliceContrib := uint64(contractSats / 2)
+	bobContrib := uint64(contractSats) - aliceContrib
+
+	txHex, err := buildFundingTx(game.Alice, game.Bob, game.AliceUTXO, game.BobUTXO, scriptHex, contractSats)
+	if err != nil {
+		return fmt.Errorf("build funding tx: %w", err)
+	}
+
+	txid, err := broadcastTx(txHex)
+	if err != nil {
+		return fmt.Errorf("broadcast funding tx: %w", err)
+	}
+
+	if err := mine(1); err != nil {
+		return fmt.Errorf("mine: %w", err)
+	}
+
+	game.ContractTxid = txid
+	game.ContractVout = 0
+
+	aliceChange := game.AliceUTXO.Satoshis - aliceContrib
+	bobChange := game.BobUTXO.Satoshis - bobContrib
+
+	aliceUTXOs, _ := findAllUTXOs(txid, game.Alice.P2PKH)
+	if len(aliceUTXOs) > 0 {
+		game.AliceUTXO = aliceUTXOs[0]
+		aliceChange = aliceUTXOs[0].Satoshis
+	}
+
+	bobUTXOs, _ := findAllUTXOs(txid, game.Bob.P2PKH)
+	if len(bobUTXOs) > 0 {
+		game.BobUTXO = bobUTXOs[0]
+		bobChange = bobUTXOs[0].Satoshis
+	}
+
+	game.Alice.Balance = int64(aliceChange)
+	game.Bob.Balance = int64(bobChange)
+	game.AliceBalance = game.Alice.Balance
+	game.BobBalance = game.Bob.Balance
+
+	game.Phase = "deployed"
+
+	game.Log = append(game.Log, LogEntry{
+		Message: fmt.Sprintf("Round %d: Contract deployed (%d sats)", game.Round, contractSats),
+		Txid:    txid,
+		Type:    "deploy",
+	})
+
+	return nil
+}
+
+func handleReveal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonError(w, "POST only", 405)
+		return
+	}
+
+	game.mu.Lock()
+	defer game.mu.Unlock()
+
+	if game.Phase != "deployed" {
+		jsonError(w, "contract not deployed", 400)
+		return
+	}
+
+	oracle := rand.Intn(100) + 1
+
+	var winner string
+	var winnerP2PKH string
+	if oracle > game.Threshold {
+		if game.AliceBet == "over" {
+			winner = "alice"
+			winnerP2PKH = game.Alice.P2PKH
+		} else {
+			winner = "bob"
+			winnerP2PKH = game.Bob.P2PKH
+		}
+	} else {
+		if game.AliceBet == "under" {
+			winner = "alice"
+			winnerP2PKH = game.Alice.P2PKH
+		} else {
+			winner = "bob"
+			winnerP2PKH = game.Bob.P2PKH
+		}
+	}
+
+	contractUTXO := &UTXO{
+		Txid:     game.ContractTxid,
+		Vout:     game.ContractVout,
+		Satoshis: contractSats,
+		Script:   game.LockingScript,
+	}
+
+	txHex, err := buildSpendingTx(game.Alice, game.Bob, contractUTXO, winnerP2PKH, contractSats)
+	if err != nil {
+		jsonError(w, fmt.Sprintf("build spending tx: %v", err), 500)
+		return
+	}
+
+	spendTxid, err := broadcastTx(txHex)
+	if err != nil {
+		jsonError(w, fmt.Sprintf("broadcast spending tx: %v", err), 500)
+		return
+	}
+
+	if err := mine(1); err != nil {
+		jsonError(w, fmt.Sprintf("mine: %v", err), 500)
+		return
+	}
+
+	winnerUTXOs, _ := findAllUTXOs(spendTxid, winnerP2PKH)
+	if winner == "alice" {
+		if len(winnerUTXOs) > 0 {
+			game.Alice.Balance = int64(game.AliceUTXO.Satoshis + winnerUTXOs[0].Satoshis)
+		}
+	} else {
+		if len(winnerUTXOs) > 0 {
+			game.Bob.Balance = int64(game.BobUTXO.Satoshis + winnerUTXOs[0].Satoshis)
+		}
+	}
+	game.AliceBalance = game.Alice.Balance
+	game.BobBalance = game.Bob.Balance
+
+	result := RoundResult{
+		Round:     game.Round,
+		Threshold: game.Threshold,
+		Oracle:    oracle,
+		AliceBet:  game.AliceBet,
+		BobBet:    game.BobBet,
+		Winner:    winner,
+		DeployTx:  game.ContractTxid,
+		SpendTx:   spendTxid,
+	}
+	game.History = append(game.History, result)
+	game.Phase = "complete"
+
+	comp := ">"
+	if oracle <= game.Threshold {
+		comp = "≤"
+	}
+	game.Log = append(game.Log, LogEntry{
+		Message: fmt.Sprintf("Round %d: Oracle=%d %s %d → %s wins!", game.Round, oracle, comp, game.Threshold, strings.ToUpper(winner[:1])+winner[1:]),
+		Txid:    spendTxid,
+		Type:    "reveal",
+	})
+
+	jsonResponse(w, map[string]interface{}{
+		"oracle":  oracle,
+		"winner":  winner,
+		"spendTx": spendTxid,
+		"state":   game,
+	})
+}

--- a/end2end-example/webapp/static/app.js
+++ b/end2end-example/webapp/static/app.js
@@ -1,0 +1,253 @@
+let state = null;
+let busy = false;
+
+function setStatus(msg) {
+  document.getElementById('status').textContent = msg;
+}
+
+function setLoading(msg) {
+  document.getElementById('status').innerHTML =
+    '<span class="loading"></span>' + msg;
+}
+
+function satsToDisplay(sats) {
+  const btc = (sats / 1e8).toFixed(4);
+  return { btc, sats: sats.toLocaleString() };
+}
+
+function updateBalances() {
+  if (!state) return;
+  const a = satsToDisplay(state.aliceBalance);
+  document.getElementById('alice-btc').textContent = a.btc;
+  document.getElementById('alice-sats').textContent = a.sats;
+
+  const b = satsToDisplay(state.bobBalance);
+  document.getElementById('bob-btc').textContent = b.btc;
+  document.getElementById('bob-sats').textContent = b.sats;
+}
+
+function renderLog() {
+  if (!state || !state.log) return;
+  const container = document.getElementById('tx-log-entries');
+  container.innerHTML = '';
+
+  for (const entry of state.log) {
+    const div = document.createElement('div');
+    div.className = 'tx-log-entry';
+
+    const icons = { fund: '\u2713', deploy: '\u25C6', reveal: '\u2605', round: '\u25CB' };
+    const icon = icons[entry.type] || '\u00B7';
+
+    let txHtml = '';
+    if (entry.txid) {
+      txHtml = '<span class="txid">txid: ' + entry.txid + '</span>';
+    }
+
+    div.innerHTML =
+      '<span class="icon ' + entry.type + '">' + icon + '</span>' +
+      '<span class="msg">' + entry.message + '</span>' +
+      txHtml;
+
+    container.appendChild(div);
+  }
+
+  container.scrollTop = container.scrollHeight;
+}
+
+function showBetChoice(player, choice) {
+  const el = document.getElementById(player + '-choice');
+  el.className = '';
+  el.classList.remove('hidden');
+  el.innerHTML = '<span class="bet-choice ' + choice + '">' + choice.toUpperCase() + '</span>';
+}
+
+async function api(method, path, body) {
+  const opts = { method };
+  if (body) {
+    opts.headers = { 'Content-Type': 'application/json' };
+    opts.body = JSON.stringify(body);
+  }
+  const resp = await fetch(path, opts);
+  const data = await resp.json();
+  if (!resp.ok) {
+    throw new Error(data.error || 'request failed');
+  }
+  return data;
+}
+
+async function initGame() {
+  if (busy) return;
+  busy = true;
+  const btn = document.getElementById('btn-init');
+  btn.disabled = true;
+  btn.textContent = 'Initializing...';
+
+  try {
+    state = await api('POST', '/api/init');
+    document.getElementById('init-screen').classList.add('hidden');
+    document.getElementById('game-screen').classList.remove('hidden');
+    updateBalances();
+    renderLog();
+    busy = false;
+    newRound();
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = 'Initialize Game';
+    busy = false;
+    alert('Init failed: ' + e.message);
+  }
+}
+
+async function newRound() {
+  if (busy) return;
+  busy = true;
+
+  resetRoundUI();
+  setLoading('Starting new round...');
+
+  try {
+    state = await api('POST', '/api/round/new');
+    document.getElementById('round-number').textContent = state.round;
+    document.getElementById('threshold-area').classList.remove('hidden');
+    document.getElementById('oracle-area').classList.remove('hidden');
+    animateThreshold(state.threshold);
+    renderLog();
+  } catch (e) {
+    setStatus('Error: ' + e.message);
+  } finally {
+    busy = false;
+  }
+}
+
+function resetRoundUI() {
+  document.getElementById('threshold-area').classList.add('hidden');
+  document.getElementById('oracle-area').classList.add('hidden');
+  document.getElementById('reveal-area').classList.add('hidden');
+  document.getElementById('result-area').classList.add('hidden');
+  document.getElementById('alice-buttons').classList.add('hidden');
+  document.getElementById('bob-buttons').classList.add('hidden');
+  document.getElementById('alice-choice').classList.add('hidden');
+  document.getElementById('bob-choice').classList.add('hidden');
+  document.getElementById('oracle-box').textContent = '???';
+  document.getElementById('oracle-box').className = 'oracle-box';
+
+  document.getElementById('alice-panel').classList.remove('winner', 'loser');
+  document.getElementById('bob-panel').classList.remove('winner', 'loser');
+  setStatus('');
+}
+
+function animateThreshold(target) {
+  const el = document.getElementById('threshold-value');
+  let count = 0;
+  const duration = 1000;
+  const interval = 50;
+  const steps = duration / interval;
+
+  const timer = setInterval(() => {
+    count++;
+    if (count >= steps) {
+      clearInterval(timer);
+      el.textContent = target;
+      showBettingUI();
+    } else {
+      el.textContent = Math.floor(Math.random() * 100) + 1;
+    }
+  }, interval);
+}
+
+function showBettingUI() {
+  document.getElementById('alice-buttons').classList.remove('hidden');
+  document.getElementById('bob-buttons').classList.add('hidden');
+  setStatus('Alice: pick OVER or UNDER');
+}
+
+async function placeBet(player, choice) {
+  if (busy) return;
+  busy = true;
+
+  setLoading(player === 'alice' ? 'Alice bets ' + choice + '...' : 'Bob bets ' + choice + '...');
+
+  try {
+    state = await api('POST', '/api/round/bet', { player, choice });
+    updateBalances();
+    renderLog();
+
+    showBetChoice('alice', state.aliceBet);
+    showBetChoice('bob', state.bobBet);
+
+    document.getElementById('alice-buttons').classList.add('hidden');
+    document.getElementById('bob-buttons').classList.add('hidden');
+
+    if (state.phase === 'deployed') {
+      setStatus('Contract deployed! Ready to reveal.');
+      document.getElementById('reveal-area').classList.remove('hidden');
+    } else {
+      document.getElementById('bob-buttons').classList.remove('hidden');
+      setStatus('Bob: pick your bet');
+    }
+  } catch (e) {
+    setStatus('Error: ' + e.message);
+  } finally {
+    busy = false;
+  }
+}
+
+async function revealOracle() {
+  if (busy) return;
+  busy = true;
+
+  document.getElementById('reveal-area').classList.add('hidden');
+  setLoading('Revealing oracle number...');
+
+  const oracleBox = document.getElementById('oracle-box');
+  oracleBox.classList.add('rolling');
+
+  await new Promise(resolve => {
+    let ticks = 0;
+    const maxTicks = 30;
+    const timer = setInterval(() => {
+      ticks++;
+      oracleBox.textContent = Math.floor(Math.random() * 100) + 1;
+      if (ticks >= maxTicks) {
+        clearInterval(timer);
+        resolve();
+      }
+    }, 60);
+  });
+
+  try {
+    const result = await api('POST', '/api/round/reveal');
+    state = result.state;
+
+    oracleBox.classList.remove('rolling');
+    oracleBox.textContent = result.oracle;
+
+    const overWins = result.oracle > state.history[state.history.length - 1].threshold;
+    oracleBox.classList.add(overWins ? 'winner-over' : 'winner-under');
+
+    updateBalances();
+    renderLog();
+
+    const banner = document.getElementById('result-banner');
+    const winnerName = result.winner.charAt(0).toUpperCase() + result.winner.slice(1);
+    banner.textContent = winnerName + ' wins 20,000 sats!';
+    banner.className = 'result-banner win';
+    document.getElementById('result-area').classList.remove('hidden');
+
+    if (result.winner === 'alice') {
+      document.getElementById('alice-panel').classList.add('winner');
+      document.getElementById('bob-panel').classList.add('loser');
+    } else {
+      document.getElementById('bob-panel').classList.add('winner');
+      document.getElementById('alice-panel').classList.add('loser');
+    }
+
+    setStatus('Round complete!');
+  } catch (e) {
+    oracleBox.classList.remove('rolling');
+    oracleBox.textContent = 'ERR';
+    setStatus('Error: ' + e.message);
+  } finally {
+    busy = false;
+  }
+}

--- a/end2end-example/webapp/static/index.html
+++ b/end2end-example/webapp/static/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PriceBet Arena</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>PriceBet Arena</h1>
+      <div class="subtitle">Over/Under betting on BSV regtest</div>
+    </header>
+
+    <div id="init-screen" class="init-screen">
+      <button id="btn-init" class="btn" onclick="initGame()">Initialize Game</button>
+    </div>
+
+    <div id="game-screen" class="hidden">
+      <div class="game-grid">
+
+        <div id="alice-panel" class="panel player-panel alice">
+          <h2>Alice</h2>
+          <div class="balance">
+            <span class="symbol">&#8383;</span>
+            <span id="alice-btc">0.0000</span>
+            <span class="sats"><span id="alice-sats">0</span> sats</span>
+          </div>
+          <div id="alice-bet-area">
+            <div id="alice-buttons" class="bet-buttons hidden">
+              <button class="btn btn-green" onclick="placeBet('alice','over')">OVER</button>
+              <button class="btn btn-red" onclick="placeBet('alice','under')">UNDER</button>
+            </div>
+            <div id="alice-choice" class="hidden"></div>
+          </div>
+        </div>
+
+        <div id="center-panel" class="panel center-panel">
+          <div class="round-label">Round</div>
+          <div id="round-number" class="round-number">-</div>
+
+          <div id="threshold-area" class="hidden">
+            <div class="threshold-label">Threshold</div>
+            <div id="threshold-value" class="threshold-value">-</div>
+          </div>
+
+          <div id="oracle-area" class="hidden">
+            <div class="oracle-label">Oracle Number</div>
+            <div id="oracle-box" class="oracle-box">???</div>
+          </div>
+
+          <div id="reveal-area" class="hidden">
+            <button id="btn-reveal" class="btn btn-reveal" onclick="revealOracle()">REVEAL</button>
+          </div>
+
+          <div id="result-area" class="hidden">
+            <div id="result-banner" class="result-banner"></div>
+            <button class="btn" onclick="newRound()" style="margin-top:12px">Next Round</button>
+          </div>
+
+          <div id="status" class="status-msg"></div>
+        </div>
+
+        <div id="bob-panel" class="panel player-panel bob">
+          <h2>Bob</h2>
+          <div class="balance">
+            <span class="symbol">&#8383;</span>
+            <span id="bob-btc">0.0000</span>
+            <span class="sats"><span id="bob-sats">0</span> sats</span>
+          </div>
+          <div id="bob-bet-area">
+            <div id="bob-buttons" class="bet-buttons hidden">
+              <button class="btn btn-green" onclick="placeBet('bob','over')">OVER</button>
+              <button class="btn btn-red" onclick="placeBet('bob','under')">UNDER</button>
+            </div>
+            <div id="bob-choice" class="hidden"></div>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="panel tx-log">
+        <h3>Transaction Log</h3>
+        <div id="tx-log-entries" class="tx-log-entries"></div>
+      </div>
+    </div>
+  </div>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/end2end-example/webapp/static/style.css
+++ b/end2end-example/webapp/static/style.css
@@ -1,0 +1,434 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #0a0a0f;
+  --bg-panel: #12121a;
+  --bg-panel-hover: #1a1a25;
+  --border: #1e1e2e;
+  --text: #e0e0e8;
+  --text-dim: #666680;
+  --cyan: #00f0ff;
+  --cyan-glow: rgba(0, 240, 255, 0.3);
+  --green: #00ff88;
+  --green-glow: rgba(0, 255, 136, 0.3);
+  --red: #ff3366;
+  --red-glow: rgba(255, 51, 102, 0.3);
+  --yellow: #ffcc00;
+  --purple: #aa66ff;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+header {
+  text-align: center;
+  padding: 30px 0 20px;
+}
+
+header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 6px;
+  text-transform: uppercase;
+  color: var(--cyan);
+  text-shadow: 0 0 20px var(--cyan-glow), 0 0 40px var(--cyan-glow);
+}
+
+header .subtitle {
+  color: var(--text-dim);
+  font-size: 12px;
+  margin-top: 6px;
+  letter-spacing: 2px;
+}
+
+.init-screen {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
+.btn {
+  background: transparent;
+  border: 1px solid var(--cyan);
+  color: var(--cyan);
+  padding: 12px 32px;
+  font-family: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  transition: all 0.2s;
+  box-shadow: 0 0 10px var(--cyan-glow);
+}
+
+.btn:hover {
+  background: rgba(0, 240, 255, 0.1);
+  box-shadow: 0 0 20px var(--cyan-glow), 0 0 40px var(--cyan-glow);
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-green {
+  border-color: var(--green);
+  color: var(--green);
+  box-shadow: 0 0 10px var(--green-glow);
+}
+
+.btn-green:hover {
+  background: rgba(0, 255, 136, 0.1);
+  box-shadow: 0 0 20px var(--green-glow), 0 0 40px var(--green-glow);
+}
+
+.btn-red {
+  border-color: var(--red);
+  color: var(--red);
+  box-shadow: 0 0 10px var(--red-glow);
+}
+
+.btn-red:hover {
+  background: rgba(255, 51, 102, 0.1);
+  box-shadow: 0 0 20px var(--red-glow), 0 0 40px var(--red-glow);
+}
+
+.btn-reveal {
+  font-size: 18px;
+  padding: 16px 48px;
+  border-color: var(--yellow);
+  color: var(--yellow);
+  box-shadow: 0 0 15px rgba(255, 204, 0, 0.3);
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+
+.btn-reveal:hover {
+  background: rgba(255, 204, 0, 0.1);
+  box-shadow: 0 0 30px rgba(255, 204, 0, 0.4), 0 0 60px rgba(255, 204, 0, 0.2);
+}
+
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: 0 0 15px rgba(255, 204, 0, 0.3); }
+  50% { box-shadow: 0 0 25px rgba(255, 204, 0, 0.5), 0 0 50px rgba(255, 204, 0, 0.2); }
+}
+
+.game-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr 1fr;
+  gap: 16px;
+  margin: 20px 0;
+}
+
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.player-panel {
+  text-align: center;
+}
+
+.player-panel h2 {
+  font-size: 16px;
+  letter-spacing: 3px;
+  margin-bottom: 16px;
+  text-transform: uppercase;
+}
+
+.player-panel.alice h2 { color: var(--cyan); }
+.player-panel.bob h2 { color: var(--purple); }
+
+.balance {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 20px;
+  transition: color 0.3s;
+}
+
+.balance .symbol {
+  color: var(--text-dim);
+  font-size: 16px;
+}
+
+.balance .sats {
+  color: var(--text-dim);
+  font-size: 11px;
+  display: block;
+}
+
+.bet-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bet-buttons .btn {
+  width: 100%;
+}
+
+.bet-choice {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 4px;
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+.bet-choice.over {
+  color: var(--green);
+  border: 1px solid var(--green);
+  box-shadow: 0 0 8px var(--green-glow);
+}
+
+.bet-choice.under {
+  color: var(--red);
+  border: 1px solid var(--red);
+  box-shadow: 0 0 8px var(--red-glow);
+}
+
+.center-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.round-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.round-number {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--cyan);
+  margin-bottom: 24px;
+}
+
+.threshold-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.threshold-value {
+  font-size: 48px;
+  font-weight: 700;
+  color: var(--yellow);
+  text-shadow: 0 0 20px rgba(255, 204, 0, 0.3);
+  margin-bottom: 20px;
+}
+
+.oracle-box {
+  width: 120px;
+  height: 80px;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 36px;
+  font-weight: 700;
+  margin-bottom: 20px;
+  transition: all 0.3s;
+}
+
+.oracle-box.rolling {
+  border-color: var(--cyan);
+  color: var(--cyan);
+  box-shadow: 0 0 15px var(--cyan-glow);
+}
+
+.oracle-box.winner-over {
+  border-color: var(--green);
+  color: var(--green);
+  box-shadow: 0 0 20px var(--green-glow);
+  animation: flash-green 0.5s ease-in-out 3;
+}
+
+.oracle-box.winner-under {
+  border-color: var(--red);
+  color: var(--red);
+  box-shadow: 0 0 20px var(--red-glow);
+  animation: flash-red 0.5s ease-in-out 3;
+}
+
+@keyframes flash-green {
+  0%, 100% { box-shadow: 0 0 20px var(--green-glow); }
+  50% { box-shadow: 0 0 40px var(--green-glow), 0 0 60px var(--green-glow); }
+}
+
+@keyframes flash-red {
+  0%, 100% { box-shadow: 0 0 20px var(--red-glow); }
+  50% { box-shadow: 0 0 40px var(--red-glow), 0 0 60px var(--red-glow); }
+}
+
+.oracle-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.status-msg {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 12px;
+  min-height: 20px;
+}
+
+.player-panel.winner {
+  animation: winner-pulse 0.6s ease-in-out 3;
+}
+
+.player-panel.winner.alice {
+  border-color: var(--green);
+  box-shadow: 0 0 20px var(--green-glow);
+}
+
+.player-panel.winner.bob {
+  border-color: var(--green);
+  box-shadow: 0 0 20px var(--green-glow);
+}
+
+.player-panel.loser {
+  opacity: 0.5;
+}
+
+@keyframes winner-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.02); }
+}
+
+.tx-log {
+  margin-top: 20px;
+}
+
+.tx-log h3 {
+  font-size: 12px;
+  color: var(--text-dim);
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.tx-log-entries {
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.tx-log-entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(30, 30, 46, 0.5);
+  font-size: 12px;
+}
+
+.tx-log-entry .icon {
+  margin-right: 8px;
+}
+
+.tx-log-entry .icon.fund { color: var(--cyan); }
+.tx-log-entry .icon.deploy { color: var(--yellow); }
+.tx-log-entry .icon.reveal { color: var(--green); }
+.tx-log-entry .icon.round { color: var(--text-dim); }
+
+.tx-log-entry .msg {
+  flex: 1;
+}
+
+.tx-log-entry .txid {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.loading {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border);
+  border-top-color: var(--cyan);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.hidden { display: none !important; }
+
+.result-banner {
+  text-align: center;
+  padding: 12px;
+  margin: 12px 0;
+  border-radius: 6px;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  animation: fade-in 0.3s ease-out;
+}
+
+.result-banner.win {
+  color: var(--green);
+  border: 1px solid var(--green);
+  box-shadow: 0 0 15px var(--green-glow);
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 	./compilers/go
 	./conformance
 	./end2end-example/go
+	./end2end-example/webapp
 	./examples/go
 	./packages/runar-go
 )

--- a/packages/runar-sdk/src/signers/local.ts
+++ b/packages/runar-sdk/src/signers/local.ts
@@ -92,10 +92,10 @@ export class LocalSigner implements Signer {
       scope,
     });
 
-    // Hash the preimage with double-SHA256 to get the sighash
-    const sighash = Hash.hash256(preimage);
-
-    // Sign the sighash digest with ECDSA
+    // PrivateKey.sign() internally SHA-256 hashes its input before signing.
+    // We pass SHA256(preimage) so the total is SHA256(SHA256(preimage)) =
+    // hash256(preimage), which is the correct BIP-143 sighash digest.
+    const sighash = Hash.sha256(preimage);
     const signature = this.bsvPrivKey.sign(sighash);
 
     // Return DER-encoded signature with sighash byte appended


### PR DESCRIPTION
## Summary
- Add a Go webapp with browser UI for deploying and interacting with PriceBet contracts on regtest
- Add TypeScript regtest demo script for on-chain end-to-end testing
- Fix `LocalSigner` sighash: use `SHA256` instead of `hash256` since `PrivateKey.sign()` already applies one round of SHA256 internally
- Correct funding amounts in dump-compiled ASCII diagram (1 BSV each, 2 BSV combined)

## Test plan
- [ ] Run the webapp locally (`cd end2end-example/webapp && go run .`) and verify the UI loads
- [ ] Run `npx tsx end2end-example/ts/regtest-demo.ts` against a regtest node
- [ ] Verify LocalSigner produces valid signatures with the SHA256 fix