### PR TITLE
fix: wire addRawOutput in TS type checker and test interpreter

### DIFF
--- a/packages/runar-compiler/src/passes/03-typecheck.ts
+++ b/packages/runar-compiler/src/passes/03-typecheck.ts
@@ -863,6 +863,41 @@ class TypeChecker {
         return VOID;
       }
 
+      if (methodName === 'addRawOutput') {
+        if (this.contract.parentClass !== 'StatefulSmartContract') {
+          this.errors.push(makeDiagnostic(
+            `addRawOutput() is only available in StatefulSmartContract`,
+            'error',
+          ));
+          return VOID;
+        }
+        if (args.length !== 2) {
+          this.errors.push(makeDiagnostic(
+            `addRawOutput() expects 2 arguments (satoshis, scriptBytes), got ${args.length}`,
+            'error',
+          ));
+        }
+        if (args.length >= 1) {
+          const satoshisType = this.inferExprType(args[0]!, env);
+          if (!isBigintFamily(satoshisType) && satoshisType !== '<unknown>') {
+            this.errors.push(makeDiagnostic(
+              `addRawOutput() first argument (satoshis) must be bigint, got '${satoshisType}'`,
+              'error',
+            ));
+          }
+        }
+        if (args.length >= 2) {
+          const scriptType = this.inferExprType(args[1]!, env);
+          if (!isSubtype(scriptType, BYTESTRING) && scriptType !== '<unknown>') {
+            this.errors.push(makeDiagnostic(
+              `addRawOutput() second argument (scriptBytes) must be ByteString, got '${scriptType}'`,
+              'error',
+            ));
+          }
+        }
+        return VOID;
+      }
+
       // Check contract method signatures
       const methodSig = this.methodSigs.get(methodName);
       if (methodSig) {
@@ -870,7 +905,7 @@ class TypeChecker {
       }
 
       this.errors.push(makeDiagnostic(
-        `Unknown method 'this.${methodName}'. Only Rúnar built-in methods (addOutput, getStateScript) and contract methods are allowed.`,
+        `Unknown method 'this.${methodName}'. Only Rúnar built-in methods (addOutput, addRawOutput, getStateScript) and contract methods are allowed.`,
         'error',
       ));
       for (const arg of args) {

--- a/packages/runar-testing/src/__tests__/add-raw-output.test.ts
+++ b/packages/runar-testing/src/__tests__/add-raw-output.test.ts
@@ -1,0 +1,135 @@
+/**
+ * addRawOutput tests — verify that contracts using addRawOutput compile
+ * and execute correctly in the interpreter.
+ *
+ * addRawOutput(satoshis, scriptBytes) creates an output with caller-specified
+ * script bytes instead of the contract's own codePart. This enables protocols
+ * that need heterogeneous outputs (e.g., paying to a P2PKH address alongside
+ * a contract continuation).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from 'runar-compiler';
+import { TestContract } from '../test-contract.js';
+import { ALICE } from '../test-keys.js';
+import { signTestMessage } from '../crypto/ecdsa.js';
+
+const rawOutputSource = `
+import { StatefulSmartContract, assert, checkSig, cat, toByteString } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class RawOutputContract extends StatefulSmartContract {
+  owner: PubKey;
+  counter: bigint;
+
+  constructor(owner: PubKey, counter: bigint) {
+    super(owner, counter);
+    this.owner = owner;
+    this.counter = counter;
+  }
+
+  public increment(sig: Sig, rawScript: ByteString) {
+    assert(checkSig(sig, this.owner));
+    this.addOutput(1n, this.owner, this.counter + 1n);
+    this.addRawOutput(1n, rawScript);
+  }
+}
+`;
+
+const rawOutputOnlySource = `
+import { StatefulSmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class RawOnly extends StatefulSmartContract {
+  owner: PubKey;
+  value: bigint;
+
+  constructor(owner: PubKey, value: bigint) {
+    super(owner, value);
+    this.owner = owner;
+    this.value = value;
+  }
+
+  public cancel(sig: Sig, payoutScript: ByteString) {
+    assert(checkSig(sig, this.owner));
+    this.addRawOutput(this.value, payoutScript);
+  }
+}
+`;
+
+const statelessRawOutputSource = `
+import { SmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class StatelessRaw extends SmartContract {
+  readonly owner: PubKey;
+
+  constructor(owner: PubKey) {
+    super(owner);
+    this.owner = owner;
+  }
+
+  public unlock(sig: Sig, script: ByteString) {
+    assert(checkSig(sig, this.owner));
+    this.addRawOutput(1n, script);
+  }
+}
+`;
+
+describe('addRawOutput', () => {
+  describe('Compilation', () => {
+    it('compiles a contract with addOutput + addRawOutput', () => {
+      const result = compile(rawOutputSource, { fileName: 'RawOutputContract.runar.ts' });
+      const errors = result.diagnostics.filter(d => d.severity === 'error');
+      expect(errors).toHaveLength(0);
+      expect(result.success).toBe(true);
+    });
+
+    it('compiles a contract with only addRawOutput', () => {
+      const result = compile(rawOutputOnlySource, { fileName: 'RawOnly.runar.ts' });
+      const errors = result.diagnostics.filter(d => d.severity === 'error');
+      expect(errors).toHaveLength(0);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects addRawOutput in a stateless SmartContract', () => {
+      const result = compile(statelessRawOutputSource, { fileName: 'StatelessRaw.runar.ts' });
+      const errors = result.diagnostics.filter(d => d.severity === 'error');
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Interpreter execution (TestContract)', () => {
+    const aliceSig = signTestMessage(ALICE.privKey);
+
+    it('increment with raw output: interpreter succeeds and produces 2 outputs', () => {
+      const contract = TestContract.fromSource(
+        rawOutputSource,
+        { owner: ALICE.pubKey, counter: 0n },
+        'RawOutputContract.runar.ts',
+      );
+      const result = contract.call('increment', {
+        sig: aliceSig,
+        rawScript: '76a914' + '00'.repeat(20) + '88ac',
+      });
+      expect(result.success).toBe(true);
+      expect(result.outputs).toHaveLength(2);
+      expect(result.outputs![1]).toHaveProperty('_rawScript');
+    });
+
+    it('cancel with only raw output: interpreter succeeds', () => {
+      const contract = TestContract.fromSource(
+        rawOutputOnlySource,
+        { owner: ALICE.pubKey, value: 1000n },
+        'RawOnly.runar.ts',
+      );
+      const result = contract.call('cancel', {
+        sig: aliceSig,
+        payoutScript: '76a914' + '00'.repeat(20) + '88ac',
+      });
+      expect(result.success).toBe(true);
+      expect(result.outputs).toHaveLength(1);
+      expect(result.outputs![0]).toHaveProperty('_rawScript');
+    });
+  });
+});

--- a/packages/runar-testing/src/interpreter/interpreter.ts
+++ b/packages/runar-testing/src/interpreter/interpreter.ts
@@ -572,6 +572,14 @@ export class RunarInterpreter {
         return { kind: 'void' };
       }
 
+      if (methodName === 'addRawOutput') {
+        const evaluatedArgs = argExprs.map(a => this.evalExpr(a, env, methods));
+        const satoshis = evaluatedArgs[0]!;
+        const scriptBytes = evaluatedArgs[1]!;
+        this._outputs.push({ satoshis, stateValues: { _rawScript: scriptBytes } });
+        return { kind: 'void' };
+      }
+
       if (methodName === 'getStateScript') {
         return { kind: 'bytes', value: new Uint8Array(0) };
       }


### PR DESCRIPTION
## Summary

- `addRawOutput(satoshis, scriptBytes)` was implemented across the compiler pipeline (ANF lowering, stack lowering, Go/Rust/Python compilers) but missing from two places in the TypeScript toolchain
- Adds `addRawOutput` to the type checker method whitelist in `03-typecheck.ts` with proper validation
- Adds `addRawOutput` handling to the test interpreter so `TestContract` can execute contracts that use it

## Changes

**`packages/runar-compiler/src/passes/03-typecheck.ts`**
- Recognize `addRawOutput` as a built-in method
- Validate: exactly 2 args, first must be `bigint`, second must be `ByteString`
- Only allowed in `StatefulSmartContract` subclasses
- Updated error message to list `addRawOutput` alongside `addOutput` and `getStateScript`

**`packages/runar-testing/src/interpreter/interpreter.ts`**
- Handle `addRawOutput` calls by recording outputs with `_rawScript` state value

**`packages/runar-testing/src/__tests__/add-raw-output.test.ts`**
- 5 tests: compilation with mixed outputs, raw-only outputs, stateless rejection, interpreter execution with output assertions

## Test plan

- [x] All 342 existing tests pass (runar-compiler + runar-testing)
- [x] 5 new addRawOutput tests pass
- [x] No regressions in multi-output-stateful tests