### PR TITLE
fix(sdk): emit addDataOutput payloads as real tx outputs (R9)

### DIFF
--- a/integration/go/data_outputs_test.go
+++ b/integration/go/data_outputs_test.go
@@ -1,0 +1,189 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"runar-integration/helpers"
+
+	runar "github.com/icellan/runar/packages/runar-go"
+)
+
+// TestAddDataOutputEndToEnd compiles a stateful contract whose method calls
+// this.addDataOutput(...), drives the call through RunarContract.Call with a
+// MockProvider, and verifies the resulting tx carries the declared data
+// output in position [1] (between the state output and the change output).
+// This is the acceptance test for BSVM R9 — data outputs must appear in
+// the tx in declaration order between state outputs and change, so the
+// compile-time continuation-hash check matches at spend time.
+func TestAddDataOutputEndToEnd(t *testing.T) {
+	const source = `
+import { StatefulSmartContract, ByteString } from 'runar-lang';
+
+export class DataEmitter extends StatefulSmartContract {
+    counter: bigint;
+
+    constructor(counter: bigint) {
+        super(counter);
+        this.counter = counter;
+    }
+
+    public emit(payload: ByteString) {
+        this.counter = this.counter + 1n;
+        this.addDataOutput(0n, payload);
+    }
+}
+`
+
+	artifact, err := helpers.CompileSourceStringToSDKArtifact(
+		source, "DataEmitter.runar.ts", map[string]interface{}{},
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	contract := runar.NewRunarContract(artifact, []interface{}{int64(0)})
+
+	provider := runar.NewMockProvider("testnet")
+	mockAddr := strings.Repeat("00", 20)
+	signer := runar.NewMockSigner("", mockAddr)
+
+	// Fund the mock address
+	provider.AddUtxo(mockAddr, runar.UTXO{
+		Txid:        strings.Repeat("aa", 32),
+		OutputIndex: 0,
+		Satoshis:    1_000_000,
+		Script:      "76a914" + strings.Repeat("00", 20) + "88ac",
+	})
+
+	_, _, err = contract.Deploy(provider, signer, runar.DeployOptions{Satoshis: 10_000})
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+
+	// OP_RETURN "bsvm-test" — the data payload
+	payload := "6a09" + "6273766d2d74657374"
+
+	txid, _, err := contract.Call("emit", []interface{}{payload}, provider, signer, nil)
+	if err != nil {
+		t.Fatalf("call emit: %v", err)
+	}
+	if txid == "" {
+		t.Fatal("expected non-empty txid")
+	}
+
+	// Inspect the broadcasted tx.
+	broadcasted := provider.GetBroadcastedTxs()
+	if len(broadcasted) < 2 {
+		t.Fatalf("expected >=2 broadcasted txs (deploy+call), got %d", len(broadcasted))
+	}
+	callTxHex := broadcasted[len(broadcasted)-1]
+	outputs, err := parseOutputsFromRawTxHex(callTxHex)
+	if err != nil {
+		t.Fatalf("parse tx: %v", err)
+	}
+
+	// Expected output order for this single-state + single-data method:
+	// [0] = state (stateful continuation)
+	// [1] = data (OP_RETURN "bsvm-test" = the payload we passed)
+	// [2] = change (P2PKH)
+	if len(outputs) < 2 {
+		t.Fatalf("expected at least 2 outputs (state + data), got %d: %v", len(outputs), outputs)
+	}
+	if outputs[1].script != payload {
+		t.Errorf("expected data output at index 1 to be %s, got %s", payload, outputs[1].script)
+	}
+	if outputs[1].satoshis != 0 {
+		t.Errorf("expected data output satoshis to be 0, got %d", outputs[1].satoshis)
+	}
+}
+
+// parseOutputsFromRawTxHex extracts (script, satoshis) pairs from a raw
+// transaction hex. Minimal parser — enough for assertions, not for
+// production use.
+func parseOutputsFromRawTxHex(txHex string) ([]parsedOutput, error) {
+	return parseTx(txHex)
+}
+
+type parsedOutput struct {
+	satoshis int64
+	script   string
+}
+
+func parseTx(hex string) ([]parsedOutput, error) {
+	pos := 0
+	// version: 4 bytes
+	pos += 8
+	// input count (varint)
+	nIn, w := readVarIntHex(hex, pos)
+	pos += w
+	for i := 0; i < nIn; i++ {
+		pos += 64 + 8 // prevTxid + prevOutIndex
+		scriptLen, slw := readVarIntHex(hex, pos)
+		pos += slw + scriptLen*2 + 8 // script + sequence
+	}
+	// output count (varint)
+	nOut, w := readVarIntHex(hex, pos)
+	pos += w
+	outs := make([]parsedOutput, 0, nOut)
+	for i := 0; i < nOut; i++ {
+		// satoshis: 8 bytes little-endian
+		sats := int64(0)
+		for j := 0; j < 8; j++ {
+			b, err := parseHexByte(hex[pos : pos+2])
+			if err != nil {
+				return nil, err
+			}
+			sats |= int64(b) << (8 * j)
+			pos += 2
+		}
+		scriptLen, slw := readVarIntHex(hex, pos)
+		pos += slw
+		script := hex[pos : pos+scriptLen*2]
+		pos += scriptLen * 2
+		outs = append(outs, parsedOutput{satoshis: sats, script: script})
+	}
+	return outs, nil
+}
+
+func readVarIntHex(hex string, pos int) (int, int) {
+	first, _ := parseHexByte(hex[pos : pos+2])
+	if first < 0xfd {
+		return int(first), 2
+	}
+	if first == 0xfd {
+		lo, _ := parseHexByte(hex[pos+2 : pos+4])
+		hi, _ := parseHexByte(hex[pos+4 : pos+6])
+		return int(lo) | (int(hi) << 8), 6
+	}
+	if first == 0xfe {
+		b0, _ := parseHexByte(hex[pos+2 : pos+4])
+		b1, _ := parseHexByte(hex[pos+4 : pos+6])
+		b2, _ := parseHexByte(hex[pos+6 : pos+8])
+		b3, _ := parseHexByte(hex[pos+8 : pos+10])
+		return int(b0) | (int(b1) << 8) | (int(b2) << 16) | (int(b3) << 24), 10
+	}
+	b0, _ := parseHexByte(hex[pos+2 : pos+4])
+	b1, _ := parseHexByte(hex[pos+4 : pos+6])
+	b2, _ := parseHexByte(hex[pos+6 : pos+8])
+	b3, _ := parseHexByte(hex[pos+8 : pos+10])
+	return int(b0) | (int(b1) << 8) | (int(b2) << 16) | (int(b3) << 24), 18
+}
+
+func parseHexByte(s string) (uint64, error) {
+	var val uint64
+	for _, c := range s {
+		val <<= 4
+		switch {
+		case c >= '0' && c <= '9':
+			val |= uint64(c - '0')
+		case c >= 'a' && c <= 'f':
+			val |= uint64(c - 'a' + 10)
+		case c >= 'A' && c <= 'F':
+			val |= uint64(c - 'A' + 10)
+		default:
+			return 0, nil
+		}
+	}
+	return val, nil
+}

--- a/integration/go/helpers/compiler.go
+++ b/integration/go/helpers/compiler.go
@@ -663,6 +663,10 @@ func ConvertIRValue(v ir.ANFValue) map[string]interface{} {
 		m["satoshis"] = v.Satoshis
 		m["scriptBytes"] = v.ScriptBytes
 
+	case "add_data_output":
+		m["satoshis"] = v.Satoshis
+		m["scriptBytes"] = v.ScriptBytes
+
 	case "get_state_script":
 		// no extra fields needed
 	}

--- a/packages/runar-go/anf_interpreter.go
+++ b/packages/runar-go/anf_interpreter.go
@@ -66,6 +66,27 @@ func ComputeNewState(
 	args map[string]interface{},
 	constructorArgs []interface{},
 ) (map[string]interface{}, error) {
+	state, _, err := ComputeNewStateAndDataOutputs(anf, methodName, currentState, args, constructorArgs)
+	return state, err
+}
+
+// ComputeNewStateAndDataOutputs is like ComputeNewState but also returns
+// data outputs resolved from this.addDataOutput(...) calls in the method
+// body, in declaration order. The returned ContractOutput entries have
+// Script as the hex-encoded ByteString and Satoshis as declared.
+//
+// Data outputs are what the compiler's auto-injected continuation-hash
+// check expects to see in the spending tx between the state outputs and
+// the change output. The SDK uses the returned slice to populate
+// BuildCallOptions.DataOutputs so BuildCallTransaction emits them at the
+// correct position.
+func ComputeNewStateAndDataOutputs(
+	anf *ANFProgram,
+	methodName string,
+	currentState map[string]interface{},
+	args map[string]interface{},
+	constructorArgs []interface{},
+) (map[string]interface{}, []ContractOutput, error) {
 	// Find the method
 	var method *ANFMethod
 	for i := range anf.Methods {
@@ -75,7 +96,7 @@ func ComputeNewState(
 		}
 	}
 	if method == nil {
-		return nil, fmt.Errorf("computeNewState: method '%s' not found in ANF IR", methodName)
+		return nil, nil, fmt.Errorf("computeNewState: method '%s' not found in ANF IR", methodName)
 	}
 
 	// Initialize environment with property values: mutable fields from
@@ -117,11 +138,12 @@ func ComputeNewState(
 		}
 	}
 
-	// Track state mutations
+	// Track state mutations and data outputs
 	stateDelta := make(map[string]interface{})
+	var dataOutputs []ContractOutput
 
 	// Walk bindings
-	anfEvalBindings(anf, method.Body, env, stateDelta)
+	anfEvalBindings(anf, method.Body, env, stateDelta, &dataOutputs)
 
 	// Merge delta into current state
 	result := make(map[string]interface{})
@@ -131,7 +153,7 @@ func ComputeNewState(
 	for k, v := range stateDelta {
 		result[k] = v
 	}
-	return result, nil
+	return result, dataOutputs, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -143,9 +165,10 @@ func anfEvalBindings(
 	bindings []ANFBinding,
 	env map[string]interface{},
 	stateDelta map[string]interface{},
+	dataOutputs *[]ContractOutput,
 ) {
 	for _, binding := range bindings {
-		val := anfEvalValue(anf, binding.Value, env, stateDelta)
+		val := anfEvalValue(anf, binding.Value, env, stateDelta, dataOutputs)
 		env[binding.Name] = val
 	}
 }
@@ -155,6 +178,7 @@ func anfEvalValue(
 	value map[string]interface{},
 	env map[string]interface{},
 	stateDelta map[string]interface{},
+	dataOutputs *[]ContractOutput,
 ) interface{} {
 	kind, _ := value["kind"].(string)
 
@@ -224,7 +248,7 @@ func anfEvalValue(
 						}
 					}
 					// Evaluate method body
-					anfEvalBindings(anf, m.Body, callEnv, stateDelta)
+					anfEvalBindings(anf, m.Body, callEnv, stateDelta, dataOutputs)
 					// Copy updated property values back to caller env
 					for _, prop := range anf.Properties {
 						if v, ok := callEnv[prop.Name]; ok {
@@ -255,7 +279,7 @@ func anfEvalValue(
 		for k, v := range env {
 			childEnv[k] = v
 		}
-		anfEvalBindings(anf, branch, childEnv, stateDelta)
+		anfEvalBindings(anf, branch, childEnv, stateDelta, dataOutputs)
 		// Copy new bindings back
 		for k, v := range childEnv {
 			env[k] = v
@@ -277,7 +301,7 @@ func anfEvalValue(
 			for k, v := range env {
 				loopEnv[k] = v
 			}
-			anfEvalBindings(anf, body, loopEnv, stateDelta)
+			anfEvalBindings(anf, body, loopEnv, stateDelta, dataOutputs)
 			for k, v := range loopEnv {
 				env[k] = v
 			}
@@ -323,8 +347,24 @@ func anfEvalValue(
 		}
 		return nil
 
+	case "add_data_output":
+		// Resolve the two arg refs from env and record the data output.
+		// satoshis operand: bigint/int/float — coerce via *big.Int.Int64().
+		// scriptBytes operand: ByteString stored as a hex string.
+		satRef, _ := value["satoshis"].(string)
+		scriptRef, _ := value["scriptBytes"].(string)
+		sats := anfToBigInt(env[satRef]).Int64()
+		scriptHex := anfToString(env[scriptRef])
+		if dataOutputs != nil {
+			*dataOutputs = append(*dataOutputs, ContractOutput{
+				Script:   scriptHex,
+				Satoshis: sats,
+			})
+		}
+		return nil
+
 	// On-chain-only operations — skip
-	case "check_preimage", "deserialize_state", "get_state_script", "add_raw_output", "add_data_output":
+	case "check_preimage", "deserialize_state", "get_state_script", "add_raw_output":
 		return nil
 	}
 

--- a/packages/runar-go/sdk_calling.go
+++ b/packages/runar-go/sdk_calling.go
@@ -14,6 +14,11 @@ type BuildCallOptions struct {
 	ContractOutputs []ContractOutput
 	// Additional contract inputs with their own unlocking scripts (for merge).
 	AdditionalContractInputs []AdditionalContractInput
+	// Data outputs declared in the method body via this.addDataOutput(...).
+	// Emitted between the contract (state) outputs and the change output, in
+	// declaration order — matching the order the compiler's auto-injected
+	// continuation-hash check expects.
+	DataOutputs []ContractOutput
 }
 
 // ContractOutput describes one contract continuation output.
@@ -56,9 +61,11 @@ func BuildCallTransaction(
 ) (tx *transaction.Transaction, inputCount int, changeAmount int64) {
 	var extraContractInputs []AdditionalContractInput
 	var contractOutputs []ContractOutput
+	var dataOutputs []ContractOutput
 	if len(opts) > 0 && opts[0] != nil {
 		extraContractInputs = opts[0].AdditionalContractInputs
 		contractOutputs = opts[0].ContractOutputs
+		dataOutputs = opts[0].DataOutputs
 	}
 
 	// Build full input list: primary contract, extra contract inputs, P2PKH funding
@@ -86,6 +93,9 @@ func BuildCallTransaction(
 	for _, co := range contractOutputs {
 		contractOutputSats += co.Satoshis
 	}
+	for _, do := range dataOutputs {
+		contractOutputSats += do.Satoshis
+	}
 
 	// Estimate fee using actual script sizes
 	input0Size := 32 + 4 + varIntByteSize(len(unlockingScript)/2) +
@@ -102,6 +112,9 @@ func BuildCallTransaction(
 	outputsSize := 0
 	for _, co := range contractOutputs {
 		outputsSize += 8 + varIntByteSize(len(co.Script)/2) + len(co.Script)/2
+	}
+	for _, do := range dataOutputs {
+		outputsSize += 8 + varIntByteSize(len(do.Script)/2) + len(do.Script)/2
 	}
 	if changeAddress != "" || changeScript != "" {
 		outputsSize += 34 // P2PKH change
@@ -156,6 +169,17 @@ func BuildCallTransaction(
 		ls, _ := sdkscript.NewFromHex(co.Script)
 		tx.AddOutput(&transaction.TransactionOutput{
 			Satoshis:      uint64(co.Satoshis),
+			LockingScript: ls,
+		})
+	}
+
+	// Data outputs (from this.addDataOutput in the method body). Emitted
+	// after all state outputs and before the change output so the tx's
+	// hashOutputs matches the compile-time continuation-hash check.
+	for _, do := range dataOutputs {
+		ls, _ := sdkscript.NewFromHex(do.Script)
+		tx.AddOutput(&transaction.TransactionOutput{
+			Satoshis:      uint64(do.Satoshis),
 			LockingScript: ls,
 		})
 	}

--- a/packages/runar-go/sdk_contract.go
+++ b/packages/runar-go/sdk_contract.go
@@ -474,6 +474,25 @@ func (c *RunarContract) PrepareCall(
 	var contractOutputs []ContractOutput
 	hasMultiOutput := options != nil && len(options.Outputs) > 0
 
+	// Resolve data outputs declared via this.addDataOutput(...). Explicit
+	// options.DataOutputs wins; otherwise run the ANF interpreter to
+	// resolve the method body. This also gives us the new state without
+	// a second interpreter pass, so reuse it below.
+	var resolvedDataOutputs []ContractOutput
+	var autoComputedState map[string]interface{}
+	if isStateful && c.Artifact.ANF != nil {
+		namedArgs := buildNamedArgs(userParams, resolvedArgs)
+		if state, dataOuts, err := ComputeNewStateAndDataOutputs(
+			c.Artifact.ANF, methodName, c.state, namedArgs, c.constructorArgs,
+		); err == nil {
+			autoComputedState = state
+			resolvedDataOutputs = dataOuts
+		}
+	}
+	if options != nil && options.DataOutputs != nil {
+		resolvedDataOutputs = options.DataOutputs
+	}
+
 	newLockingScript := ""
 	newSatoshis := int64(0)
 
@@ -496,14 +515,9 @@ func (c *RunarContract) PrepareCall(
 			for k, v := range options.NewState {
 				c.state[k] = v
 			}
-		} else if methodNeedsChange && c.Artifact.ANF != nil {
-			// Auto-compute new state from ANF IR
-			namedArgs := buildNamedArgs(userParams, resolvedArgs)
-			computed, err := ComputeNewState(c.Artifact.ANF, methodName, c.state, namedArgs, c.constructorArgs)
-			if err == nil {
-				for k, v := range computed {
-					c.state[k] = v
-				}
+		} else if methodNeedsChange && autoComputedState != nil {
+			for k, v := range autoComputedState {
+				c.state[k] = v
 			}
 		}
 		newLockingScript = c.GetLockingScript()
@@ -582,6 +596,9 @@ func (c *RunarContract) PrepareCall(
 	buildOpts := &BuildCallOptions{}
 	if len(contractOutputs) > 0 {
 		buildOpts.ContractOutputs = contractOutputs
+	}
+	if len(resolvedDataOutputs) > 0 {
+		buildOpts.DataOutputs = resolvedDataOutputs
 	}
 	if len(extraContractUtxos) > 0 {
 		buildOpts.AdditionalContractInputs = make([]AdditionalContractInput, len(extraContractUtxos))
@@ -720,6 +737,9 @@ func (c *RunarContract) PrepareCall(
 		rebuildOpts := &BuildCallOptions{}
 		if len(contractOutputs) > 0 {
 			rebuildOpts.ContractOutputs = contractOutputs
+		}
+		if len(resolvedDataOutputs) > 0 {
+			rebuildOpts.DataOutputs = resolvedDataOutputs
 		}
 		if len(extraContractUtxos) > 0 {
 			rebuildOpts.AdditionalContractInputs = make([]AdditionalContractInput, len(extraContractUtxos))

--- a/packages/runar-go/sdk_test.go
+++ b/packages/runar-go/sdk_test.go
@@ -2938,3 +2938,179 @@ func TestComputeNewState_UnknownMethod_Error(t *testing.T) {
 		t.Fatal("expected error for unknown method")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// addDataOutput SDK emission — BSVM R9
+// The spec's continuation hash for a stateful method that calls
+// addDataOutput commits to `[state outputs] || [data outputs] ||
+// changeOutput`. These tests verify BuildCallTransaction emits the
+// data outputs at the right position with correct fee accounting and
+// that the ANF interpreter resolves them from the method body.
+// ---------------------------------------------------------------------------
+
+func TestBuildCallTransaction_DataOutputsOrder(t *testing.T) {
+	utxo := makeUtxo(100000, 0)
+	stateScript := "76a914" + strings.Repeat("dd", 20) + "88ac"
+	data0 := "6a0474657374"   // OP_RETURN "test"
+	data1 := "6a056c6162656c" // OP_RETURN "label"
+	changeScript := "76a914" + strings.Repeat("ff", 20) + "88ac"
+
+	opts := &BuildCallOptions{
+		DataOutputs: []ContractOutput{
+			{Script: data0, Satoshis: 0},
+			{Script: data1, Satoshis: 0},
+		},
+	}
+	callTxObj, _, _ := BuildCallTransaction(
+		utxo, "51", stateScript, 50000, "changeaddr", changeScript, nil, 100, opts,
+	)
+	parsed := parseTxHex(callTxObj.Hex())
+
+	if parsed.outputCount != 4 {
+		t.Fatalf("expected 4 outputs (state, data0, data1, change), got %d", parsed.outputCount)
+	}
+	if parsed.outputs[0].script != stateScript {
+		t.Errorf("output 0 (state): expected state script, got %s", parsed.outputs[0].script)
+	}
+	if parsed.outputs[1].script != data0 {
+		t.Errorf("output 1 (data0): expected %s, got %s", data0, parsed.outputs[1].script)
+	}
+	if parsed.outputs[2].script != data1 {
+		t.Errorf("output 2 (data1): expected %s, got %s", data1, parsed.outputs[2].script)
+	}
+	if parsed.outputs[3].script != changeScript {
+		t.Errorf("output 3 (change): expected change script, got %s", parsed.outputs[3].script)
+	}
+}
+
+func TestBuildCallTransaction_DataOutputsFeeEstimate(t *testing.T) {
+	makeTx := func(opts *BuildCallOptions) int64 {
+		utxo := makeUtxo(100000, 0)
+		stateScript := "76a914" + strings.Repeat("dd", 20) + "88ac"
+		changeScript := "76a914" + strings.Repeat("ff", 20) + "88ac"
+		var variadic []*BuildCallOptions
+		if opts != nil {
+			variadic = []*BuildCallOptions{opts}
+		}
+		_, _, change := BuildCallTransaction(
+			utxo, "51", stateScript, 50000, "changeaddr", changeScript, nil, 100, variadic...,
+		)
+		return change
+	}
+
+	changeWithout := makeTx(nil)
+	dataScript := "6a" + strings.Repeat("ab", 30) // 32-byte OP_RETURN payload
+	changeWith := makeTx(&BuildCallOptions{
+		DataOutputs: []ContractOutput{{Script: dataScript, Satoshis: 0}},
+	})
+
+	dataByteLen := len(dataScript) / 2
+	// Output on wire: 8 (value) + varint(scriptLen) + scriptLen. scriptLen < 0xfd ⇒ varint=1.
+	extraOutputBytes := int64(8 + 1 + dataByteLen)
+	feeRate := int64(100)
+	expectedFeeDelta := (extraOutputBytes*feeRate + 999) / 1000
+	diff := changeWithout - changeWith
+	if diff != expectedFeeDelta {
+		t.Errorf("expected change to drop by %d sat (fee for %d extra bytes @ %d/kB), got drop of %d (without=%d, with=%d)",
+			expectedFeeDelta, extraOutputBytes, feeRate, diff, changeWithout, changeWith)
+	}
+}
+
+func TestBuildCallTransaction_DataOutputsWithNonZeroSats(t *testing.T) {
+	utxo := makeUtxo(100000, 0)
+	stateScript := "76a914" + strings.Repeat("dd", 20) + "88ac"
+	changeScript := "76a914" + strings.Repeat("ff", 20) + "88ac"
+
+	// Same tx without data output for baseline change calc
+	_, _, baselineChange := BuildCallTransaction(
+		utxo, "51", stateScript, 50000, "changeaddr", changeScript, nil, 100,
+	)
+
+	dataScript := "76a914" + strings.Repeat("cc", 20) + "88ac"
+	opts := &BuildCallOptions{
+		DataOutputs: []ContractOutput{{Script: dataScript, Satoshis: 1000}},
+	}
+	callTxObj, _, changeWith := BuildCallTransaction(
+		utxo, "51", stateScript, 50000, "changeaddr", changeScript, nil, 100, opts,
+	)
+	parsed := parseTxHex(callTxObj.Hex())
+
+	// The data output must carry its declared 1000 satoshis
+	if parsed.outputs[1].satoshis != 1000 {
+		t.Errorf("expected data output to carry 1000 sats, got %d", parsed.outputs[1].satoshis)
+	}
+	if parsed.outputs[1].script != dataScript {
+		t.Errorf("expected data output script, got %s", parsed.outputs[1].script)
+	}
+
+	// Fee only goes up by the extra output bytes. So change = baseline - 1000 - feeDelta.
+	dataByteLen := len(dataScript) / 2
+	extraOutputBytes := int64(8 + 1 + dataByteLen)
+	feeDelta := (extraOutputBytes*100 + 999) / 1000
+	expected := baselineChange - 1000 - feeDelta
+	if changeWith != expected {
+		t.Errorf("expected change=%d (baseline %d - 1000 sats - %d fee), got %d",
+			expected, baselineChange, feeDelta, changeWith)
+	}
+}
+
+func TestComputeDataOutputs_FromANF(t *testing.T) {
+	// Minimal ANF with a single add_data_output binding. The satoshis
+	// come from a load_const bigint; the scriptBytes come from a
+	// load_const hex-encoded ByteString.
+	opReturnHex := "6a0474657374" // OP_RETURN "test"
+	anf := &ANFProgram{
+		ContractName: "DataEmitter",
+		Properties: []ANFProperty{
+			{Name: "counter", Type: "bigint", Readonly: false},
+		},
+		Methods: []ANFMethod{
+			{Name: "constructor", IsPublic: false, Body: []ANFBinding{}},
+			{
+				Name:     "emit",
+				IsPublic: true,
+				Params: []ANFParam{
+					{Name: "txPreimage", Type: "SigHashPreimage"},
+					{Name: "_changePKH", Type: "Addr"},
+					{Name: "_changeAmount", Type: "bigint"},
+				},
+				Body: []ANFBinding{
+					{Name: "t_sats", Value: map[string]interface{}{"kind": "load_const", "value": float64(0)}},
+					{Name: "t_script", Value: map[string]interface{}{"kind": "load_const", "value": opReturnHex}},
+					{Name: "t_emit", Value: map[string]interface{}{
+						"kind":        "add_data_output",
+						"satoshis":    "t_sats",
+						"scriptBytes": "t_script",
+					}},
+					// Keep the counter mutating so this exercises state transition too
+					{Name: "t_prop", Value: map[string]interface{}{"kind": "load_prop", "name": "counter"}},
+					{Name: "t_one", Value: map[string]interface{}{"kind": "load_const", "value": float64(1)}},
+					{Name: "t_sum", Value: map[string]interface{}{"kind": "bin_op", "op": "+", "left": "t_prop", "right": "t_one", "resultType": "bigint"}},
+					{Name: "t_update", Value: map[string]interface{}{"kind": "update_prop", "name": "counter", "value": "t_sum"}},
+				},
+			},
+		},
+	}
+
+	currentState := map[string]interface{}{"counter": big.NewInt(0)}
+	newState, dataOutputs, err := ComputeNewStateAndDataOutputs(
+		anf, "emit", currentState, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("ComputeNewStateAndDataOutputs failed: %v", err)
+	}
+	if len(dataOutputs) != 1 {
+		t.Fatalf("expected 1 data output, got %d", len(dataOutputs))
+	}
+	if dataOutputs[0].Satoshis != 0 {
+		t.Errorf("expected 0 sats, got %d", dataOutputs[0].Satoshis)
+	}
+	if dataOutputs[0].Script != opReturnHex {
+		t.Errorf("expected script %s, got %s", opReturnHex, dataOutputs[0].Script)
+	}
+	// Also assert state transition still worked
+	countVal, ok := newState["counter"].(*big.Int)
+	if !ok || countVal.Int64() != 1 {
+		t.Errorf("expected counter=1 after emit, got %v", newState["counter"])
+	}
+}

--- a/packages/runar-go/sdk_types.go
+++ b/packages/runar-go/sdk_types.go
@@ -94,6 +94,15 @@ type CallOptions struct {
 	// proof + the same VK that was baked into the contract at compile
 	// time via CompileOptions.Groth16WAVKey.
 	Groth16WAWitness *bn254witness.Witness `json:"-"`
+
+	// DataOutputs is an optional explicit override for data outputs
+	// emitted via this.addDataOutput(...) in the method body. When nil,
+	// the SDK resolves data outputs automatically by running the ANF
+	// interpreter on the method body (the common case). Pass a non-nil
+	// slice to bypass the interpreter — useful when the caller already
+	// knows the exact (satoshis, script) pairs and does not want the SDK
+	// to re-derive them from method arguments.
+	DataOutputs []ContractOutput `json:"dataOutputs,omitempty"`
 }
 
 // TerminalOutput specifies an exact output for a terminal method call.

--- a/packages/runar-py/runar/sdk/anf_interpreter.py
+++ b/packages/runar-py/runar/sdk/anf_interpreter.py
@@ -41,6 +41,29 @@ def compute_new_state(
     Returns:
         The updated state (merged with current_state).
     """
+    state, _ = compute_new_state_and_data_outputs(
+        anf, method_name, current_state, args, constructor_args,
+    )
+    return state
+
+
+def compute_new_state_and_data_outputs(
+    anf: dict,
+    method_name: str,
+    current_state: dict,
+    args: dict,
+    constructor_args: list = None,
+):
+    """Like :func:`compute_new_state` but also returns data outputs.
+
+    Data outputs come from ``this.addDataOutput(...)`` calls in the method
+    body, in declaration order. Each entry is a ``{"script": hex, "satoshis": int}``
+    dict. The SDK uses these to populate the tx between state outputs and
+    the change output so the on-chain continuation-hash check matches.
+
+    Returns:
+        (state, data_outputs) — the new state dict and a list of data output dicts.
+    """
     if constructor_args is None:
         constructor_args = []
     method = None
@@ -84,13 +107,14 @@ def compute_new_state(
         if pname in args:
             env[pname] = args[pname]
 
-    # Track state mutations
+    # Track state mutations and data outputs
     state_delta: Dict[str, Any] = {}
+    data_outputs: List[dict] = []
 
     # Walk bindings
-    _eval_bindings(method.get('body', []), env, state_delta, anf)
+    _eval_bindings(method.get('body', []), env, state_delta, data_outputs, anf)
 
-    return {**current_state, **state_delta}
+    return {**current_state, **state_delta}, data_outputs
 
 
 # ---------------------------------------------------------------------------
@@ -101,10 +125,11 @@ def _eval_bindings(
     bindings: List[dict],
     env: Dict[str, Any],
     state_delta: Dict[str, Any],
+    data_outputs: List[dict],
     anf: Optional[dict] = None,
 ) -> None:
     for binding in bindings:
-        val = _eval_value(binding['value'], env, state_delta, anf)
+        val = _eval_value(binding['value'], env, state_delta, data_outputs, anf)
         env[binding['name']] = val
 
 
@@ -112,6 +137,7 @@ def _eval_value(
     value: dict,
     env: Dict[str, Any],
     state_delta: Dict[str, Any],
+    data_outputs: List[dict],
     anf: Optional[dict] = None,
 ) -> Any:
     kind = value.get('kind', '')
@@ -150,13 +176,13 @@ def _eval_value(
 
     if kind == 'method_call':
         call_args = [env.get(a) for a in value.get('args', [])]
-        return _eval_method_call(env.get(value.get('object')), value.get('method'), call_args, env, state_delta, anf)
+        return _eval_method_call(env.get(value.get('object')), value.get('method'), call_args, env, state_delta, data_outputs, anf)
 
     if kind == 'if':
         cond = env.get(value['cond'])
         branch = value['then'] if _is_truthy(cond) else value['else']
         child_env = dict(env)
-        _eval_bindings(branch, child_env, state_delta, anf)
+        _eval_bindings(branch, child_env, state_delta, data_outputs, anf)
         env.update(child_env)
         if branch:
             return child_env.get(branch[-1]['name'])
@@ -170,7 +196,7 @@ def _eval_value(
         for i in range(count):
             env[iter_var] = i
             loop_env = dict(env)
-            _eval_bindings(body, loop_env, state_delta, anf)
+            _eval_bindings(body, loop_env, state_delta, data_outputs, anf)
             env.update(loop_env)
             if body:
                 last_val = loop_env.get(body[-1]['name'])
@@ -201,9 +227,19 @@ def _eval_value(
                     state_delta[prop_name] = resolved
         return None
 
+    if kind == 'add_data_output':
+        # Resolve the two arg refs from env and record the data output.
+        sat_ref = value.get('satoshis', '')
+        script_ref = value.get('scriptBytes', '')
+        sats = _to_int(env.get(sat_ref))
+        script_val = env.get(script_ref)
+        script_hex = script_val if isinstance(script_val, str) else ''
+        data_outputs.append({'satoshis': sats, 'script': script_hex})
+        return None
+
     # On-chain-only operations -- skip in simulation
     if kind in ('check_preimage', 'deserialize_state', 'get_state_script',
-                'add_raw_output', 'add_data_output'):
+                'add_raw_output'):
         return None
 
     return None
@@ -425,8 +461,11 @@ def _eval_method_call(
     args: List[Any],
     caller_env: Optional[Dict[str, Any]] = None,
     state_delta: Optional[Dict[str, Any]] = None,
+    data_outputs: Optional[List[dict]] = None,
     anf: Optional[dict] = None,
 ) -> Any:
+    if data_outputs is None:
+        data_outputs = []
     # Look up private method in ANF IR
     if anf and method:
         for m in anf.get('methods', []):
@@ -446,7 +485,7 @@ def _eval_method_call(
                 # Evaluate method body
                 body = m.get('body', [])
                 child_delta: Dict[str, Any] = {}
-                _eval_bindings(body, new_env, child_delta, anf)
+                _eval_bindings(body, new_env, child_delta, data_outputs, anf)
                 # Propagate state delta back
                 if state_delta is not None:
                     state_delta.update(child_delta)

--- a/packages/runar-py/runar/sdk/calling.py
+++ b/packages/runar-py/runar/sdk/calling.py
@@ -19,17 +19,23 @@ def build_call_transaction(
     fee_rate: int = 100,
     contract_outputs: list[dict] | None = None,
     additional_contract_inputs: list[dict] | None = None,
+    data_outputs: list[dict] | None = None,
 ) -> tuple[str, int, int]:
     """Build a raw transaction that spends a contract UTXO.
 
     contract_outputs: list of {"script": str, "satoshis": int} for multi-output.
     additional_contract_inputs: list of {"utxo": Utxo, "unlocking_script": str}
         for additional contract inputs (e.g. merge).
+    data_outputs: list of {"script": str, "satoshis": int} declared via
+        `this.addDataOutput(...)` in the method body. Emitted between
+        contract (state) outputs and the change output in declaration
+        order — matching the compile-time continuation-hash layout.
 
     Returns (tx_hex, input_count, change_amount).
     """
     extra_contract_inputs = additional_contract_inputs or []
     additional = additional_utxos or []
+    resolved_data_outputs = data_outputs or []
     all_utxos = (
         [current_utxo]
         + [ci['utxo'] for ci in extra_contract_inputs]
@@ -46,7 +52,10 @@ def build_call_transaction(
         sats = new_satoshis if new_satoshis > 0 else current_utxo.satoshis
         resolved_contract_outputs = [{'script': new_locking_script, 'satoshis': sats}]
 
-    contract_output_sats = sum(co['satoshis'] for co in resolved_contract_outputs)
+    contract_output_sats = (
+        sum(co['satoshis'] for co in resolved_contract_outputs)
+        + sum(do['satoshis'] for do in resolved_data_outputs)
+    )
 
     # Estimate fee using actual script sizes
     input0_size = (
@@ -70,6 +79,9 @@ def build_call_transaction(
     outputs_size = 0
     for co in resolved_contract_outputs:
         s = co['script']
+        outputs_size += 8 + _varint_byte_size(len(s) // 2) + len(s) // 2
+    for do in resolved_data_outputs:
+        s = do['script']
         outputs_size += 8 + _varint_byte_size(len(s) // 2) + len(s) // 2
     if change_address or change_script:
         outputs_size += 34  # P2PKH change
@@ -110,7 +122,7 @@ def build_call_transaction(
         tx += 'ffffffff'
 
     # Outputs
-    num_outputs = len(resolved_contract_outputs)
+    num_outputs = len(resolved_contract_outputs) + len(resolved_data_outputs)
     if change > 0 and (change_address or change_script):
         num_outputs += 1
     tx += _encode_varint(num_outputs)
@@ -119,6 +131,14 @@ def build_call_transaction(
     for co in resolved_contract_outputs:
         tx += _to_le64(co['satoshis'])
         s = co['script']
+        tx += _encode_varint(len(s) // 2)
+        tx += s
+
+    # Data outputs (from this.addDataOutput in method body). Emitted after
+    # state outputs and before change to match the continuation hash.
+    for do in resolved_data_outputs:
+        tx += _to_le64(do['satoshis'])
+        s = do['script']
         tx += _encode_varint(len(s) // 2)
         tx += s
 

--- a/packages/runar-py/runar/sdk/contract.py
+++ b/packages/runar-py/runar/sdk/contract.py
@@ -19,7 +19,7 @@ from runar.sdk.state import (
     _parse_fixed_array_dims, _flatten_nested, _regroup_nested,
 )
 from runar.sdk.oppushtx import compute_op_push_tx
-from runar.sdk.anf_interpreter import compute_new_state
+from runar.sdk.anf_interpreter import compute_new_state, compute_new_state_and_data_outputs
 from runar.sdk.ordinals import (
     Inscription, build_inscription_envelope, parse_inscription_envelope,
 )
@@ -422,6 +422,19 @@ class RunarContract:
         # Build contract outputs: multi-output takes priority, then single
         contract_outputs: list[dict] | None = None
 
+        # Data outputs resolved from this.addDataOutput(...). Explicit
+        # opts.data_outputs (if provided) wins; otherwise populated by the
+        # ANF interpreter pass below.
+        resolved_data_outputs: list[dict] = []
+        explicit_data_outputs = getattr(opts, 'data_outputs', None)
+        if explicit_data_outputs:
+            resolved_data_outputs = [
+                {'script': d['script'], 'satoshis': d['satoshis']}
+                if isinstance(d, dict)
+                else {'script': d.script, 'satoshis': d.satoshis}
+                for d in explicit_data_outputs
+            ]
+
         if is_stateful and has_multi_output:
             # Multi-output: build a locking script for each output
             code_script = self._code_script or self._build_code_script()
@@ -459,10 +472,12 @@ class RunarContract:
                     self._constructor_args,
                     self.artifact.abi.constructor_params,
                 )
-                computed = compute_new_state(
+                computed, data_outs = compute_new_state_and_data_outputs(
                     self.artifact.anf, method_name, flat_state, named_args,
                     flat_ctor_args,
                 )
+                if data_outs and not resolved_data_outputs:
+                    resolved_data_outputs = data_outs
                 merged = {**flat_state, **computed}
                 # Re-group synthetic scalars back into array values.
                 regrouped = _regroup_fixed_array_state(
@@ -517,6 +532,7 @@ class RunarContract:
                 {'utxo': u, 'unlocking_script': extra_unlock_placeholders[i]}
                 for i, u in enumerate(extra_contract_utxos)
             ] if extra_contract_utxos else None,
+            data_outputs=resolved_data_outputs or None,
         )
 
         # Sign P2PKH funding inputs (after contract inputs)
@@ -602,6 +618,7 @@ class RunarContract:
                     {'utxo': u, 'unlocking_script': extra_unlocks[i]}
                     for i, u in enumerate(extra_contract_utxos)
                 ] if extra_contract_utxos else None,
+                data_outputs=resolved_data_outputs or None,
             )
             signed_tx = tx_hex
 

--- a/packages/runar-py/runar/sdk/types.py
+++ b/packages/runar-py/runar/sdk/types.py
@@ -213,6 +213,11 @@ class CallOptions:
     additional_contract_input_args: list[list] | None = None
     terminal_outputs: list[TerminalOutput | dict] | None = None
     funding_utxos: list[Utxo] | None = None
+    # Optional explicit override for data outputs emitted via
+    # this.addDataOutput(...) in the method body. When None or empty, the
+    # SDK resolves data outputs automatically by running the ANF interpreter.
+    # Entries are {"script": hex, "satoshis": int}.
+    data_outputs: list[dict] | None = None
 
 
 @dataclass

--- a/packages/runar-rb/lib/runar/sdk/anf_interpreter.rb
+++ b/packages/runar-rb/lib/runar/sdk/anf_interpreter.rb
@@ -48,6 +48,20 @@ module Runar
       # @return [Hash] the updated state (merged with current_state)
       # @raise [ArgumentError] when method_name is not found as a public method in the ANF IR
       def compute_new_state(anf, method_name, current_state, args, constructor_args: [], max_loop_iterations: MAX_LOOP_ITERATIONS)
+        state, _ = compute_new_state_and_data_outputs(
+          anf, method_name, current_state, args,
+          constructor_args: constructor_args,
+          max_loop_iterations: max_loop_iterations,
+        )
+        state
+      end
+
+      # Like #compute_new_state but also returns data outputs resolved
+      # from +this.addDataOutput(...)+ in declaration order. Each entry
+      # is +{satoshis: Integer, script: String}+. The SDK uses these
+      # to populate the tx between state outputs and the change output
+      # so the on-chain continuation-hash check matches.
+      def compute_new_state_and_data_outputs(anf, method_name, current_state, args, constructor_args: [], max_loop_iterations: MAX_LOOP_ITERATIONS)
         method = find_public_method(anf, method_name)
 
         unless method
@@ -93,9 +107,10 @@ module Runar
         end
 
         state_delta = {}
-        eval_bindings(Array(method['body']), env, state_delta, anf)
+        data_outputs = []
+        eval_bindings(Array(method['body']), env, state_delta, data_outputs, anf)
 
-        current_state.merge(state_delta)
+        [current_state.merge(state_delta), data_outputs]
       ensure
         Thread.current[:runar_max_loop_iterations] = nil
       end
@@ -106,9 +121,9 @@ module Runar
       # @param env         [Hash]        current name → value environment (mutated in place)
       # @param state_delta [Hash]        accumulated state mutations (mutated in place)
       # @param anf         [Hash, nil]   full ANF IR (for method lookup)
-      def eval_bindings(bindings, env, state_delta, anf = nil)
+      def eval_bindings(bindings, env, state_delta, data_outputs, anf = nil)
         bindings.each do |binding|
-          val = eval_value(binding['value'], env, state_delta, anf)
+          val = eval_value(binding['value'], env, state_delta, data_outputs, anf)
           env[binding['name']] = val
         end
       end
@@ -121,7 +136,7 @@ module Runar
       # @param anf         [Hash, nil]
       # @return [Object]
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-      def eval_value(value, env, state_delta, anf = nil)
+      def eval_value(value, env, state_delta, data_outputs, anf = nil)
         kind = value['kind'].to_s
 
         case kind
@@ -154,13 +169,13 @@ module Runar
 
         when 'method_call'
           call_args = Array(value['args']).map { |a| env[a] }
-          eval_method_call(env[value['object']], value['method'], call_args, env, state_delta, anf)
+          eval_method_call(env[value['object']], value['method'], call_args, env, state_delta, data_outputs, anf)
 
         when 'if'
           cond   = env[value['cond']]
           branch = is_truthy(cond) ? value['then'] : value['else']
           child_env = env.dup
-          eval_bindings(Array(branch), child_env, state_delta, anf)
+          eval_bindings(Array(branch), child_env, state_delta, data_outputs, anf)
           env.merge!(child_env)
           branch && !branch.empty? ? child_env[branch.last['name']] : nil
 
@@ -177,7 +192,7 @@ module Runar
           count.times do |i|
             env[iter_var] = i
             loop_env = env.dup
-            eval_bindings(body, loop_env, state_delta, anf)
+            eval_bindings(body, loop_env, state_delta, data_outputs, anf)
             env.merge!(loop_env)
             last_val = body.empty? ? nil : loop_env[body.last['name']]
           end
@@ -210,7 +225,18 @@ module Runar
           end
           nil
 
-        when 'check_preimage', 'deserialize_state', 'get_state_script', 'add_raw_output', 'add_data_output'
+        when 'add_data_output'
+          # Resolve the two arg refs and record the data output.
+          sat_ref = value['satoshis']
+          script_ref = value['scriptBytes']
+          sats = env[sat_ref]
+          sats = sats.to_i if sats
+          script_val = env[script_ref]
+          script_hex = script_val.is_a?(String) ? script_val : ''
+          data_outputs << { satoshis: sats || 0, script: script_hex }
+          nil
+
+        when 'check_preimage', 'deserialize_state', 'get_state_script', 'add_raw_output'
           # On-chain-only operations — skip in simulation.
           nil
 
@@ -488,7 +514,7 @@ module Runar
       # @param state_delta [Hash, nil]
       # @param anf         [Hash, nil]
       # @return [Object]
-      def eval_method_call(_obj, method_name, args, caller_env = nil, state_delta = nil, anf = nil)
+      def eval_method_call(_obj, method_name, args, caller_env = nil, state_delta = nil, data_outputs = [], anf = nil)
         return nil unless anf && method_name
 
         private_method = Array(anf['methods']).find do |m|
@@ -514,7 +540,7 @@ module Runar
 
         body = Array(private_method['body'])
         child_delta = {}
-        eval_bindings(body, new_env, child_delta, anf)
+        eval_bindings(body, new_env, child_delta, data_outputs, anf)
 
         # Propagate state mutations back to the caller environment.
         state_delta&.merge!(child_delta)

--- a/packages/runar-rb/lib/runar/sdk/calling.rb
+++ b/packages/runar-rb/lib/runar/sdk/calling.rb
@@ -33,6 +33,10 @@ module Runar
     # @param options [Hash, nil] optional extensions:
     #   - +:contract_outputs+ [Array<Hash>] each +{script:, satoshis:}+ for multi-output
     #   - +:additional_contract_inputs+ [Array<Hash>] each +{utxo:, unlocking_script:}+
+    #   - +:data_outputs+ [Array<Hash>] data outputs declared via
+    #     +this.addDataOutput(...)+ in the method body. Each +{script:, satoshis:}+.
+    #     Emitted between the contract (state) outputs and the change output, in
+    #     declaration order — matching the compile-time continuation-hash layout.
     # @return [Array(String, Integer, Integer)] [tx_hex, input_count, change_amount]
     def build_call_transaction(
       current_utxo,
@@ -47,6 +51,7 @@ module Runar
     )
       opts                   = options || {}
       extra_contract_inputs  = opts[:additional_contract_inputs] || []
+      data_outputs           = opts[:data_outputs] || []
       additional             = additional_utxos || []
 
       all_utxos = [current_utxo] + extra_contract_inputs.map { |ci| ci[:utxo] } + additional
@@ -63,7 +68,9 @@ module Runar
           []
         end
 
-      contract_output_sats = resolved_outputs.sum { |co| co[:satoshis] }
+      contract_output_sats =
+        resolved_outputs.sum { |co| co[:satoshis] } +
+        data_outputs.sum { |do_| do_[:satoshis] }
 
       # Estimate transaction size for fee calculation.
       #
@@ -83,6 +90,10 @@ module Runar
 
       outputs_size = resolved_outputs.sum do |co|
         s_len = co[:script].length / 2
+        8 + varint_byte_size(s_len) + s_len
+      end
+      outputs_size += data_outputs.sum do |do_|
+        s_len = do_[:script].length / 2
         8 + varint_byte_size(s_len) + s_len
       end
 
@@ -132,13 +143,22 @@ module Runar
 
       # Output count
       has_change = change.positive? && has_change_recipient
-      output_count = resolved_outputs.length + (has_change ? 1 : 0)
+      output_count = resolved_outputs.length + data_outputs.length + (has_change ? 1 : 0)
       tx << encode_varint(output_count)
 
       # Contract continuation outputs.
       resolved_outputs.each do |co|
         s = co[:script]
         tx << to_le64(co[:satoshis])
+        tx << encode_varint(s.length / 2)
+        tx << s
+      end
+
+      # Data outputs (from this.addDataOutput in method body). Emitted after
+      # state outputs and before change to match the continuation hash.
+      data_outputs.each do |do_|
+        s = do_[:script]
+        tx << to_le64(do_[:satoshis])
         tx << encode_varint(s.length / 2)
         tx << s
       end

--- a/packages/runar-rb/lib/runar/sdk/contract.rb
+++ b/packages/runar-rb/lib/runar/sdk/contract.rb
@@ -318,16 +318,30 @@ module Runar
         change_pkh_hex = compute_change_pkh(signer, is_stateful, method_needs_change)
 
         # Auto-compute new state via ANF interpreter when artifact has ANF IR and
-        # no explicit new_state was provided. This mirrors the Python SDK behavior:
-        # compute_new_state is called here (where method_name and args are available),
-        # not in build_continuation (which has neither).
+        # no explicit new_state was provided. This also resolves data outputs
+        # declared via this.addDataOutput(...) in the method body, which the
+        # SDK needs to emit in the tx so the on-chain continuation-hash check
+        # matches at spend time.
+        resolved_data_outputs = Array(opts.data_outputs).map do |entry|
+          if entry.is_a?(Hash)
+            { script: entry[:script] || entry['script'], satoshis: entry[:satoshis] || entry['satoshis'] }
+          else
+            entry
+          end
+        end
         if is_stateful && @artifact.anf && opts.new_state.nil?
           named_args = build_named_args(user_params, resolved_args)
-          opts = opts.dup
-          opts.new_state = ANFInterpreter.compute_new_state(
+          computed_state, anf_data_outputs = ANFInterpreter.compute_new_state_and_data_outputs(
             @artifact.anf, method_name, @state, named_args,
             constructor_args: @constructor_args
           )
+          opts = opts.dup
+          opts.new_state = computed_state
+          if resolved_data_outputs.empty? && anf_data_outputs.any?
+            resolved_data_outputs = anf_data_outputs.map do |d|
+              { script: d[:script], satoshis: d[:satoshis] }
+            end
+          end
         end
 
         # Terminal call path: build a transaction with exact outputs, no funding inputs.
@@ -410,6 +424,7 @@ module Runar
 
         call_options = {}
         call_options[:contract_outputs] = contract_outputs if contract_outputs
+        call_options[:data_outputs] = resolved_data_outputs if resolved_data_outputs.any?
         if extra_contract_utxos.any?
           call_options[:additional_contract_inputs] = extra_contract_utxos.each_with_index.map do |utxo, i|
             { utxo: utxo, unlocking_script: extra_unlock_placeholders[i] }
@@ -436,6 +451,7 @@ module Runar
             change_address, change_script, additional_utxos, fee_rate, signer,
             is_stateful, needs_op_push_tx, preimage_index,
             contract_outputs: contract_outputs,
+            data_outputs: resolved_data_outputs,
             extra_contract_utxos: extra_contract_utxos,
             resolved_per_input_args: resolved_per_input_args,
             prevouts_indices: prevouts_indices
@@ -976,6 +992,7 @@ module Runar
         change_address, change_script, additional_utxos, fee_rate, signer,
         is_stateful, needs_op_push_tx, preimage_index,
         contract_outputs: nil,
+        data_outputs: [],
         extra_contract_utxos: [],
         resolved_per_input_args: [],
         prevouts_indices: []
@@ -992,6 +1009,7 @@ module Runar
               change_amount, new_satoshis, new_locking_script,
               change_address, change_script, additional_utxos, fee_rate, signer,
               contract_outputs: contract_outputs,
+              data_outputs: data_outputs,
               extra_contract_utxos: extra_contract_utxos,
               resolved_per_input_args: resolved_per_input_args,
               prevouts_indices: prevouts_indices
@@ -1025,6 +1043,7 @@ module Runar
         change_amount, new_satoshis, new_locking_script,
         change_address, change_script, additional_utxos, fee_rate, signer,
         contract_outputs: nil,
+        data_outputs: [],
         extra_contract_utxos: [],
         resolved_per_input_args: [],
         prevouts_indices: []
@@ -1034,6 +1053,7 @@ module Runar
 
         call_opts = {}
         call_opts[:contract_outputs] = contract_outputs if contract_outputs
+        call_opts[:data_outputs] = data_outputs if data_outputs && !data_outputs.empty?
 
         # First pass — build unlock with placeholder Sig/prevouts params.
         input0_unlock, = build_stateful_unlock(

--- a/packages/runar-rb/lib/runar/sdk/types.rb
+++ b/packages/runar-rb/lib/runar/sdk/types.rb
@@ -239,6 +239,7 @@ module Runar
       :additional_contract_input_args,
       :terminal_outputs,
       :funding_utxos,
+      :data_outputs,
       keyword_init: true
     ) do
       def initialize(
@@ -250,7 +251,8 @@ module Runar
         additional_contract_inputs: nil,
         additional_contract_input_args: nil,
         terminal_outputs: nil,
-        funding_utxos: nil
+        funding_utxos: nil,
+        data_outputs: nil
       )
         super
       end

--- a/packages/runar-rs/src/sdk/anf_interpreter.rs
+++ b/packages/runar-rs/src/sdk/anf_interpreter.rs
@@ -165,6 +165,15 @@ fn json_to_val(v: &serde_json::Value) -> Val {
 // Public API
 // ---------------------------------------------------------------------------
 
+/// A data output resolved from `this.addDataOutput(...)` in the method body.
+/// The SDK emits these between state outputs and the change output so the
+/// tx's hashOutputs matches the compile-time continuation-hash constant.
+#[derive(Debug, Clone)]
+pub struct DataOutputEntry {
+    pub satoshis: i64,
+    pub script: String,
+}
+
 /// Compute the new state after executing a contract method.
 ///
 /// Returns the updated state (merged with `current_state`).
@@ -179,6 +188,20 @@ pub fn compute_new_state(
     args: &HashMap<String, SdkValue>,
     constructor_args: &[SdkValue],
 ) -> Result<HashMap<String, SdkValue>, String> {
+    compute_new_state_and_data_outputs(anf, method_name, current_state, args, constructor_args)
+        .map(|(state, _)| state)
+}
+
+/// Compute the new state AND resolved data outputs after executing a
+/// contract method. See [`compute_new_state`] for state semantics; data
+/// outputs come from `this.addDataOutput(...)` calls in declaration order.
+pub fn compute_new_state_and_data_outputs(
+    anf: &ANFProgram,
+    method_name: &str,
+    current_state: &HashMap<String, SdkValue>,
+    args: &HashMap<String, SdkValue>,
+    constructor_args: &[SdkValue],
+) -> Result<(HashMap<String, SdkValue>, Vec<DataOutputEntry>), String> {
     // Find the public method
     let method = anf.methods.iter().find(|m| m.name == method_name && m.is_public)
         .ok_or_else(|| format!("compute_new_state: method '{}' not found in ANF IR", method_name))?;
@@ -222,18 +245,19 @@ pub fn compute_new_state(
         }
     }
 
-    // Track state mutations
+    // Track state mutations and data outputs
     let mut state_delta: HashMap<String, Val> = HashMap::new();
+    let mut data_outputs: Vec<DataOutputEntry> = Vec::new();
 
     // Walk bindings
-    eval_bindings(&method.body, &mut env, &mut state_delta, anf);
+    eval_bindings(&method.body, &mut env, &mut state_delta, &mut data_outputs, anf);
 
     // Merge delta into current_state
     let mut result = current_state.clone();
     for (k, v) in state_delta {
         result.insert(k, v.to_sdk());
     }
-    Ok(result)
+    Ok((result, data_outputs))
 }
 
 // ---------------------------------------------------------------------------
@@ -244,10 +268,11 @@ fn eval_bindings(
     bindings: &[ANFBinding],
     env: &mut HashMap<String, Val>,
     state_delta: &mut HashMap<String, Val>,
+    data_outputs: &mut Vec<DataOutputEntry>,
     anf: &ANFProgram,
 ) {
     for binding in bindings {
-        let val = eval_value(&binding.value, env, state_delta, anf);
+        let val = eval_value(&binding.value, env, state_delta, data_outputs, anf);
         env.insert(binding.name.clone(), val);
     }
 }
@@ -256,6 +281,7 @@ fn eval_value(
     value: &serde_json::Value,
     env: &mut HashMap<String, Val>,
     state_delta: &mut HashMap<String, Val>,
+    data_outputs: &mut Vec<DataOutputEntry>,
     anf: &ANFProgram,
 ) -> Val {
     let kind = match value.get("kind").and_then(|k| k.as_str()) {
@@ -333,7 +359,7 @@ fn eval_value(
                         child_env.insert(param.name.clone(), arg_val.clone());
                     }
                 }
-                eval_bindings(&method.body, &mut child_env, state_delta, anf);
+                eval_bindings(&method.body, &mut child_env, state_delta, data_outputs, anf);
                 // Copy property updates back to caller env
                 for prop in &anf.properties {
                     if let Some(v) = child_env.get(&prop.name) {
@@ -361,7 +387,7 @@ fn eval_value(
                     .collect();
                 // Create child env for the branch
                 let mut child_env = env.clone();
-                eval_bindings(&bindings, &mut child_env, state_delta, anf);
+                eval_bindings(&bindings, &mut child_env, state_delta, data_outputs, anf);
                 // Copy new bindings back
                 for (k, v) in &child_env {
                     env.insert(k.clone(), v.clone());
@@ -389,7 +415,7 @@ fn eval_value(
                 for i in 0..count {
                     env.insert(iter_var.clone(), Val::Int(i));
                     let mut loop_env = env.clone();
-                    eval_bindings(&bindings, &mut loop_env, state_delta, anf);
+                    eval_bindings(&bindings, &mut loop_env, state_delta, data_outputs, anf);
                     // Copy loop bindings back
                     for (k, v) in &loop_env {
                         env.insert(k.clone(), v.clone());
@@ -431,9 +457,19 @@ fn eval_value(
             Val::Undefined
         }
 
+        "add_data_output" => {
+            // Resolve the two arg refs from env and record the data output.
+            let sat_ref = str_field(value, "satoshis");
+            let script_ref = str_field(value, "scriptBytes");
+            let sats = env.get(&sat_ref).map(|v| v.to_i64()).unwrap_or(0);
+            let script_hex = env.get(&script_ref).map(|v| v.as_hex()).unwrap_or_default();
+            data_outputs.push(DataOutputEntry { satoshis: sats, script: script_hex });
+            Val::Undefined
+        }
+
         // On-chain-only operations — skip in simulation
         "check_preimage" | "deserialize_state" | "get_state_script"
-        | "add_raw_output" | "add_data_output" => Val::Undefined,
+        | "add_raw_output" => Val::Undefined,
 
         _ => Val::Undefined,
     }

--- a/packages/runar-rs/src/sdk/calling.rs
+++ b/packages/runar-rs/src/sdk/calling.rs
@@ -24,6 +24,11 @@ pub struct CallTxOptions {
     pub contract_outputs: Option<Vec<ContractOutput>>,
     /// Additional contract inputs with their own unlocking scripts (for merge).
     pub additional_contract_inputs: Option<Vec<AdditionalContractInput>>,
+    /// Data outputs declared via `this.addDataOutput(...)` in the method
+    /// body. Emitted between the contract (state) outputs and the change
+    /// output, in declaration order — matching the order the compiler's
+    /// auto-injected continuation-hash check expects.
+    pub data_outputs: Option<Vec<ContractOutput>>,
 }
 
 /// Build a raw transaction that spends a contract UTXO (method call).
@@ -101,7 +106,15 @@ pub fn build_call_transaction_ext(
         vec![]
     };
 
-    let contract_output_sats: i64 = contract_outputs.iter().map(|o| o.satoshis).sum();
+    let data_outputs: Vec<ContractOutput> = if let Some(dos) = options.and_then(|o| o.data_outputs.as_ref()) {
+        dos.iter().map(|co| ContractOutput { script: co.script.clone(), satoshis: co.satoshis }).collect()
+    } else {
+        vec![]
+    };
+
+    let contract_output_sats: i64 =
+        contract_outputs.iter().map(|o| o.satoshis).sum::<i64>()
+            + data_outputs.iter().map(|o| o.satoshis).sum::<i64>();
 
     // Estimate fee using actual script sizes
     let unlock_byte_len = unlocking_script.len() / 2;
@@ -118,6 +131,10 @@ pub fn build_call_transaction_ext(
     for co in &contract_outputs {
         let co_byte_len = co.script.len() / 2;
         outputs_size += 8 + varint_byte_size(co_byte_len) + co_byte_len as i64;
+    }
+    for do_ in &data_outputs {
+        let do_byte_len = do_.script.len() / 2;
+        outputs_size += 8 + varint_byte_size(do_byte_len) + do_byte_len as i64;
     }
     let has_change_target = change_address.is_some() || change_script.is_some();
     if has_change_target {
@@ -164,7 +181,7 @@ pub fn build_call_transaction_ext(
     }
 
     // Output count
-    let mut num_outputs = contract_outputs.len() as u64;
+    let mut num_outputs = (contract_outputs.len() + data_outputs.len()) as u64;
     if change > 0 && has_change_target {
         num_outputs += 1;
     }
@@ -175,6 +192,14 @@ pub fn build_call_transaction_ext(
         tx.push_str(&to_little_endian_64(co.satoshis));
         tx.push_str(&encode_varint((co.script.len() / 2) as u64));
         tx.push_str(&co.script);
+    }
+
+    // Data outputs (from this.addDataOutput in method body). Emitted after
+    // state outputs and before change to match the continuation hash.
+    for do_ in &data_outputs {
+        tx.push_str(&to_little_endian_64(do_.satoshis));
+        tx.push_str(&encode_varint((do_.script.len() / 2) as u64));
+        tx.push_str(&do_.script);
     }
 
     // Change output

--- a/packages/runar-rs/src/sdk/contract.rs
+++ b/packages/runar-rs/src/sdk/contract.rs
@@ -513,6 +513,34 @@ impl RunarContract {
 
         let mut contract_outputs: Option<Vec<ContractOutput>> = None;
 
+        // Resolve data outputs declared via this.addDataOutput(...).
+        // Explicit options.data_outputs wins; otherwise run the ANF
+        // interpreter to resolve them. Also keep the computed state so
+        // the block below doesn't have to re-run the interpreter.
+        let mut resolved_data_outputs: Vec<ContractOutput> = Vec::new();
+        let mut auto_computed_state: Option<HashMap<String, SdkValue>> = None;
+        if is_stateful {
+            if let Some(ref anf) = self.artifact.anf {
+                let named_args = build_named_args(&user_params, &resolved_args);
+                if let Ok((state, data_outs)) = anf_interpreter::compute_new_state_and_data_outputs(
+                    anf, method_name, &self.state, &named_args,
+                    &self.constructor_args,
+                ) {
+                    auto_computed_state = Some(state);
+                    resolved_data_outputs = data_outs.into_iter().map(|d| ContractOutput {
+                        script: d.script,
+                        satoshis: d.satoshis,
+                    }).collect();
+                }
+            }
+        }
+        if let Some(explicit) = options.and_then(|o| o.data_outputs.as_ref()) {
+            resolved_data_outputs = explicit.iter().map(|d| ContractOutput {
+                script: d.script.clone(),
+                satoshis: d.satoshis,
+            }).collect();
+        }
+
         if is_stateful && has_multi_output {
             // Multi-output: build a locking script for each output
             let code_script = self.code_script.clone().unwrap_or_else(|| self.build_code_script());
@@ -543,15 +571,9 @@ impl RunarContract {
                     self.state.insert(k.clone(), v.clone());
                 }
             } else if method_needs_change {
-                if let Some(ref anf) = self.artifact.anf {
-                    let named_args = build_named_args(&user_params, &resolved_args);
-                    if let Ok(computed) = anf_interpreter::compute_new_state(
-                        anf, method_name, &self.state, &named_args,
-                        &self.constructor_args,
-                    ) {
-                        for (k, v) in computed {
-                            self.state.insert(k, v);
-                        }
+                if let Some(computed) = auto_computed_state.take() {
+                    for (k, v) in computed {
+                        self.state.insert(k, v);
                     }
                 }
             }
@@ -620,6 +642,14 @@ impl RunarContract {
                         utxo: utxo.clone(),
                         unlocking_script: extra_unlock_placeholders[i].clone(),
                     }
+                }).collect())
+            },
+            data_outputs: if resolved_data_outputs.is_empty() {
+                None
+            } else {
+                Some(resolved_data_outputs.iter().map(|co| ContractOutput {
+                    script: co.script.clone(),
+                    satoshis: co.satoshis,
                 }).collect())
             },
         };
@@ -770,6 +800,14 @@ impl RunarContract {
                             utxo: utxo.clone(),
                             unlocking_script: extra_unlocks[i].clone(),
                         }
+                    }).collect())
+                },
+                data_outputs: if resolved_data_outputs.is_empty() {
+                    None
+                } else {
+                    Some(resolved_data_outputs.iter().map(|co| ContractOutput {
+                        script: co.script.clone(),
+                        satoshis: co.satoshis,
                     }).collect())
                 },
             };

--- a/packages/runar-rs/src/sdk/types.rs
+++ b/packages/runar-rs/src/sdk/types.rs
@@ -86,6 +86,22 @@ pub struct CallOptions {
     /// The fee comes from the contract balance. The contract is considered
     /// fully spent after this call (currentUtxo becomes None).
     pub terminal_outputs: Option<Vec<TerminalOutput>>,
+    /// Optional explicit override for data outputs emitted via
+    /// `this.addDataOutput(...)` in the method body. When `None`, the SDK
+    /// resolves data outputs automatically by running the ANF interpreter
+    /// on the method body (the common case). Pass a non-empty `Vec` to
+    /// bypass the interpreter.
+    pub data_outputs: Option<Vec<ContractDataOutput>>,
+}
+
+/// A data output entry — hex-encoded script + satoshis — for the
+/// `CallOptions::data_outputs` fallback API. Same shape as
+/// `calling::ContractOutput` but kept in this module so callers can
+/// construct options without importing from `calling`.
+#[derive(Debug, Clone)]
+pub struct ContractDataOutput {
+    pub script: String,
+    pub satoshis: i64,
 }
 
 /// Specification for an exact output in a terminal method call.

--- a/packages/runar-sdk/src/anf-interpreter.ts
+++ b/packages/runar-sdk/src/anf-interpreter.ts
@@ -32,6 +32,11 @@ import { Hash, Utils } from '@bsv/sdk';
  * @param constructorArgs  Constructor arg values (declaration order) for readonly fields.
  * @returns The updated state (merged with currentState).
  */
+export interface DataOutputEntry {
+  satoshis: bigint | number;
+  script: string;
+}
+
 export function computeNewState(
   anf: ANFProgram,
   methodName: string,
@@ -39,6 +44,25 @@ export function computeNewState(
   args: Record<string, unknown>,
   constructorArgs: unknown[] = [],
 ): Record<string, unknown> {
+  return computeNewStateAndDataOutputs(
+    anf, methodName, currentState, args, constructorArgs,
+  ).state;
+}
+
+/**
+ * Like {@link computeNewState} but also returns data outputs resolved
+ * from `this.addDataOutput(...)` in the method body. Entries appear in
+ * declaration order and are what `buildCallTransaction` should emit
+ * between state outputs and the change output so the on-chain
+ * continuation-hash check passes.
+ */
+export function computeNewStateAndDataOutputs(
+  anf: ANFProgram,
+  methodName: string,
+  currentState: Record<string, unknown>,
+  args: Record<string, unknown>,
+  constructorArgs: unknown[] = [],
+): { state: Record<string, unknown>; dataOutputs: DataOutputEntry[] } {
   // Find the method in ANF
   const method = anf.methods.find(
     (m) => m.name === methodName && m.isPublic,
@@ -83,13 +107,14 @@ export function computeNewState(
     }
   }
 
-  // Track state mutations
+  // Track state mutations and data outputs
   const stateDelta: Record<string, unknown> = {};
+  const dataOutputs: DataOutputEntry[] = [];
 
   // Walk bindings
-  evalBindings(method.body, env, stateDelta, anf);
+  evalBindings(method.body, env, stateDelta, dataOutputs, anf);
 
-  return { ...currentState, ...stateDelta };
+  return { state: { ...currentState, ...stateDelta }, dataOutputs };
 }
 
 // ---------------------------------------------------------------------------
@@ -100,10 +125,11 @@ function evalBindings(
   bindings: ANFBinding[],
   env: Record<string, unknown>,
   stateDelta: Record<string, unknown>,
+  dataOutputs: DataOutputEntry[],
   anf?: ANFProgram,
 ): void {
   for (const binding of bindings) {
-    const val = evalValue(binding.value, env, stateDelta, anf);
+    const val = evalValue(binding.value, env, stateDelta, dataOutputs, anf);
     env[binding.name] = val;
   }
 }
@@ -112,6 +138,7 @@ function evalValue(
   value: ANFValue,
   env: Record<string, unknown>,
   stateDelta: Record<string, unknown>,
+  dataOutputs: DataOutputEntry[],
   anf?: ANFProgram,
 ): unknown {
   switch (value.kind) {
@@ -150,6 +177,7 @@ function evalValue(
         value.method,
         value.args.map((a: string) => env[a]),
         stateDelta,
+        dataOutputs,
         anf,
       );
 
@@ -158,7 +186,7 @@ function evalValue(
       const branch = isTruthy(cond) ? value.then : value.else;
       // Create a child env for the branch
       const childEnv = { ...env };
-      evalBindings(branch, childEnv, stateDelta, anf);
+      evalBindings(branch, childEnv, stateDelta, dataOutputs, anf);
       // Copy any new bindings back (the last binding is typically the branch result)
       Object.assign(env, childEnv);
       // Return the last binding's value from the branch
@@ -174,7 +202,7 @@ function evalValue(
       for (let i = 0; i < count; i++) {
         env[iterVar] = BigInt(i);
         const loopEnv = { ...env };
-        evalBindings(body, loopEnv, stateDelta, anf);
+        evalBindings(body, loopEnv, stateDelta, dataOutputs, anf);
         // Copy loop bindings back
         Object.assign(env, loopEnv);
         if (body.length > 0) {
@@ -209,6 +237,17 @@ function evalValue(
           stateDelta[propName] = newVal;
         }
       }
+      return undefined;
+    }
+
+    case 'add_data_output': {
+      // Resolve the two arg refs from env and record the data output.
+      const sats = toBigInt(env[value.satoshis]);
+      const script = env[value.scriptBytes];
+      dataOutputs.push({
+        satoshis: sats,
+        script: typeof script === 'string' ? script : '',
+      });
       return undefined;
     }
 
@@ -439,6 +478,7 @@ function evalMethodCall(
   methodName: string,
   args: unknown[],
   stateDelta: Record<string, unknown>,
+  dataOutputs: DataOutputEntry[],
   anf?: ANFProgram,
 ): unknown {
   // Private method calls appear in the ANF with their bodies available
@@ -463,7 +503,7 @@ function evalMethodCall(
 
       // Execute the method body — pass real stateDelta so update_prop
       // mutations in private methods are captured
-      evalBindings(method.body, methodEnv, stateDelta, anf);
+      evalBindings(method.body, methodEnv, stateDelta, dataOutputs, anf);
 
       // Propagate property changes back to the caller's env
       for (const prop of anf.properties) {

--- a/packages/runar-sdk/src/calling.ts
+++ b/packages/runar-sdk/src/calling.ts
@@ -33,9 +33,15 @@ export function buildCallTransaction(
     contractOutputs?: Array<{ script: string; satoshis: number }>;
     /** Additional contract inputs with their own unlocking scripts (for merge). */
     additionalContractInputs?: Array<{ utxo: UTXO; unlockingScript: string }>;
+    /** Data outputs declared via `this.addDataOutput(...)` in the method
+     * body. Emitted between contract (state) outputs and the change output,
+     * in declaration order — matching the compile-time continuation-hash
+     * layout. */
+    dataOutputs?: Array<{ script: string; satoshis: number }>;
   },
 ): { tx: Transaction; inputCount: number; changeAmount: number } {
   const extraContractInputs = options?.additionalContractInputs ?? [];
+  const dataOutputs = options?.dataOutputs ?? [];
   const allUtxos = [currentUtxo, ...extraContractInputs.map((i) => i.utxo), ...(additionalUtxos ?? [])];
 
   const totalInput = allUtxos.reduce((sum, u) => sum + u.satoshis, 0);
@@ -47,7 +53,9 @@ export function buildCallTransaction(
       ? [{ script: newLockingScript, satoshis: newSatoshis ?? currentUtxo.satoshis }]
       : []);
 
-  const contractOutputSats = contractOutputs.reduce((sum, o) => sum + o.satoshis, 0);
+  const contractOutputSats =
+    contractOutputs.reduce((sum, o) => sum + o.satoshis, 0)
+    + dataOutputs.reduce((sum, o) => sum + o.satoshis, 0);
 
   // Estimate fee using actual script sizes
   const input0Size = 32 + 4 + varIntByteSize(unlockingScript.length / 2) +
@@ -64,6 +72,9 @@ export function buildCallTransaction(
   let outputsSize = 0;
   for (const co of contractOutputs) {
     outputsSize += 8 + varIntByteSize(co.script.length / 2) + co.script.length / 2;
+  }
+  for (const do_ of dataOutputs) {
+    outputsSize += 8 + varIntByteSize(do_.script.length / 2) + do_.script.length / 2;
   }
   if (changeAddress || changeScript) {
     outputsSize += 34; // P2PKH change
@@ -111,6 +122,15 @@ export function buildCallTransaction(
     tx.addOutput({
       satoshis: co.satoshis,
       lockingScript: LockingScript.fromHex(co.script),
+    });
+  }
+
+  // Data outputs (from this.addDataOutput in method body). Emitted after
+  // state outputs and before change to match the continuation hash.
+  for (const do_ of dataOutputs) {
+    tx.addOutput({
+      satoshis: do_.satoshis,
+      lockingScript: LockingScript.fromHex(do_.script),
     });
   }
 

--- a/packages/runar-sdk/src/contract.ts
+++ b/packages/runar-sdk/src/contract.ts
@@ -12,7 +12,7 @@ import { buildCallTransaction } from './calling.js';
 import { serializeState, extractStateFromScript, findLastOpReturn } from './state.js';
 import { computeOpPushTx } from './oppushtx.js';
 import { buildP2PKHScript } from './script-utils.js';
-import { computeNewState } from './anf-interpreter.js';
+import { computeNewStateAndDataOutputs } from './anf-interpreter.js';
 import { buildInscriptionEnvelope, parseInscriptionEnvelope } from './ordinals/envelope.js';
 import { Utils, Hash, Transaction as BsvTransaction, LockingScript, UnlockingScript } from '@bsv/sdk';
 import { WalletProvider } from './providers/wallet-provider.js';
@@ -708,6 +708,14 @@ export class RunarContract {
     const extraContractUtxos = options?.additionalContractInputs ?? [];
     const hasMultiOutput = options?.outputs && options.outputs.length > 0;
 
+    // Data outputs declared via this.addDataOutput(...). Explicit
+    // options.dataOutputs wins; otherwise populated by the ANF
+    // interpreter pass below.
+    let resolvedDataOutputs: Array<{ script: string; satoshis: number }> =
+      options?.dataOutputs
+        ? options.dataOutputs.map((d) => ({ script: d.script, satoshis: Number(d.satoshis) }))
+        : [];
+
     if (isStateful && hasMultiOutput) {
       const codeScript = this._codeScript ?? this.buildCodeScript();
       contractOutputs = options!.outputs!.map((out) => {
@@ -727,10 +735,16 @@ export class RunarContract {
         // expanded scalars) can read them by name.
         const flatState = flattenFixedArrayState(this._state, this.artifact.stateFields);
         const flatCtorArgs = flattenFixedArrayArgs(this.constructorArgs, this.artifact.abi.constructor.params);
-        const computed = computeNewState(
+        const { state: computed, dataOutputs: anfDataOutputs } = computeNewStateAndDataOutputs(
           this.artifact.anf, methodName, flatState, namedArgs,
           flatCtorArgs,
         );
+        if (anfDataOutputs.length > 0 && resolvedDataOutputs.length === 0) {
+          resolvedDataOutputs = anfDataOutputs.map((d) => ({
+            script: d.script,
+            satoshis: Number(d.satoshis),
+          }));
+        }
         const merged = { ...flatState, ...computed };
         // Re-group synthetic scalars back into array values, then merge
         // into the user-visible state.
@@ -787,6 +801,7 @@ export class RunarContract {
         additionalContractInputs: extraContractUtxos.length > 0
           ? extraContractUtxos.map((utxo, i) => ({ utxo, unlockingScript: extraUnlockPlaceholders[i]! }))
           : undefined,
+        dataOutputs: resolvedDataOutputs.length > 0 ? resolvedDataOutputs : undefined,
       },
     );
 
@@ -885,6 +900,7 @@ export class RunarContract {
           additionalContractInputs: extraContractUtxos.length > 0
             ? extraContractUtxos.map((utxo, i) => ({ utxo, unlockingScript: extraUnlocks[i]! }))
             : undefined,
+          dataOutputs: resolvedDataOutputs.length > 0 ? resolvedDataOutputs : undefined,
         },
       ));
 

--- a/packages/runar-sdk/src/types.ts
+++ b/packages/runar-sdk/src/types.ts
@@ -138,4 +138,13 @@ export interface CallOptions {
    * when the contract's own balance is insufficient for outputs + fees.
    */
   fundingUtxos?: UTXO[];
+
+  /**
+   * Optional explicit override for data outputs emitted via
+   * `this.addDataOutput(...)` in the method body. When omitted, the SDK
+   * resolves data outputs automatically by running the ANF interpreter on
+   * the method body (the common case). Pass a non-empty array to bypass
+   * the interpreter.
+   */
+  dataOutputs?: Array<{ script: string; satoshis: number | bigint }>;
 }

--- a/packages/runar-zig/src/sdk_anf_interpreter.zig
+++ b/packages/runar-zig/src/sdk_anf_interpreter.zig
@@ -106,7 +106,10 @@ pub const ANFNode = union(enum) {
     deserialize_state: struct {},
     get_state_script: struct {},
     add_raw_output: struct {},
-    add_data_output: struct {},
+    add_data_output: struct {
+        satoshis: []const u8 = "",
+        script_bytes: []const u8 = "",
+    },
     unknown: void,
 };
 
@@ -118,9 +121,23 @@ pub const InterpreterError = error{
 /// Sentinel value for "no result" / undefined.
 const anf_none: ANFValue = .{ .none = {} };
 
+/// A data output resolved from `this.addDataOutput(...)` in the method body.
+/// Caller owns the `script` slice (allocated from the caller's allocator).
+pub const DataOutputEntry = struct {
+    satoshis: i64,
+    script: []u8,
+};
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/// Result of `computeNewStateAndDataOutputs`: the new state map and a
+/// slice of data outputs. Caller owns both.
+pub const NewStateResult = struct {
+    state: std.StringHashMap(ANFValue),
+    data_outputs: []DataOutputEntry,
+};
 
 /// Compute the new state after executing a contract method.
 ///
@@ -133,6 +150,27 @@ pub fn computeNewState(
     args: std.StringHashMap(ANFValue),
     constructor_args: []const ANFValue,
 ) !std.StringHashMap(ANFValue) {
+    const result = try computeNewStateAndDataOutputs(
+        allocator, anf, method_name, current_state, args, constructor_args,
+    );
+    // Discard data outputs — free their script allocations.
+    for (result.data_outputs) |d| allocator.free(d.script);
+    allocator.free(result.data_outputs);
+    return result.state;
+}
+
+/// Like `computeNewState` but also returns data outputs resolved from
+/// `this.addDataOutput(...)` calls in declaration order. Caller owns both
+/// the state map and the returned data-output slice (including each
+/// entry's `script`).
+pub fn computeNewStateAndDataOutputs(
+    allocator: std.mem.Allocator,
+    anf: *const ANFProgram,
+    method_name: []const u8,
+    current_state: std.StringHashMap(ANFValue),
+    args: std.StringHashMap(ANFValue),
+    constructor_args: []const ANFValue,
+) !NewStateResult {
     // Use an arena for all intermediate allocations during interpretation
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -187,11 +225,13 @@ pub fn computeNewState(
         }
     }
 
-    // Track state mutations
+    // Track state mutations and data outputs. data_outputs holds arena
+    // slices; we dupe them into the caller allocator below.
     var state_delta = std.StringHashMap(ANFValue).init(arena_alloc);
+    var data_outputs_arena = std.ArrayList(DataOutputEntry).empty;
 
     // Walk bindings
-    try evalBindings(arena_alloc, meth.body, &env, &state_delta, anf);
+    try evalBindings(arena_alloc, meth.body, &env, &state_delta, &data_outputs_arena, anf);
 
     // Merge with current state — use caller allocator for result
     var result = std.StringHashMap(ANFValue).init(allocator);
@@ -209,7 +249,14 @@ pub fn computeNewState(
         try result.put(entry.key_ptr.*, val);
     }
 
-    return result;
+    // Dupe data-output scripts into the caller allocator so they survive
+    // the arena deinit.
+    const do_out = try allocator.alloc(DataOutputEntry, data_outputs_arena.items.len);
+    for (data_outputs_arena.items, 0..) |d, i| {
+        do_out[i] = .{ .satoshis = d.satoshis, .script = try allocator.dupe(u8, d.script) };
+    }
+
+    return .{ .state = result, .data_outputs = do_out };
 }
 
 // ---------------------------------------------------------------------------
@@ -232,10 +279,11 @@ fn evalBindings(
     bindings: []const ANFBinding,
     env: *std.StringHashMap(ANFValue),
     state_delta: *std.StringHashMap(ANFValue),
+    data_outputs: *std.ArrayList(DataOutputEntry),
     anf: *const ANFProgram,
 ) error{OutOfMemory}!void {
     for (bindings) |binding| {
-        const val = try evalNode(allocator, binding.value, env, state_delta, anf);
+        const val = try evalNode(allocator, binding.value, env, state_delta, data_outputs, anf);
         try env.put(binding.name, val);
     }
 }
@@ -245,6 +293,7 @@ fn evalNode(
     node: ANFNode,
     env: *std.StringHashMap(ANFValue),
     state_delta: *std.StringHashMap(ANFValue),
+    data_outputs: *std.ArrayList(DataOutputEntry),
     anf: *const ANFProgram,
 ) error{OutOfMemory}!ANFValue {
     switch (node) {
@@ -282,12 +331,12 @@ fn evalNode(
             return evalCall(allocator, c.func, c.args, env);
         },
         .method_call => |mc| {
-            return evalMethodCall(allocator, mc.method, mc.args, env, state_delta, anf);
+            return evalMethodCall(allocator, mc.method, mc.args, env, state_delta, data_outputs, anf);
         },
         .if_node => |ifn| {
             const cond = env.get(ifn.cond) orelse anf_none;
             const branch = if (isTruthy(cond)) ifn.then_branch else ifn.else_branch;
-            try evalBindings(allocator, branch, env, state_delta, anf);
+            try evalBindings(allocator, branch, env, state_delta, data_outputs, anf);
             if (branch.len > 0) {
                 return env.get(branch[branch.len - 1].name) orelse anf_none;
             }
@@ -297,7 +346,7 @@ fn evalNode(
             var last_val: ANFValue = anf_none;
             for (0..ln.count) |i| {
                 try env.put(ln.iter_var, .{ .int = @intCast(i) });
-                try evalBindings(allocator, ln.body, env, state_delta, anf);
+                try evalBindings(allocator, ln.body, env, state_delta, data_outputs, anf);
                 if (ln.body.len > 0) {
                     last_val = env.get(ln.body[ln.body.len - 1].name) orelse anf_none;
                 }
@@ -331,8 +380,26 @@ fn evalNode(
             }
             return anf_none;
         },
+        .add_data_output => |ado| {
+            // Resolve the two arg refs from env and record the data output.
+            const sat_val = env.get(ado.satoshis) orelse anf_none;
+            const script_val = env.get(ado.script_bytes) orelse anf_none;
+            const sats: i64 = switch (sat_val) {
+                .int => |n| n,
+                else => 0,
+            };
+            const script_bytes: []const u8 = switch (script_val) {
+                .bytes => |b| b,
+                else => "",
+            };
+            try data_outputs.append(allocator, .{
+                .satoshis = sats,
+                .script = try allocator.dupe(u8, script_bytes),
+            });
+            return anf_none;
+        },
         // On-chain-only operations — skip
-        .check_preimage, .deserialize_state, .get_state_script, .add_raw_output, .add_data_output => {
+        .check_preimage, .deserialize_state, .get_state_script, .add_raw_output => {
             return anf_none;
         },
         .unknown => {
@@ -695,6 +762,7 @@ fn evalMethodCall(
     arg_names: []const []const u8,
     env: *std.StringHashMap(ANFValue),
     state_delta: *std.StringHashMap(ANFValue),
+    data_outputs: *std.ArrayList(DataOutputEntry),
     anf: *const ANFProgram,
 ) error{OutOfMemory}!ANFValue {
     // Find the private method
@@ -719,7 +787,7 @@ fn evalMethodCall(
             }
 
             // Execute the method body
-            try evalBindings(allocator, m.body, &method_env, state_delta, anf);
+            try evalBindings(allocator, m.body, &method_env, state_delta, data_outputs, anf);
 
             // Propagate property changes back
             for (anf.properties) |prop| {
@@ -1177,7 +1245,12 @@ fn parseANFNode(allocator: std.mem.Allocator, val: std.json.Value) error{OutOfMe
     if (std.mem.eql(u8, kind, "deserialize_state")) return .{ .deserialize_state = .{} };
     if (std.mem.eql(u8, kind, "get_state_script")) return .{ .get_state_script = .{} };
     if (std.mem.eql(u8, kind, "add_raw_output")) return .{ .add_raw_output = .{} };
-    if (std.mem.eql(u8, kind, "add_data_output")) return .{ .add_data_output = .{} };
+    if (std.mem.eql(u8, kind, "add_data_output")) {
+        return .{ .add_data_output = .{
+            .satoshis = if (obj.get("satoshis")) |v| (if (v == .string) try allocator.dupe(u8, v.string) else "") else "",
+            .script_bytes = if (obj.get("scriptBytes")) |v| (if (v == .string) try allocator.dupe(u8, v.string) else "") else "",
+        } };
+    }
     if (std.mem.eql(u8, kind, "add_output")) {
         var state_values: std.ArrayListUnmanaged([]const u8) = .empty;
         if (obj.get("stateValues")) |sv| {

--- a/packages/runar-zig/src/sdk_call.zig
+++ b/packages/runar-zig/src/sdk_call.zig
@@ -11,6 +11,11 @@ const provider_mod = @import("sdk_provider.zig");
 
 pub const CallBuildOptions = struct {
     contract_outputs: []const types.ContractOutput = &.{},
+    /// Data outputs declared via `this.addDataOutput(...)` in the method
+    /// body. Emitted between the contract (state) outputs and the change
+    /// output, in declaration order — matching the compile-time
+    /// continuation-hash layout.
+    data_outputs: []const types.ContractOutput = &.{},
 };
 
 pub const CallResult = struct {
@@ -52,12 +57,16 @@ pub fn buildCallTransaction(
         try contract_outputs.append(allocator, .{ .script = new_locking_script_hex, .satoshis = sats });
     }
 
+    const data_outputs: []const types.ContractOutput =
+        if (opts != null) opts.?.data_outputs else &.{};
+
     // Calculate total inputs
     var total_input: i64 = current_utxo.satoshis;
     for (additional_utxos) |u| total_input += u.satoshis;
 
     var contract_output_sats: i64 = 0;
     for (contract_outputs.items) |co| contract_output_sats += co.satoshis;
+    for (data_outputs) |do_| contract_output_sats += do_.satoshis;
 
     // Estimate fee
     const input0_script_len = unlocking_script_hex.len / 2;
@@ -68,6 +77,10 @@ pub fn buildCallTransaction(
     var outputs_size: usize = 0;
     for (contract_outputs.items) |co| {
         const script_len = co.script.len / 2;
+        outputs_size += 8 + varIntByteSize(script_len) + script_len;
+    }
+    for (data_outputs) |do_| {
+        const script_len = do_.script.len / 2;
         outputs_size += 8 + varIntByteSize(script_len) + script_len;
     }
     if (change_address != null) {
@@ -134,6 +147,18 @@ pub fn buildCallTransaction(
         try builder.addOutput(.{
             .satoshis = co.satoshis,
             .locking_script = bsvz.script.Script.init(co_bytes),
+        });
+    }
+
+    // Data outputs (from this.addDataOutput in method body). Emitted
+    // after state outputs and before change to match the continuation
+    // hash the compiler embedded in the locking script.
+    for (data_outputs) |do_| {
+        const do_bytes = try bsvz.primitives.hex.decode(allocator, do_.script);
+        defer allocator.free(do_bytes);
+        try builder.addOutput(.{
+            .satoshis = do_.satoshis,
+            .locking_script = bsvz.script.Script.init(do_bytes),
         });
     }
 

--- a/packages/runar-zig/src/sdk_contract.zig
+++ b/packages/runar-zig/src/sdk_contract.zig
@@ -356,6 +356,15 @@ pub const RunarContract = struct {
         var new_satoshis: i64 = 0;
         defer if (new_locking_script.len > 0) self.allocator.free(new_locking_script);
 
+        // Data outputs resolved from this.addDataOutput(...) in the method
+        // body (or supplied explicitly via options.data_outputs). We free
+        // these — including each entry's script slice — at call-scope exit.
+        var anf_data_outputs: []anf_interp.DataOutputEntry = &.{};
+        defer {
+            for (anf_data_outputs) |d| self.allocator.free(d.script);
+            if (anf_data_outputs.len > 0) self.allocator.free(anf_data_outputs);
+        }
+
         if (is_stateful) {
             new_satoshis = contract_utxo.satoshis;
             if (options) |o| {
@@ -374,10 +383,8 @@ pub const RunarContract = struct {
                 }
                 self.state = vals;
             } else if (needs_change and self.artifact.anf_json != null) {
-                // Auto-compute new state from ANF IR
-                self.autoComputeState(method_name, user_params, resolved_args) catch {
-                    // If ANF interpretation fails, continue with current state
-                };
+                // Auto-compute new state + data outputs from ANF IR
+                anf_data_outputs = self.autoComputeState(method_name, user_params, resolved_args) catch &.{};
             }
             new_locking_script = try self.getLockingScript();
         }
@@ -410,6 +417,32 @@ pub const RunarContract = struct {
         }
 
         const code_sep_idx = try self.getCodeSepIndex(method_index);
+
+        // Convert data outputs (interpreter DataOutputEntry -> ContractOutput
+        // with hex-encoded scripts) for the tx builder. The scripts must be
+        // hex-encoded because CallBuildOptions.contract_outputs uses hex too.
+        // Explicit options.data_outputs wins over the ANF-resolved set.
+        var data_outputs_hex: std.ArrayListUnmanaged(types.ContractOutput) = .empty;
+        defer {
+            for (data_outputs_hex.items) |co| self.allocator.free(@constCast(co.script));
+            data_outputs_hex.deinit(self.allocator);
+        }
+        if (is_stateful) {
+            const explicit_do: ?[]const types.ContractOutput =
+                if (options) |o| o.data_outputs else null;
+            if (explicit_do) |eo| {
+                for (eo) |co| {
+                    const dup_script = try self.allocator.dupe(u8, co.script);
+                    try data_outputs_hex.append(self.allocator, .{ .script = dup_script, .satoshis = co.satoshis });
+                }
+            } else {
+                for (anf_data_outputs) |d| {
+                    const hex_buf = try self.allocator.alloc(u8, d.script.len * 2);
+                    _ = try bsvz.primitives.hex.encodeLower(d.script, hex_buf);
+                    try data_outputs_hex.append(self.allocator, .{ .script = hex_buf, .satoshis = d.satoshis });
+                }
+            }
+        }
 
         // ---------------------------------------------------------------
         // Stateless path
@@ -508,6 +541,12 @@ pub const RunarContract = struct {
         );
         defer self.allocator.free(placeholder_unlock);
 
+        const build_opts: call_mod.CallBuildOptions = .{
+            .data_outputs = data_outputs_hex.items,
+        };
+        const build_opts_ptr: ?*const call_mod.CallBuildOptions =
+            if (data_outputs_hex.items.len > 0) &build_opts else null;
+
         var call_result = call_mod.buildCallTransaction(
             self.allocator,
             contract_utxo,
@@ -517,7 +556,7 @@ pub const RunarContract = struct {
             change_address,
             additional_utxos.items,
             fee_rate,
-            null,
+            build_opts_ptr,
         ) catch return ContractError.CallFailed;
         defer call_result.deinit(self.allocator);
 
@@ -584,7 +623,7 @@ pub const RunarContract = struct {
                 change_address,
                 additional_utxos.items,
                 fee_rate,
-                null,
+                build_opts_ptr,
             ) catch {
                 self.allocator.free(first_unlock);
                 ptx_result.deinit(self.allocator);
@@ -991,14 +1030,18 @@ pub const RunarContract = struct {
     // ---------------------------------------------------------------------------
 
     /// Auto-compute state transitions from the ANF IR embedded in the artifact.
-    /// Converts StateValue arrays to/from ANFValue hashmaps for the interpreter.
+    /// Also returns any data outputs declared via `this.addDataOutput(...)` in
+    /// the method body, allocated from `self.allocator`. Caller owns both the
+    /// returned slice and each entry's `script`. Returns an empty slice if the
+    /// artifact has no ANF IR or the interpreter fails.
     fn autoComputeState(
         self: *RunarContract,
         method_name: []const u8,
         user_params: []types.ABIParam,
         resolved_args: []const types.StateValue,
-    ) !void {
-        const anf_json = self.artifact.anf_json orelse return;
+    ) ![]anf_interp.DataOutputEntry {
+        const empty: []anf_interp.DataOutputEntry = &.{};
+        const anf_json = self.artifact.anf_json orelse return empty;
 
         // Use an arena for all ANF parsing and interpretation work
         var arena = std.heap.ArenaAllocator.init(self.allocator);
@@ -1006,7 +1049,7 @@ pub const RunarContract = struct {
         const work = arena.allocator();
 
         // Parse the ANF IR from JSON
-        const anf_program = anf_interp.parseANFFromJson(work, anf_json) catch return;
+        const anf_program = anf_interp.parseANFFromJson(work, anf_json) catch return empty;
 
         // Build current state map: property name -> ANFValue
         var current_state = std.StringHashMap(anf_interp.ANFValue).init(work);
@@ -1030,14 +1073,17 @@ pub const RunarContract = struct {
             ctor_anf_args[i] = stateValueToAnf(arg);
         }
 
-        // Compute new state
-        var computed = anf_interp.computeNewState(work, &anf_program, method_name, current_state, named_args, ctor_anf_args) catch return;
-        defer computed.deinit();
+        // Compute new state AND data outputs.
+        const result = anf_interp.computeNewStateAndDataOutputs(
+            self.allocator, &anf_program, method_name, current_state, named_args, ctor_anf_args,
+        ) catch return empty;
+        var state_map = result.state;
+        defer state_map.deinit();
 
         // Apply computed state back to self.state
         for (self.artifact.state_fields, 0..) |field, i| {
             if (i < self.state.len) {
-                if (computed.get(field.name)) |anf_val| {
+                if (state_map.get(field.name)) |anf_val| {
                     // Free old state value
                     self.state[i].deinit(self.allocator);
                     // Convert ANFValue back to StateValue
@@ -1045,6 +1091,8 @@ pub const RunarContract = struct {
                 }
             }
         }
+
+        return result.data_outputs;
     }
 
     // ---------------------------------------------------------------------------

--- a/packages/runar-zig/src/sdk_types.zig
+++ b/packages/runar-zig/src/sdk_types.zig
@@ -76,6 +76,11 @@ pub const CallOptions = struct {
     satoshis: i64 = 0,
     change_address: ?[]const u8 = null,
     new_state: ?[]const StateValue = null,
+    /// Optional explicit override for data outputs emitted via
+    /// `this.addDataOutput(...)` in the method body. When null, the SDK
+    /// resolves data outputs automatically by running the ANF interpreter.
+    /// Scripts must be hex-encoded.
+    data_outputs: ?[]const ContractOutput = null,
 };
 
 /// ContractOutput describes one contract continuation output.


### PR DESCRIPTION
## Summary

Stateful methods calling `this.addDataOutput(sats, script)` compile with a continuation-hash check over `[state outputs] || [data outputs] || change`, but every SDK's `BuildCallTransaction` emitted only `[state outputs] || change`. Every contract using `addDataOutput` was unspendable — `hashOutputs` at spend time did not match the compile-time constant.

Fix across all six SDKs (TS, Go, Rust, Python, Zig, Ruby):
- ANF interpreter executes `add_data_output` instead of skipping it
- New `computeNewStateAndDataOutputs` returns both state + data outputs
- `BuildCallTransaction` takes a `DataOutputs` slice, emits them between state and change, includes them in fee estimate + change deduction
- `PrepareCall` resolves data outputs via the ANF interpreter and forwards them
- `CallOptions` gains optional `DataOutputs` for explicit override

Also fixes a pre-existing bug in `integration/go/helpers/compiler.go` `ConvertIRValue` that dropped `add_data_output` fields during the compiler-IR→SDK-ANF handoff.

## Test plan
- [x] Unit tests in `packages/runar-go/sdk_test.go` (order, fee, non-zero sats, ANF interpreter)
- [x] End-to-end `integration/go/data_outputs_test.go` — compile real contract, call via MockProvider, assert tx layout
- [x] All six SDK test suites pass (runar-go, runar-rs 362, runar-py 415, runar-zig 141, runar-rb 832, runar-sdk/testing/compiler 2459)
- [x] 41/41 sdk-output conformance — all six SDKs byte-identical on deployed locking scripts