### PR TITLE
fix(sdk/zig): switch liveHttpEnabled() off std.c.getenv to drop libc requirement

### DIFF
--- a/packages/runar-zig/src/sdk_http_client.zig
+++ b/packages/runar-zig/src/sdk_http_client.zig
@@ -275,8 +275,11 @@ pub const StdHttpTransport = struct {
 const testing = std.testing;
 
 fn liveHttpEnabled() bool {
-    const raw = std.c.getenv("RUN_LIVE_HTTP") orelse return false;
-    const v = std.mem.sliceTo(raw, 0);
+    // std.testing.environ is the test runner's pre-populated env block; it
+    // avoids a libc dependency that std.c.getenv would force the build to
+    // link. Only referenced from a test block so the testing module is
+    // always available where this is called from.
+    const v = std.testing.environ.getPosix("RUN_LIVE_HTTP") orelse return false;
     return std.mem.eql(u8, v, "1");
 }
 


### PR DESCRIPTION
## Summary

CI Zig SDK job has been failing since the Zig 0.16.0 toolchain bump because `sdk_http_client.zig` test helper `liveHttpEnabled()` calls `std.c.getenv`, which Zig 0.16 now requires explicit libc linkage for. The test build does not link libc.

Fix: switch to `std.testing.environ.getPosix(\"RUN_LIVE_HTTP\")` — the test runner pre-populates the global environ block, so the libc dependency is dropped entirely and the helper's behaviour is unchanged.

Failing run: https://github.com/icellan/runar/actions/runs/24915591751

## Test plan

- [x] \`cd packages/runar-zig && zig build test\` — 141 passed, 0 failed, 2 skipped (live HTTP tests remain skipped because RUN_LIVE_HTTP not set, matching prior behaviour)