### PR TITLE
runar-rs: add `CallOptions.locktime` to enable deadline-based contracts

### DIFF
--- a/packages/runar-rs/src/sdk/calling.rs
+++ b/packages/runar-rs/src/sdk/calling.rs
@@ -24,6 +24,10 @@ pub struct CallTxOptions {
     pub contract_outputs: Option<Vec<ContractOutput>>,
     /// Additional contract inputs with their own unlocking scripts (for merge).
     pub additional_contract_inputs: Option<Vec<AdditionalContractInput>>,
+    /// Override the call tx's nLockTime. `None` → defaults to `0` (legacy).
+    /// `Some(N)` writes `N` as little-endian `u32` in the locktime field.
+    /// Required for contracts that assert `extractLocktime(preimage) >= deadline`.
+    pub locktime: Option<u32>,
 }
 
 /// Build a raw transaction that spends a contract UTXO (method call).
@@ -191,8 +195,13 @@ pub fn build_call_transaction_ext(
         tx.push_str(&actual_change_script);
     }
 
-    // Locktime
-    tx.push_str(&to_little_endian_32(0));
+    // Locktime: default `0` (legacy behavior); overridable via
+    // `CallTxOptions.locktime`. Contracts asserting
+    // `extractLocktime(preimage) >= deadline` (e.g. auction `close`/`claim`)
+    // require this override; the previously hardcoded `0` caused NULLFAIL
+    // on every terminal call with a non-zero deadline.
+    let locktime_value = options.and_then(|o| o.locktime).unwrap_or(0);
+    tx.push_str(&to_little_endian_32(locktime_value));
 
     let change_amount = if change > 0 { change } else { 0 };
     (tx, all_utxos.len(), change_amount)

--- a/packages/runar-rs/src/sdk/contract.rs
+++ b/packages/runar-rs/src/sdk/contract.rs
@@ -618,6 +618,10 @@ impl RunarContract {
                     }
                 }).collect())
             },
+            // Thread `CallOptions.locktime` through to the tx builder so contracts
+            // asserting `extractLocktime(preimage)` can succeed. Default `None` → `0`
+            // (legacy behavior preserved).
+            locktime: options.and_then(|o| o.locktime),
         };
 
         let (tx_hex, input_count, mut change_amount) = build_call_transaction_ext(
@@ -768,6 +772,10 @@ impl RunarContract {
                         }
                     }).collect())
                 },
+                // Rebuild path must also honor the override: a preimage computed
+                // on a rebuilt tx with `locktime = 0` would mismatch what
+                // `extractLocktime` sees in the final on-chain tx.
+                locktime: options.and_then(|o| o.locktime),
             };
 
             let (rebuilt_tx, _, rebuilt_change) = build_call_transaction_ext(
@@ -1014,7 +1022,7 @@ impl RunarContract {
         method_name: &str,
         resolved_args: &mut Vec<SdkValue>,
         _signer: &dyn Signer,
-        _options: Option<&CallOptions>,
+        options: Option<&CallOptions>,
         terminal_outputs: &[TerminalOutput],
         current_utxo: &Utxo,
         is_stateful: bool,
@@ -1027,6 +1035,13 @@ impl RunarContract {
         change_pkh_hex: &str,
     ) -> Result<PreparedCall, String> {
         let term_code_sep_idx = self.get_code_sep_index(self.find_method_index(method_name));
+
+        // Terminal calls (auction `close`, `claim`, `withdraw`) typically assert
+        // `extractLocktime(preimage) >= deadline`. Without an override the SDK
+        // previously hardcoded `0` → every such call NULLFAILed. Default `None`
+        // preserves existing terminal-call behavior for contracts that don't
+        // check locktime.
+        let terminal_locktime = options.and_then(|o| o.locktime).unwrap_or(0);
 
         // Build placeholder unlocking script
         // Terminal never needs code part (needsCodePart = false)
@@ -1056,7 +1071,7 @@ impl RunarContract {
                 tx.push_str(&encode_varint((out.script_hex.len() / 2) as u64));
                 tx.push_str(&out.script_hex);
             }
-            tx.push_str(&to_little_endian_32(0)); // locktime
+            tx.push_str(&to_little_endian_32(terminal_locktime)); // locktime
             tx
         };
 

--- a/packages/runar-rs/src/sdk/types.rs
+++ b/packages/runar-rs/src/sdk/types.rs
@@ -86,6 +86,13 @@ pub struct CallOptions {
     /// The fee comes from the contract balance. The contract is considered
     /// fully spent after this call (currentUtxo becomes None).
     pub terminal_outputs: Option<Vec<TerminalOutput>>,
+    /// Override the call tx's nLockTime field. Defaults to `None` → SDK uses
+    /// `0` (legacy behavior, preserves existing contracts). Set to `Some(height)`
+    /// for contracts that assert `extractLocktime(preimage) >= deadline`
+    /// (e.g., auction `close`/`claim` methods). Threaded through to both the
+    /// non-terminal (`build_call_transaction_ext`) and terminal call-tx
+    /// build sites.
+    pub locktime: Option<u32>,
 }
 
 /// Specification for an exact output in a terminal method call.


### PR DESCRIPTION
Fixes #40.

## Summary

Adds an optional `locktime: Option<u32>` field to `CallOptions` (and the lower-level `CallTxOptions`) in `packages/runar-rs/`. Defaults to `None`. When set, the SDK uses the provided value as the call transaction's `nLockTime`; when unset, the SDK falls back to the legacy hardcoded `0`.

Unblocks contracts that assert against `extractLocktime(txPreimage)` (deadline-based auctions, escrow timeouts, vesting releases, etc.).

## Changes

- `packages/runar-rs/src/sdk/types.rs` — add `locktime: Option<u32>` field to `CallOptions`
- `packages/runar-rs/src/sdk/calling.rs` — add matching field to `CallTxOptions` + read `options.and_then(|o| o.locktime).unwrap_or(0)` at the non-terminal call-tx build site
- `packages/runar-rs/src/sdk/contract.rs` — thread `CallOptions.locktime` through to both invocations of `build_call_transaction_ext` (initial build + rebuild path) and into the terminal-path's `build_terminal_tx` closure

## Backwards compatibility

Purely additive. Existing callers that don't set `locktime` see byte-identical output. All 307 lib tests in `packages/runar-rs/` pass unchanged.

**Minor API note**: callers that construct `CallOptions` field-by-field without `..Default::default()` will see a missing-field compile error. Suggest documenting in the changelog. Happy to add `#[non_exhaustive]` if maintainers prefer (itself a breaking change but future-proofs the struct).

## Test plan

- [x] `cargo test --release --lib` in `packages/runar-rs/` — 307/307 passes
- [x] `cargo check` clean

A regression test suite covering default + override behavior is in flight as a follow-up commit if helpful — happy to include in this PR or land separately.

## Mainnet validation

The same patch (vendored locally against the same code paths) has been validated end-to-end on BSV mainnet. A test EnglishAuction was deployed and bid/closed using a non-zero deadline:

- **Bid** (state-continuing — regression evidence): [`09814d16…6244c`](https://whatsonchain.com/tx/09814d1666d7ff14aaf6f1110c7654b6a4a5c6f287a25680ba8dd9a7c266244c) block 949122
- **Close** (terminal, deadline-asserting — primary evidence): [`779ea679…3606`](https://whatsonchain.com/tx/779ea67979d38deeefffa8e734125e701572582996fc51fa7bb66646f6073606) block 949222

Without the `locktime` override, the close transaction is rejected with `Script evaluated without error but finished with a false/empty top stack element` (the script's deadline assertion failing). With this PR, the same transaction mines.

## Open design question

Should the default be the current chain tip rather than `0`? `0` preserves legacy behavior (back-compat safe). Chain-tip default would be more "useful out of the box" but is a behavior change. Happy to discuss in review.

## Related

This is the first of three fixes that together enable auction-style terminal-method contracts to mine on mainnet:

1. **This PR** — `nLockTime` override (deadline-assertion preconditions)
2. Companion issue/PR — terminal-method sighash subscript trim (BIP-143 compliance)
3. Companion issue/PR — compiler stack-cleanup gate (cross-compiler, see issue for scope)

Issues 2 and 3 will follow with their own PRs.
