### PR TITLE
runar-rs: fix BIP-143 sighash subscript trim for terminal methods

### DIFF
--- a/packages/runar-rs/src/sdk/contract.rs
+++ b/packages/runar-rs/src/sdk/contract.rs
@@ -314,10 +314,16 @@ impl RunarContract {
         let mut signatures = HashMap::new();
         let contract_utxo = prepared.contract_utxo.clone();
         for &idx in &prepared.sig_indices {
-            // Stateful: user checkSig is AFTER OP_CODESEPARATOR — trim subscript.
-            // Stateless: user checkSig is BEFORE — use full script.
+            // Per BIP-143 / BSV consensus: if the script contains an
+            // OP_CODESEPARATOR before the OP_CHECKSIG, the sighash is computed
+            // over the subscript AFTER that separator — regardless of whether
+            // the contract has state fields. Trimming was previously gated on
+            // `is_stateful`, which produced wrong sighashes for terminal methods
+            // (e.g. `Auction.close`) whose `is_stateful` flag was false on the
+            // call path despite the locking script containing an
+            // OP_CODESEPARATOR — failing with NULLFAIL on mainnet.
             let mut subscript = contract_utxo.script.clone();
-            if prepared.is_stateful && prepared.code_sep_idx >= 0 {
+            if prepared.code_sep_idx >= 0 {
                 let trim_pos = ((prepared.code_sep_idx as usize) + 1) * 2;
                 if trim_pos <= subscript.len() {
                     subscript = subscript[trim_pos..].to_string();
@@ -1416,8 +1422,37 @@ impl RunarContract {
         }
     }
 
-    /// Get the adjusted code separator index for a method.
+    /// Get the byte offset of an `OP_CODESEPARATOR` for a given method index.
+    ///
+    /// When `code_script` is set (i.e., the contract is loaded from chain, OR
+    /// the deploy script has already been built from real constructor args),
+    /// we walk the actual script and return the true on-chain byte position.
+    /// This is required because `from_txid` populates `constructor_args` with
+    /// dummy `SdkValue::Int(0)` placeholders — the real arg bytes are already
+    /// baked into the on-chain locking script — so `adjust_code_sep_offset()`
+    /// computes a shift of zero and returns the wrong offset whenever the
+    /// `OP_CODESEPARATOR` sits after constructor slots that expand at deploy
+    /// time (e.g. PubKey args = 1 → 34 bytes). The symptom of using the wrong
+    /// offset is NULLFAIL at `OP_CHECKSIG` for terminal methods.
+    ///
+    /// Falls back to the legacy template-adjusted offset for synthetic /
+    /// unit-test paths that have no `code_script` available.
     fn get_code_sep_index(&self, method_index: usize) -> i64 {
+        if let Some(ref code_script) = self.code_script {
+            if let Some(ref indices) = self.artifact.code_separator_indices {
+                let real_offsets = find_codesep_offsets(code_script);
+                if method_index < indices.len() && method_index < real_offsets.len() {
+                    return real_offsets[method_index] as i64;
+                }
+            }
+            if self.artifact.code_separator_index.is_some() {
+                let real_offsets = find_codesep_offsets(code_script);
+                if let Some(&off) = real_offsets.first() {
+                    return off as i64;
+                }
+            }
+        }
+
         if let Some(ref indices) = self.artifact.code_separator_indices {
             if method_index < indices.len() {
                 return self.adjust_code_sep_offset(indices[method_index]) as i64;
@@ -1455,6 +1490,51 @@ impl RunarContract {
 // ---------------------------------------------------------------------------
 // Encoding helpers
 // ---------------------------------------------------------------------------
+
+/// Walk a hex-encoded script and return the byte offsets of every
+/// `OP_CODESEPARATOR` (`0xab`) that sits at a real opcode boundary
+/// (i.e., not inside push-data).
+///
+/// Used by `get_code_sep_index` to recover the true on-chain byte offsets
+/// when the in-memory constructor args don't reflect what was actually
+/// baked into the locking script (e.g. after `from_txid` populates dummy
+/// `Int(0)` placeholders).
+fn find_codesep_offsets(script_hex: &str) -> Vec<usize> {
+    let mut out = Vec::new();
+    let mut off = 0usize;
+    let len = script_hex.len();
+    while off + 2 <= len {
+        let op = u8::from_str_radix(&script_hex[off..off + 2], 16).unwrap_or(0);
+        let byte_pos = off / 2;
+        if op == 0xab {
+            out.push(byte_pos);
+            off += 2;
+        } else if (0x01..=0x4b).contains(&op) {
+            off += 2 + (op as usize) * 2;
+        } else if op == 0x4c {
+            if off + 4 > len { break; }
+            let push_len = u8::from_str_radix(&script_hex[off + 2..off + 4], 16).unwrap_or(0) as usize;
+            off += 4 + push_len * 2;
+        } else if op == 0x4d {
+            if off + 6 > len { break; }
+            let lo = u8::from_str_radix(&script_hex[off + 2..off + 4], 16).unwrap_or(0) as usize;
+            let hi = u8::from_str_radix(&script_hex[off + 4..off + 6], 16).unwrap_or(0) as usize;
+            let push_len = lo | (hi << 8);
+            off += 6 + push_len * 2;
+        } else if op == 0x4e {
+            if off + 10 > len { break; }
+            let b0 = u8::from_str_radix(&script_hex[off + 2..off + 4], 16).unwrap_or(0) as usize;
+            let b1 = u8::from_str_radix(&script_hex[off + 4..off + 6], 16).unwrap_or(0) as usize;
+            let b2 = u8::from_str_radix(&script_hex[off + 6..off + 8], 16).unwrap_or(0) as usize;
+            let b3 = u8::from_str_radix(&script_hex[off + 8..off + 10], 16).unwrap_or(0) as usize;
+            let push_len = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+            off += 10 + push_len * 2;
+        } else {
+            off += 2;
+        }
+    }
+    out
+}
 
 /// Extract all input outpoints from a raw tx hex as a concatenated hex string.
 /// Each outpoint is txid (32 bytes LE) + vout (4 bytes LE) = 36 bytes.


### PR DESCRIPTION
Fixes #42.

## Summary

Two-part fix to `packages/runar-rs/src/sdk/contract.rs`:

1. **Drop the over-narrow `is_stateful` gate on the user-sig subscript trim.** Per BIP-143 / BSV consensus, when a script contains an `OP_CODESEPARATOR` before an `OP_CHECKSIG`, the sighash is computed over the subscript AFTER that separator — independent of whether the contract has state fields. The previous condition produced wrong sighashes (NULLFAIL on mainnet) for terminal methods on `StatefulSmartContract` subclasses.

2. **Replace `get_code_sep_index`'s template-adjusted offset with a script-walking helper `find_codesep_offsets`** when `code_script` is set. `from_txid` populates `constructor_args` with dummy `SdkValue::Int(0)` placeholders (the real arg bytes are already baked into the on-chain locking script), so `adjust_code_sep_offset()` computes a shift of zero and returns the wrong offset whenever the `OP_CODESEPARATOR` sits after constructor slots that expand at deploy time (e.g. `PubKey` args 1 byte → 34 bytes). The new helper walks the actual script byte-by-byte for the true on-chain offsets.

## Why this is correct

The BSV consensus rule is that any `OP_CODESEPARATOR` in the script before the `OP_CHECKSIG` resets `scriptCode` — regardless of whether the script involves state-mutation tooling. The previous condition was over-narrow.

State-mutating methods (`bid()`-style) produce byte-identical sighashes (their `is_stateful` branch was already true → the trim already ran). Only terminal methods (`close()`-style) get the new — and now-correct — behavior. For stateless `SmartContract` subclasses with no `OP_CODESEPARATOR`, `code_sep_idx < 0` so the trim doesn't run — identical to pre-patch behavior.

The script-walking helper correctly handles all BSV push opcodes (`0x01..0x4b`, `OP_PUSHDATA1`, `OP_PUSHDATA2`, `OP_PUSHDATA4`). Falls back to the legacy template-adjusted offset for synthetic / unit-test paths that have no `code_script` available.

## Changes

- `packages/runar-rs/src/sdk/contract.rs`:
  - Subscript-trim conditional (drop `is_stateful` term — the BIP-143-correct condition is `code_sep_idx >= 0` alone)
  - `get_code_sep_index` now prefers the script-walking helper when `code_script` is set
  - New `find_codesep_offsets` helper in the "Encoding helpers" section

No API surface change.

## Backwards compatibility

- State-mutating methods produce byte-identical sighashes
- Stateless `SmartContract` subclasses with no `OP_CODESEPARATOR` see no behavior change
- All 307 lib tests in `packages/runar-rs/` pass unchanged

## Mainnet validation

A test EnglishAuction was deployed, bid, and closed on BSV mainnet using the patched SDK:

- **Deploy**: [`2d4532e5…2815e6`](https://whatsonchain.com/tx/2d4532e575622511d2d0eaca411aab1ae96748947ec1d495ae07109aac2815e6) block 949121
- **Bid** (state-continuing — regression evidence; sighash unchanged): [`09814d16…6244c`](https://whatsonchain.com/tx/09814d1666d7ff14aaf6f1110c7654b6a4a5c6f287a25680ba8dd9a7c266244c) block 949122
- **Close** (terminal — primary evidence): [`779ea679…3606`](https://whatsonchain.com/tx/779ea67979d38deeefffa8e734125e701572582996fc51fa7bb66646f6073606) block 949222

Without this fix, the close transaction is rejected by every ARC broadcaster with `arc error 461 — Signature must be zero for failed CHECK(MULTI)SIG operation` (NULLFAIL). With this fix, the same transaction mines.

## Test plan

- [x] `cargo test --release --lib` in `packages/runar-rs/` — 307/307 passes
- [x] `cargo check` clean
- [x] Mainnet broadcast + WoC verification (above)

## Depends on / related

This fix targets the same root issue as #40 / #41 (deadline-based terminal methods). Without the locktime override from #41, the on-chain `extractLocktime >= deadline` assertion fails before CHECKSIG ever runs — so the locktime fix is a precondition for exercising this code path on a non-zero-deadline contract. The two PRs are otherwise independent and can land in either order.

This is the second of three fixes that together enable auction-style terminal-method contracts to mine on mainnet:

1. #41 — `nLockTime` override
2. **This PR** — terminal-method sighash subscript trim
3. Companion issue + draft PR — compiler stack-cleanup gate (cross-compiler scope, follows)
