### PR TITLE
fix: add missing Visibility import in Rust multiformat_tests.rs

### DIFF
--- a/compilers/rust/tests/multiformat_tests.rs
+++ b/compilers/rust/tests/multiformat_tests.rs
@@ -9,6 +9,7 @@
 //! focus on parse-level correctness and dispatch routing.
 
 use runar_compiler_rust::compile_from_source_str;
+use runar_compiler_rust::frontend::ast::Visibility;
 use runar_compiler_rust::frontend::parser::parse_source;
 
 fn conformance_dir() -> std::path::PathBuf {


### PR DESCRIPTION
## Summary

- Add missing `use runar_compiler_rust::frontend::ast::Visibility;` import to `compilers/rust/tests/multiformat_tests.rs`

The test file references `Visibility::Public` at line 222 without importing the type, causing the entire Rust test suite to fail to compile:

```
error[E0433]: failed to resolve: use of undeclared type `Visibility`
   --> tests/multiformat_tests.rs:222:48
```

One-line fix. All 534 Rust tests pass after the change.

## Test plan

- [x] `cd compilers/rust && cargo test` — 534 tests pass (0 failures)

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)