### PR TITLE
docs(cr): Rust DSL macro reduction — change request & plan

### DIFF
--- a/docs/change-requests/2026-05-14-rust-dsl-implementation-plan.md
+++ b/docs/change-requests/2026-05-14-rust-dsl-implementation-plan.md
@@ -1,0 +1,183 @@
+# Implementation plan: Reduce Rust DSL macro decorations
+
+| Field | Value |
+|-------|-------|
+| **Parent change request** | [`2026-05-14-rust-dsl-reduce-macro-decorations.md`](./2026-05-14-rust-dsl-reduce-macro-decorations.md) |
+| **Status** | Ready to execute after **repository owner approval** on the tracking issue |
+| **Role** | Product architecture — phased delivery plan for engineering |
+
+This plan assumes the CR’s technical direction (struct macros retained; **`impl ContractName`** without **`#[methods]`**; **`pub fn`** vs **`fn`** for public vs private; **`init`** unchanged). Where the CR lists open questions, **recommended defaults** appear below — adjust if owners choose otherwise.
+
+---
+
+## Recommended decisions (defaults for implementers)
+
+| Open question | Recommended default | Rationale |
+|---------------|--------------------|-----------|
+| Migration style | **Backward compatible for at least one minor release** old spellings parsed (no semver major spike). Deprecate in rustdoc/`#[deprecated]` on stub macros where applicable. |
+| Multiple `impl ContractName {}` blocks | **Support merge in source order** (matches rustc’s split-impl ergonomics); **error on duplicate method name** with a clear diagnostic. |
+| Codemod | **Mechanical churn in-repo** via scripted replace + **`rustfmt`**; publish a short **migration** section rather than blocking on `cargo fix`. |
+| `pub(crate)` / restricted `pub` | **Defer** explicitly; parser continues current behaviour (**single bare `pub` token** ⇒ treat as Rust public keyword read path). Contract authors use **`pub fn`** for entrypoints. |
+
+---
+
+## Preconditions (gates)
+
+1. **Owner sign-off** recorded on the single tracking issue linked from the CR.
+2. Confirm **semver policy** with owners: deprecation-only on macros is typically **minor**; removing macro exports or breaking `.runar.rs` without legacy parse path would be **major**.
+
+No implementation merges before precondition 1.
+
+---
+
+## Phase 0 — Traceability & scope lock
+
+**Goal:** Freeze what “done” means and avoid churn.
+
+- [ ] Link this plan from the tracking issue alongside the CR.
+- [ ] List target paths: primary touch **`compilers/rust/src/frontend/parser_rustmacro.rs`**, **`packages/runar-rs-macros/src/lib.rs`**, **`examples/rust/**/*.runar.rs`**, conformance **`*.runar.rs`**, **`docs/formats/rust.md`**, **`packages/runar-rs/README.md`**, root **`CHANGELOG.md`**.
+- [ ] Optional but useful: add one **fixture** `.runar.rs` that uses *only* the new style (`impl Foo` without `#[methods]`, entrypoints **without** `#[public]`) for regression.
+
+**Exit:** Engineers can open one issue/PR checklist against Phases 1–6 below.
+
+---
+
+## Phase 1 — Parser: discover `impl` without `#[runar::methods]`
+
+**Goal:** Equivalent method list and `Visibility` as today after corpus migration.
+
+### 1.1 Refactor `RustDslParser::parse`
+
+- **Structural change:** Prefer a **two-pass** read over `tokens` with `pos` reset (or checkpoint), so pass (a) parses the contract **`struct`** and **properties** (`contract_name` known), pass (b) collects **every** **`impl CONTRACT_NAME`** method block in file order — including blocks currently reached only via **`#[runar::methods(...)]`** prefix.
+- **Unify** logic that walks method items (attributes, **`pub`**, **`fn`**, signature, body) into a helper so **`#[methods]` path and bare `impl`** share one implementation (**DRY**, fewer semantic divergences).
+
+### 1.2 Backward compat during deprecation window
+
+While old sources exist in the wild:
+
+- If **`#[runar::methods(T)]`** immediately precedes **`impl T`**, parse that block exactly as today (**no duplicate ingestion** once unified collection is correct).
+- For **`#[public]`:** keep accepting it and mapping to **`Public`** alongside **`pub fn`** until the corpus + docs fully drop it (avoid breaking external crates mid-minor).
+
+### 1.3 Multiple `impl` blocks
+
+- For each **`impl IDENT`** where **`IDENT == contract_name`**, append parsed methods after the prior block’s methods.
+- **Duplicate method name:** emit **`Diagnostic::error`** (do not silently overwrite).
+
+### 1.4 Diagnostics & edge cases
+
+- **`impl` before struct:** deterministic error (**“contract struct must be declared before referencing `impl NAME`”** or similar — align with rustc reality where order may still lex).
+- **`impl OtherType`:** skip (Rust allows other impls; Rúnar should ignore unrelated blocks or document “only contract impl”).
+- Preserve **`init`** extraction and synthetic **constructor** generation unchanged (already post-processes **`methods`** vector).
+
+### 1.5 Unit tests (`compilers/rust`)
+
+Add or extend tests in **`parser_rustmacro.rs`** (existing `#[cfg(test)]` module and/or **`compilers/rust/tests`**) where appropriate:
+
+- [ ] Minimal contract: **`impl Counter { pub fn … / fn … }`** with **no** **`#[methods]`**.
+- [ ] Regression: **`#[methods]`** still works; unchanged output vs bare **`impl`** (same snippet, two variants) — normalized comparison on **`ContractNode` methods**: names + visibilities + param counts (or stringify snapshot if project prefers).
+- [ ] **`#[public] fn`** private + **`#[public]` only** backward-compat path **if retained**.
+- [ ] Two **`impl Foo`** blocks, distinct methods merged in order.
+- [ ] Duplicate method name ⇒ error.
+- [ ] **`init`** + **`pub fn`** public methods interplay unchanged.
+
+**Exit:** **`cd compilers/rust && cargo test`** green.
+
+---
+
+## Phase 2 — In-repo corpus migration
+
+**Goal:** Teach maintainers dogfood the canonical style; shrink confusion in examples.
+
+Suggested order (**lowest blast radius → highest**):
+
+1. **New-style smoke fixture** under **`compilers/rust`** tests or conformance (if `.runar.rs` present there).
+2. **`examples/rust`**: mechanically remove **`#[runar::methods(…)]`** and **`#[public]`** rows where **`pub fn`** already exists; run **`cargo fmt`**; fix any **`#[path]` tests**.
+3. **Conformance**: every **`conformance/**/*.runar.rs`** or examples referenced **`source.json` — same mechanical edit **if** parity is unaffected (same IR/hex expectation).
+4. **Integration / other `*.runar.rs`** under **`integration/rust`** etc., if any.
+
+Prefer **deterministic scripted edit** (`perl`/`python`/`cargo xtask`-style inline script documented in Phase 6) + manual review for outliers.
+
+**Exit:** **`cd examples/rust && cargo test`** green; conformance + parser-only untouched for tiers not using Rust-format sources (Rust tier still green).
+
+---
+
+## Phase 3 — Proc-macros: deprecation path
+
+**Goal:** crates.io consumers see a clear glide path without surprise breaks.
+
+Files: **`packages/runar-rs-macros/src/lib.rs`**, **`packages/runar-rs/src/prelude.rs`**, crate **`Cargo.toml`** / **`CHANGELOG.md`**.
+
+- [ ] **`#[methods]`**, **`#[public]`**: add **`#[deprecated(note = "...use `pub fn` / plain `impl`...")]`** on the procedural macro stubs **if rustc allows cleanly** on `proc_macro_attribute` (verify on MSRV ~1.70); otherwise **document-only deprecation** in `//!` / `///`.
+- [ ] Crate-level **`deprecated`** lint policy: document that external users **should** migrate but old attributes remain expanded as identity shims until next major — **exact policy per owner semver call**.
+- [ ] Remove **compile-fail expectations** only if intentionally breaking (usually **defer**).
+
+**Exit:** **`cd packages/runar-rs-macros && cargo test`** (including **`trybuild`** if present).
+
+---
+
+## Phase 4 — Documentation (dual audience: repo + crates.io)
+
+**Goal:** Published README and handbook match behaviour.
+
+Concurrent edits (same PR wave or staged PR):
+
+- [ ] **`docs/formats/rust.md`**: primary syntax **`impl`** + **`pub fn`**; legacy **`#[methods]` / `#[public]`** in a **Migrating from older Rúnar Rust** subsection.
+- [ ] **`packages/runar-rs/README.md`**: rewrite **Quick start / Writing a Contract** examples; keep TOC crates.io-safe (see CR).
+- [ ] **`examples/rust/function-patterns/FunctionPatterns.runar.rs`** (or similar annotated teaching file): update pedagogical comments.
+- [ ] Optional: **`readme = "README.md"`** in **`runar-lang`**, **`runar-lang-macros`**, **`runar-compiler-rust`** `Cargo.toml` files per CR.
+
+**Exit:** Linguist / human review passes; examples copy-pasted from README compile **without** decorators.
+
+---
+
+## Phase 5 — Verification matrix (mandatory CI-equivalent checklist)
+
+Before calling the feature shipped, locally or on CI (**must match `.github/workflows/ci.yml`** intent):
+
+| Check | Command / artefact |
+|-------|---------------------|
+| Rust compiler tests | **`cd compilers/rust && cargo test`** |
+| Rust SDK + examples | **`cd packages/runar-rs && cargo test`** … **`cd examples/rust && cargo test`** |
+| Monorepo JS build + tests including cross-compiler | **`pnpm run build`** + **`pnpm run test`** |
+| Parser-only conformance | **`conformance/...`** `--parser-only` for Rust tier |
+| Multi-format conformance (fold off + fold on parity) | Conformance runner as in CI |
+
+**Regression focus:** Fixture diffs produce **byte-identical** IR/hex versus pre-change for the same nominal contract semantics.
+
+---
+
+## Phase 6 — Release notes & optional automation follow-up
+
+- [ ] **`CHANGELOG.md`**: behavioural change + deprecation with migration pointers.
+- [ ] Bump **`semver`** according to Phase 0 policy (likely **minor** if legacy parse stays).
+- [ ] **`scripts/release.sh`** / contributor docs: bullet “DSL syntax deprecation — see CHANGELOG”.
+- **Out of CR scope but recommended:** CI **`cargo publish --dry-run`** on tag (track separately).
+
+---
+
+## PR slicing suggestion (reviewable batches)
+
+| PR | Contents | Depends on |
+|----|----------|------------|
+| **PR-A** | Parser + **compilers/rust** tests only; keep **decorators fully valid** path | Approval |
+| **PR-B** | Examples + conformance **mechanical migrate** | PR-A merged |
+| **PR-C** | Macro deprecation + docs + CHANGELOG version note | PR-B merged (can partially parallel docs with PR-A if clearly marked PRE-CR) |
+
+Smaller commits inside each PR preserve bisect hygiene.
+
+---
+
+## Rollback strategy
+
+- **Parser:** revert **`parser_rustmacro.rs`** and restore corpus in one revert commit.
+- **Released crates:** semver **yank** last resort — prefer emitting deprecated macros + parser accepting old syntax (**avoid needing yanks**).
+
+---
+
+## Definition of Done
+
+- Bare **`impl CONTRACT`** without **`#[methods]`** compiles identical AST for migrated contracts as before.
+- **`pub fn`** / **`fn`** split matches **`Public` / Private** semantics; **`init`** untouched.
+- **CI-equivalent checklist** green.
+- **`docs/formats/rust.md`** + **`packages/runar-rs/README.md`** aligned; **CHANGELOG** entry.
+- **Owner approval** archived on tracking issue prior to merging **PR-A** onward.

--- a/docs/change-requests/2026-05-14-rust-dsl-implementation-plan.md
+++ b/docs/change-requests/2026-05-14-rust-dsl-implementation-plan.md
@@ -3,6 +3,7 @@
 | Field | Value |
 |-------|-------|
 | **Parent change request** | [`2026-05-14-rust-dsl-reduce-macro-decorations.md`](./2026-05-14-rust-dsl-reduce-macro-decorations.md) |
+| **Tracking issue** | [icellan/runar#37](https://github.com/icellan/runar/issues/37) |
 | **Status** | Ready to execute after **repository owner approval** on the tracking issue |
 | **Role** | Product architecture — phased delivery plan for engineering |
 

--- a/docs/change-requests/2026-05-14-rust-dsl-reduce-macro-decorations.md
+++ b/docs/change-requests/2026-05-14-rust-dsl-reduce-macro-decorations.md
@@ -1,0 +1,246 @@
+# Change Request: Reduce Rust DSL macro decorations (`#[methods]`, `#[public]`)
+
+| Field | Value |
+|-------|-------|
+| **Status** | Proposed — awaiting repository owner approval |
+| **Area** | Rust DSL (`.runar.rs`), proc-macros (`runar-rs-macros`), Rust compiler frontend (`parser_rustmacro.rs`) |
+| **Authoring context** | Product architecture review against `docs/formats/rust.md` and current compiler implementation |
+| **Implementation plan** | [`2026-05-14-rust-dsl-implementation-plan.md`](./2026-05-14-rust-dsl-implementation-plan.md) — phased engineering plan (execute after owner approval) |
+
+---
+
+## Governance and workflow
+
+### Tracking issue
+
+- Open a single **GitHub issue** titled along the lines of: *Rust DSL: remove redundant `#[methods]` / `#[public]` decorations*.
+- Paste or link **this document** (`docs/change-requests/2026-05-14-rust-dsl-reduce-macro-decorations.md`) in the issue description as the authoritative proposal.
+- The **PR that adds this document** should reference that issue (`Fixes #…` / `Refs #…` per repo convention).
+- **All subsequent implementation PRs** should reference the **same issue** so design, approval, and delivery stay traceable.
+
+### Hard blocker
+
+**Implementation work must not merge until explicitly approved by the repository owner.**
+
+This change request may be merged as documentation-only once reviewed, but coding, fixture churn, or macro/API changes remain blocked until owner sign-off is recorded on the tracking issue.
+
+---
+
+## Problem statement
+
+Rust contract authors currently apply decorations at three levels:
+
+1. **Struct**: `#[runar::contract]` or `#[runar::stateful_contract]` — required so `rustc` can strip `#[readonly]` from fields (Rust does not allow custom attribute macros on fields the way we need).
+2. **Impl block**: `#[runar::methods(ContractName)]` — must appear before `impl ContractName { … }` or the **Rúnar hand-written `.runar.rs` parser never enters the impl** (the impl is effectively skipped).
+3. **Methods**: `#[public]` on spending entry points, and in practice **`pub fn` is typically also present** so tests can call methods from sibling modules.
+
+This creates **felt redundancy** (“decorate the struct, the impl, and every public method”), documentation burden, and a mental model gap: `#[methods]` is not doing semantic lowering in the compiler (it anchors parsing); `#[public]` is largely **duplicating** Rust visibility for methods in the frontend today.
+
+Contributors repeatedly ask whether all three layers are strictly necessary — and whether ergonomics can match “normal Rust impl” (`impl Foo { pub fn … }`) while preserving the exact same AST and script outputs.
+
+---
+
+## Current behavior (facts from codebase)
+
+### Proc-macros (`packages/runar-rs-macros/src/lib.rs`)
+
+- `#[contract]` / `#[stateful_contract]`: strips `#[readonly]` from fields and emits the struct — **semantic for `rustc`**.
+- `#[methods(Name)]`: validates shape and emits the impl unchanged — effectively an **identity** macro plus argument validation for the toolchain.
+- `#[public]`: passes the method through unchanged — **identity** at macro expansion.
+
+### Frontend parser (`compilers/rust/src/frontend/parser_rustmacro.rs`)
+
+- The tokenizer/parser only collects methods when it sees an attribute that **starts with** `runar::methods`; then it parses `impl … { … }` and walks methods inside.
+- For each method it sets visibility to **`Public` if either**:
+  - the method carries a `#[public]` attribute **or**
+  - the method has Rust `pub` before `fn`.
+
+So **`#[public]` and `pub fn` duplicate the same Rúnar “spending entry” signal** today. Private helpers correspond to **`fn`** without either (or arguably without `#[public]` if authors omit `pub`).
+
+### Documentation (`docs/formats/rust.md`)
+
+- Describes struct attributes, `#[runar::methods(ContractName)]`, and `#[public]` as the normative spelling.
+- States that fields should be `pub` for ergonomic native tests — independent of method visibility rules.
+
+---
+
+## Proposal (high level)
+
+### 1. Retain struct-level macros (non-negotiable for now)
+
+Keep **`#[runar::contract]`** / **`#[runar::stateful_contract]`** on the struct. They satisfy the **`rustc`** need to strip field-level `#[readonly]` and preserve a single authoritative contract declaration.
+
+### 2. Remove the need for `#[runar::methods(ContractName)]`
+
+**Desired author experience:**
+
+```rust
+#[runar::contract]
+pub struct Counter {
+    pub count: Bigint,
+}
+
+impl Counter {
+    pub fn increment(&mut self) {
+        self.count += 1;
+    }
+
+    fn double(&mut self) {
+        self.count *= 2;
+    }
+}
+```
+
+**Semantics (unchanged from today):**
+
+- Any `impl ContractName { … }` block where `ContractName` matches the lone Rúnar contract struct in that file contributes methods to that contract AST.
+- If multiple `impl ContractName { … }` blocks appear (Rust allows this), the parser **merges methods** across them in source order unless we explicitly reject splitting (recommended open question below).
+
+Implementation direction: extend `RustDslParser` with a phase that scans for `impl` + ident matching `contract_name`, without requiring a preceding `#`/`runar::methods` sentinel. Optionally keep **`#[runar::methods(T)]` as deprecated no-op for one or more releases** (parser accepts and ignores).
+
+### 3. Drop `#[public]`; encode spending entrypoints with Rust `pub fn`
+
+**Rule:** **`pub fn`** on contract methods ⇒ Rúnar **public / spending entry**; **`fn` (no `pub`)** ⇒ **private helper** (including `init`).
+
+This preserves today’s codegen and validation pipelines because they already consume `Visibility::Public` equivalently regardless of whether it came from `#[public]` or `pub`.
+
+**Deprecation path:**
+
+- Prefer documenting `#[public]` as **obsolete** immediately after approval.
+- During migration, optionally keep parser support so old sources still compile, or automate mechanical removal (fixture + example sweep).
+
+---
+
+## Behaviour parity checklist (must remain identical post-change)
+
+The following concerns must be systematically regression-tested against **byte-identical** or **normally accepted** conformance outputs:
+
+| Concern | How we preserve it |
+|---------|---------------------|
+| **Public vs private methods** | `pub fn` vs `fn` duplicates current `Public`/`Private` split (already partially shared with `#[public]`). |
+| **`init`** | Remains **`fn init(&mut self)`** without `pub` ; still stripped and converted into property initializers. |
+| **Synthetic constructor** | Unchanged generation from struct fields minus `init` defaults — no dependency on decorators. |
+| **Stateful detection** | Still derived from `[readonly]` on fields (`#[contract]` semantics), unchanged. |
+| **Multi-public-method dispatch / artifacts** | Only method visibility/name/body AST matters; decorators are not Stack-IR artifacts. |
+| **`cargo check` / tests** | `pub` helpers remain callable from `_test.rs`/`#[path]` modules as today. |
+
+---
+
+## Edge cases / design decisions for review
+
+These should be nailed down during owner review or in a brief follow-on design comment on the tracking issue:
+
+1. **Rust restricted visibility**: `pub(crate) fn`, `pub(super) fn`, etc. The tokenizer treats `pub` as a keyword; the current parser consumes a single `pub` token before `fn`. **Today's parser likely does not support `pub(crate) fn`** on contract methods cleanly. Recommendation: formally define **`pub fn` only** as Rúnar-public; constrained `pub(..)` variants are **out of scope** or classified as helpers (`fn`) until explicitly supported.
+
+2. **Multiple contract structs**: Rúnar’s model is **one contract per `.runar.rs` file**. If detection is by name matching between struct and impl, we should **enforce** exactly one annotated contract struct before collecting impl bodies.
+
+3. **Impl ordering vs struct**: Parsing may require two passes — first locate struct + name, second collect matching `impl` blocks — or incremental state while scanning. Behaviour with `impl` before struct (illegal in practice for forward references?) should emit a precise diagnostic.
+
+4. **Macro crates**: Prefer **deprecation** (`#[deprecated]` + doc) on `methods`/`public` in `runar_lang_macros`, rather than abrupt removal, to avoid breaking external users without a semver story.
+
+---
+
+## Deliverables after approval
+
+1. **`compilers/rust`**: Parser changes + unit tests covering impl discovery without `#[methods]`.
+2. **Proc-macros / prelude**: Deprecated `methods`/`public`; `docs/formats/rust.md` + README Rust sections updated.
+3. **Mechanical churn**: conformance fixtures (`*.runar.rs`), `examples/rust`, and compiler tests relying on decorators.
+4. **Semver note**: Crate version bump rationale for `runar-lang-macros` / `runar` if public API or attributes change.
+5. **Crates.io-facing documentation** (see next section): README, `Cargo.toml` metadata, rustdoc, and changelog entries aligned with any deprecation or syntax change.
+
+---
+
+## Public crates (`crates.io`) — documentation obligations
+
+The Rust surface is published as three crates (dependency order: compiler → macros → SDK):
+
+| Crates.io name | In-repo path | Role |
+|----------------|--------------|------|
+| `runar-compiler-rust` | `compilers/rust` | CLI + library compiler |
+| `runar-lang-macros` | `packages/runar-rs-macros` | `#[contract]`, `#[methods]`, `#[public]`, … |
+| `runar-lang` | `packages/runar-rs` | SDK + prelude (often renamed to `runar` via `package = "runar-lang"` in dependents) |
+
+**Why documentation matters**
+
+- crates.io prominently renders the **crate README** and `Cargo.toml` **description**, **keywords**, **categories**, and links (**repository**, **homepage**). Consumers often never open the repo; the README is the onboarding contract.
+- The SDK README explicitly calls out [crates.io layout concerns](../../packages/runar-rs/README.md) (flat TOC, standalone reading). Any DSL ergonomics change should update **`packages/runar-rs/README.md`** (“Writing a Contract”) and **`docs/formats/rust.md`** in the **same delivery unit** so GitHub docs, book-style guides, and the published README stay coherent.
+- **Proc-macros** should carry clear **`//!` crate docs** and per-macro **`///` docs** (`packages/runar-rs-macros/src/lib.rs`): what each attribute does, deprecation timeline if applicable, and how it maps to the Rúnar compiler (not “magic” behaviour).
+- **Semantic versioning**: Treat observable changes to accepted `.runar.rs` syntax or macro stubs as potentially **minor/major** for `runar-lang-macros` and `runar-lang`, per [API Evolution / Rust semver guidance](https://doc.rust-lang.org/cargo/reference/semver.html). Document the choice in **`CHANGELOG.md`** at the workspace root alongside version bumps (**`scripts/release.sh`** / **`scripts/bump-version.sh`** flow).
+- **Optional hardening**: set `readme = "README.md"` explicitly in each crate’s **`Cargo.toml`** if not already present, so crates.io always picks up the intended file when publishing.
+
+**For this change request specifically**
+
+- Update author examples to the new minimal spelling once implemented; keep a short **“migrating from `#[methods]` / `#[public]`”** subsection in the SDK README and in `docs/formats/rust.md`.
+- If macros become deprecated no-ops, reflect that in rustdoc with `#[deprecated]` messages pointing to the new style.
+
+---
+
+## Rust testing, CI, and crates.io release mechanics
+
+### What CI already runs (GitHub Actions)
+
+Rust is **not** untested in CI — it is covered in **`.github/workflows/ci.yml`** and related workflows. At a high level:
+
+| Job / step | What it exercises |
+|------------|-------------------|
+| **`rust-compiler`** | `compilers/rust`: `cargo build --release`, **`cargo test`**. Uploads `runar-compiler-rust` binary for conformance. |
+| **`rust-sdk`** | `packages/runar-rs`: **`cargo test`**; **`examples/rust`**: **`cargo test`** (native contract + `compile_check` patterns across the example corpus). |
+| **`ts-compiler`** | Builds **`compilers/rust`** for **`pnpm run test`** cross-compiler / vitest matrices that include the Rust toolchain where required. |
+| **`conformance`** | Downloads the Rust compiler artifact; IR → hex parity vs other tiers + golden **`expected-script.hex`**; **`--parser-only`** and **`--multi-format`** runner passes (including **`*.runar.rs`** fixtures per `source.json`). |
+| **`conformance-anf-parity`** | Builds the Rust ANF driver; parity across SDK interpreters. |
+| **`sdk-conformance`** | Builds **`conformance/sdk-output/tools/rs-sdk-tool`**; verifies deploy/script outputs across SDKs including Rust. |
+| **`integration`** | **`integration/rust`**: **`cargo test --release -- --ignored`** (regtest + heavier paths), coordinated with other tiers. |
+
+Additional Rust compiler build steps appear in **`.github/workflows/cross-compiler-bytewise.yml`** where relevant.
+
+**Implication for this proposal:** parser or macro changes must keep **`compilers/rust` tests**, **`examples/rust`**, conformance **multi-format** / **parser-only**, and any **`.runar.rs`** fixtures green — that is the existing quality gate before a release.
+
+### How releases reach `crates.io` today
+
+There is **no** GitHub Actions workflow in this repository that automatically runs **`cargo publish`** on tag or `main`. Publishing is a **maintainer-driven, local script** flow:
+
+1. **`scripts/release.sh <version>`** — bumps versions (`scripts/bump-version.sh`), commits, tags (`v*`, Go module tags), pushes, then invokes **`scripts/publish-all.sh`**.
+2. **`scripts/publish-all.sh`** — after npm steps, runs **`cargo publish`** in order: **`compilers/rust`** (`runar-compiler-rust`) → **`packages/runar-rs-macros`** → **`packages/runar-rs`**, with waits between publishes for the crates.io index.
+
+**Auth**: `cargo login` (or equivalent token) must be available on the machine running the script; this is **outside** CI by design in the current tree.
+
+### How we “guarantee” behaviour end-to-end
+
+- **Pre-merge / on `main`**: GitHub Actions above provide compiler unit tests, SDK tests, example tests, multi-format conformance, fold-on parity, ANF parity, SDK output conformance, and integration tests. A red `main` should block a release in policy (even though the publish script does not itself invoke CI).
+- **At release time**: `release.sh` currently runs **`pnpm run build`** and **`cargo build --release`** for the compiler as a **local** smoke step; it does **not** substitute for the full CI matrix. **Recommendation for maintainers** (can be recorded in release docs): only run **`scripts/publish-all.sh`** after **`main`** (or the release branch) is **green** on GitHub, and consider adding a documented checklist or a future optional **`--dry-run` / `cargo publish --dry-run`** preflight in CI (out of scope for this change request unless the owner wants it).
+
+### Optional follow-up (not part of this CR unless requested)
+
+- Add a **release** or **publish** workflow that triggers on `v*` tags, runs **`cargo publish --dry-run`** (and/or **`cargo package`**) for all three crates, or gates publish on a successful workflow run — to reduce drift between “CI green” and “what actually shipped to crates.io”.
+
+---
+
+## Acceptance criteria
+
+- Author can write idiomatic **`impl ContractName`** without **`#[runar::methods(...)]`**.
+- Spending entrypoints are spelled only with **`pub fn`** ; helpers with **`fn`**.
+- Existing behaviour (artifacts, ABI, opcode dispatch patterns, stateful injections) unchanged for migrated sources.
+- **Owner approval recorded** on the tracking issue prior to merging implementation PRs.
+- **Crates.io-facing docs** (`README`, `docs/formats/rust.md`, macro rustdoc, changelog) updated in lockstep with any user-visible syntax or deprecation story.
+- **`compilers/rust` `cargo test`**, **`packages/runar-rs` / `examples/rust`**, and conformance jobs that consume **`.runar.rs`** remain passing on CI after implementation.
+
+---
+
+## Open questions for reviewers
+
+1. Preferred migration: **silent backward compatibility** (`#[methods]`/`#[public]` retained as no-ops indefinitely) versus **semver major** cleanup?
+2. Should we formally support **multiple `impl ContractName`** blocks merging into one contract?
+3. Do we require a **`cargo`-side** procedural assist (e.g. `cargo fix`/lint) or is a documented `sed`/codemod enough?
+4. Should **`cargo publish`** remain fully manual via **`scripts/publish-all.sh`**, or should the project add a **tag-gated dry-run/publish** workflow for stronger CD discipline?
+
+---
+
+## References
+
+- `docs/formats/rust.md` — user-facing Rust DSL specification.
+- `packages/runar-rs-macros/src/lib.rs` — proc-macro behaviours.
+- `compilers/rust/src/frontend/parser_rustmacro.rs` — lexical parser and visibility rules cited above (`runar::methods` gate; `#[public]` **or** `pub` ⇒ public).
+- `.github/workflows/ci.yml` — Rust compiler, Rust SDK, conformance, integration jobs.
+- `scripts/release.sh`, `scripts/publish-all.sh` — version bump + crates.io publish order for Rust crates.
+- `packages/runar-rs/README.md` — crates.io-oriented SDK documentation and installation (`runar-lang` vs `runar`).
+- `CHANGELOG.md` — historical note on crates.io releases and scripts.

--- a/docs/change-requests/2026-05-14-rust-dsl-reduce-macro-decorations.md
+++ b/docs/change-requests/2026-05-14-rust-dsl-reduce-macro-decorations.md
@@ -14,9 +14,16 @@
 ### Tracking issue
 
 - Open a single **GitHub issue** titled along the lines of: *Rust DSL: remove redundant `#[methods]` / `#[public]` decorations*.
-- Paste or link **this document** (`docs/change-requests/2026-05-14-rust-dsl-reduce-macro-decorations.md`) in the issue description as the authoritative proposal.
-- The **PR that adds this document** should reference that issue (`Fixes #…` / `Refs #…` per repo convention).
-- **All subsequent implementation PRs** should reference the **same issue** so design, approval, and delivery stay traceable.
+  - **This initiative is tracked at [issue #37](https://github.com/icellan/runar/issues/37).**
+
+### Two-phase pull requests on the **same issue**
+
+| Phase | Typical PR | Contents |
+|-------|-----------|----------|
+| **A — Documentation** | e.g. [PR #38](https://github.com/icellan/runar/pull/38) | Adds **`docs/change-requests/*.md`** only. **Refs** the issue (#37); merge + owner approval **authorizes** phase B |
+| **B — Implementation** | (future) | Parser, corpus, macros, handbook updates. **Refs** issue #37; closes issue when behaviour is landed (or splits follow-ups) |
+
+Do **not** close the tracking issue until phase B completes (unless owners agree otherwise).
 
 ### Hard blocker
 


### PR DESCRIPTION
## Summary

Adds the **change request** and **implementation plan** for Rust DSL ergonomics: optional `#[runar::methods]`, optional `#[public]`, standardise on `impl Contract` + `pub fn` vs `fn`.

## Tracking

**Refs https://github.com/icellan/runar/issues/37**

## Two-phase delivery (same issue)

- **This PR (phase A):** documentation only under `docs/change-requests/`.
- **Next PR (phase B):** parser + corpus + macros + README — implementation; will also **ref** #37.

Merge of this PR + **repository owner approval recorded on #37** clears the gate for phase B.

### Do not close issue

This PR does **not** resolve the full feature; keep #37 open until implementation lands (or owners split follow-ups).
