### PR TITLE
feat(blackjack): add regtest wrapper script and docs

### DIFF
--- a/end2end-example/webapp-blackjack/.gitignore
+++ b/end2end-example/webapp-blackjack/.gitignore
@@ -1,0 +1,2 @@
+regtest/
+script21

--- a/end2end-example/webapp-blackjack/README.md
+++ b/end2end-example/webapp-blackjack/README.md
@@ -1,0 +1,71 @@
+# Script 21 — Blackjack Webapp
+
+A provably-fair blackjack game that uses Bitcoin SV smart contracts (compiled with Rúnar) for trustless betting. Each round deploys a `BlackjackBet` contract on-chain, with an oracle (Rabin signature) attesting to outcomes and full deck commitment for auditability.
+
+## Prerequisites
+
+- **Docker** — pulls `bitcoinsv/bitcoin-sv:latest` from Docker Hub
+- **Go 1.26+**
+- The Rúnar Go compiler (resolved via `go.work` / `replace` directive in `go.mod`)
+
+## 1. Start the regtest node
+
+```bash
+./regtest.sh start
+```
+
+This will:
+- Pull `bitcoinsv/bitcoin-sv:latest` from Docker Hub (on first run)
+- Create a `regtest/n1` directory with a `bitcoin.conf` for regtest mode
+- Copy `regtest_wallet.dat` into the node's data directory (if the wallet file exists)
+- Start a `bitcoin-sv-regtest` Docker container with the data volume mounted at `/data`, exposing RPC on port `18332`
+
+You can interact with the node directly:
+
+```bash
+./regtest.sh getblockcount
+./regtest.sh generate 10
+```
+
+To stop the node:
+
+```bash
+./regtest.sh stop
+```
+
+## 2. Build the webapp
+
+```bash
+go build -o script21 .
+```
+
+## 3. Run
+
+```bash
+./script21
+```
+
+The webapp starts on port `8081` by default. Open http://localhost:8081 in a browser.
+
+To use a different port:
+
+```bash
+PORT=9090 ./script21
+```
+
+### Environment variables
+
+| Variable   | Default                    | Description              |
+|------------|----------------------------|--------------------------|
+| `PORT`     | `8081`                     | HTTP listen port         |
+| `RPC_URL`  | `http://localhost:18332`   | Bitcoin node RPC URL     |
+| `RPC_USER` | `bitcoin`                  | RPC username             |
+| `RPC_PASS` | `bitcoin`                  | RPC password             |
+
+## How it works
+
+1. **New Game** — Creates house and player wallets, funds them from the regtest faucet
+2. **Deal** — Shuffles a deck, commits the SHA-256 hash on-chain, deploys a `BlackjackBet` smart contract per player
+3. **Player Turns** — Hit or stand
+4. **Dealer Turn** — Dealer draws to 17, outcomes are determined, contracts are settled on-chain using Rabin oracle signatures
+5. **Audit** — Full deck order, salt, and all transaction IDs are published on-chain for independent verification

--- a/end2end-example/webapp-blackjack/regtest.sh
+++ b/end2end-example/webapp-blackjack/regtest.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+if [ "$1" == "" ]; then
+  echo "Please specify 'start', 'stop' or other bitcoin-cli command"
+  exit 1
+fi
+
+if [ "$1" == "stop" ]; then
+  docker exec bitcoin-sv-regtest bitcoin-cli -conf=/data/bitcoin.conf stop
+  exit 0
+fi  
+
+if [ "$1" == "start" ]; then
+
+  mkdir -p $HOME/.keystore
+
+  if [ ! -f "$HOME/.keystore/ps.key" ]; then
+    echo "Creating $HOME/.keystore/ps.key..."
+    echo "tprv8ZgxMBicQKsPfPCcKvAPAhga6QNeC1xPXhPBhFtw1CvRisZHnCF4LAjDbkcY7CwhndHrvTvmRWWwqRM9XzaAVRxwh81wnPV1kX8gU1XbEhx" > $HOME/.keystore/ps.key
+  fi
+
+  if [ -L "$0" ]; then
+    DIR="$(cd "$($(pwd)/$(readlink "$0"))" && pwd)"
+  else
+    DIR="$(cd "$(dirname "$0")" && pwd)"
+  fi
+
+  for D in $DIR/regtest/n1
+  do
+    mkdir -p $D
+
+    if [ ! -f "$D/bitcoin.conf" ]; then
+      echo "Creating $D/bitcoin.conf..."
+      cat << EOL > $D/bitcoin.conf
+port=18333
+rpcbind=0.0.0.0
+rpcport=18332
+rpcuser=bitcoin
+rpcpassword=bitcoin
+rpcallowip=0.0.0.0/0
+dnsseed=0
+listenonion=0
+listen=1
+server=1
+rest=1
+regtest=1
+debug=1
+usecashaddr=0
+txindex=1
+excessiveblocksize=1000000000
+maxstackmemoryusageconsensus=100000000
+genesisactivationheight=1
+minminingtxfee=0.00000001
+zmqpubhashblock=tcp://*:28332
+zmqpubhashtx=tcp://*:28332
+zmqpubdiscardedfrommempool=tcp://*:28332
+zmqpubremovedfrommempoolblock=tcp://*:28332
+
+zmqpubinvalidtx=tcp://*:28332
+invalidtxsink=ZMQ
+
+EOL
+    fi
+
+  done
+
+  mkdir -p $DIR/regtest/n1/regtest
+
+  if [ ! -f "$DIR/regtest/n1/regtest/wallet.dat" ] && [ -f "$DIR/regtest_wallet.dat" ]; then
+    echo "Creating $DIR/regtest/n1/regtest/wallet.dat..."
+    cp "$DIR/regtest_wallet.dat" "$DIR/regtest/n1/regtest/wallet.dat"
+  fi
+
+  #IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
+
+  docker run --rm --platform linux/amd64 --name bitcoin-sv-regtest -p 18332:18332 -p 18333:18333 -p 28332:28332 --volume $DIR/regtest/n1:/data -d bitcoinsv/bitcoin-sv:latest bitcoind -minminingtxfee=0.00000001
+
+else
+
+  docker exec bitcoin-sv-regtest bitcoin-cli -conf=/data/bitcoin.conf $@
+
+fi


### PR DESCRIPTION
## Summary
- Add `regtest.sh` wrapper script for local blackjack webapp development setup
- Add `.gitignore` and `README.md` with usage instructions for the blackjack webapp

## Test plan
- [ ] Run `regtest.sh` and verify local regtest environment starts correctly
- [ ] Verify blackjack webapp connects and functions against regtest