### PR TITLE
runar-compiler: run `cleanupExcessStack` for all public methods (TS source — cross-compiler scope, draft)

### DIFF
--- a/packages/runar-compiler/src/passes/05-stack-lower.ts
+++ b/packages/runar-compiler/src/passes/05-stack-lower.ts
@@ -4411,10 +4411,21 @@ function lowerMethod(
   // its value on the stack (Bitcoin Script requires a truthy top-of-stack).
   ctx.lowerBindings(method.body, method.isPublic);
 
-  // Clean up excess stack items left by deserialize_state.
-  // Only needed for stateful methods that deserialize state from the preimage.
-  const hasDeserializeState = method.body.some(b => b.value.kind === 'deserialize_state');
-  if (method.isPublic && hasDeserializeState) {
+  // Clean up excess stack items below the top-of-stack boolean.
+  //
+  // Bitcoin Script's CLEANSTACK rule requires exactly one item on the stack
+  // at end-of-script. Excess items can come from `deserialize_state` (stateful
+  // methods reading mutable fields), from readonly-field-binding patterns in
+  // the method body (force-embedding readonly fields by referencing them),
+  // or from any other mid-method binding whose value isn't consumed by an
+  // assert. The previous gate of `hasDeserializeState` missed the readonly-
+  // only path, causing all-readonly terminal methods to emit a script that
+  // failed CLEANSTACK on mainnet — "Script did not clean its stack".
+  //
+  // `cleanupExcessStack()` is idempotent (no-op when `stackMap.depth === 1`),
+  // so running it unconditionally for public methods is safe — it adds
+  // appropriate `OP_NIP` opcodes only when the stack genuinely needs cleanup.
+  if (method.isPublic) {
     ctx.cleanupExcessStack();
   }
 


### PR DESCRIPTION
> ### Scoped fix — read before reviewing
>
> This PR fixes the issue in the **TypeScript compiler source only** (`packages/runar-compiler/src/passes/05-stack-lower.ts`). Per the project's "six compilers must stay in sync" rule documented in `CLAUDE.md`, the same gate exists in all of TS, Go, Rust, Python, Zig, and Ruby compilers. **The cross-compiler conformance suite will fail until equivalent fixes land in the other five compilers.**
>
> Opening as a **draft / partial fix** to start the conversation. The TS compiler is the one I exercise; I've validated the resulting bytecode end-to-end on BSV mainnet through that path. I'm happy to:
>
> - Extend to the Go and Rust compilers myself (similar codegen shape, I can match the pattern)
> - Leave Python/Zig/Ruby for a maintainer or contributor more familiar with those stacks
> - Close this PR if you'd prefer to handle the multi-compiler coordination as a single atomic change internally
>
> Either way, the bug + diagnostic in #44 stands.

Fixes #44 (partial — TS compiler only).

## Summary

Removes the `hasDeserializeState` term from the gate around `cleanupExcessStack()` so it runs for every public method. The helper is idempotent — it has an inner `if (this.stackMap.depth > 1)` guard at `packages/runar-compiler/src/passes/05-stack-lower.ts:352` that makes it a no-op when the stack is already balanced — so dropping the outer gate is safe and only changes the bytecode for contracts whose stack actually has excess items.

Closes the CLEANSTACK consensus-rule violation for `StatefulSmartContract` subclasses with zero mutable fields plus a readonly-field-binding pattern in their method bodies. See #44 for the full diagnostic.

## Changes

- `packages/runar-compiler/src/passes/05-stack-lower.ts` — drop the `hasDeserializeState` term from the gate at `:4417`

No API surface change. No new functions or types.

## Multi-compiler coordination — TODO before merge

Per `CLAUDE.md`'s cross-compiler conformance rule, this PR cannot land alone. The same change is needed in:

- [x] `packages/runar-compiler/src/passes/05-stack-lower.ts` (this PR — TS source)
- [ ] `compilers/go/codegen/stack.go` — folds depth check into call-site, so drop only the `hasDeserializeState` term and KEEP the `depth > 1` term, otherwise cleanup would add `OP_NIP`s to already-clean methods
- [ ] `compilers/rust/src/codegen/stack.rs` — same shape as Go
- [ ] `compilers/python/runar_compiler/codegen/stack.py`
- [ ] `compilers/zig/src/codegen/stack.zig`
- [ ] `compilers/ruby/lib/codegen/stack.rb`

Plus a conformance-suite re-pin after all six land.

## Backwards compatibility (TS compiler)

Empirical verification — recompiling every example contract in `examples/{ts,rust,go,python,zig,ruby}/`:

| Pattern | Examples | Bytecode after patch |
|---|---|---|
| `StatefulSmartContract` + ≥1 mutable field | Auction, Counter, MathDemo, MessageBoard, BoundedCounter, StateCovenant, TicTacToe, FungibleToken, NFTExample, FunctionPatterns | Byte-identical |
| `SmartContract` (stateless) | P2PKH, Escrow, OraclePriceFeed, CovenantVault, ECDemo, SchnorrZKP, ConvergenceProof, SHA-256 variants, MerkleProof, SPHINCSWallet, PostQuantumWallet, P2Blake3PKH | Byte-identical |
| `StatefulSmartContract` + 0 mutable + readonly-binding | (none in example corpus) | Would gain appropriate `OP_NIP` opcodes — currently broken on mainnet; this is the fix |

All 25+ example artifacts produce byte-identical hashes before and after the patch.

## Test plan

- [x] Diff stays clean across the existing example corpus (byte-identical artifacts)
- [x] Mainnet validation: an all-readonly stateful contract with a terminal `claim()` method, compiled with the patched compiler, deploys and is claimed on BSV mainnet:
  - **Deploy**: [`3ea48c3e…12f9`](https://whatsonchain.com/tx/3ea48c3e434c84ae5206fd3fe22303d8d60821d8914feed9d6e83010dca312f9) block 949228
  - **Claim**: [`580c5c0e…de71`](https://whatsonchain.com/tx/580c5c0e56c9edea4e94954eda900bb33e7d607c345da1da10e747126a29de71) block 949230
  - Without the patch, the claim is rejected with `Script did not clean its stack`
- [ ] Cross-compiler conformance — will fail until other 5 compilers receive equivalent fixes (acknowledged in the scoped-fix banner above)

## Suggested follow-up

Add a minimal regression test to the conformance suite: a contract with the pattern `class T extends StatefulSmartContract { readonly a: bigint; ...; public m(sig: Sig) { let _bind = this.a; assert(checkSig(sig, ...)); } }`. This proves stack-cleanup runs for the all-readonly + readonly-binding case across all six compilers, and prevents the gate from accidentally being reintroduced.

## Related

This is the third of three fixes that together enable auction-style terminal-method contracts to mine on BSV mainnet:

1. #41 — `nLockTime` override (`CallOptions.locktime`)
2. #43 — terminal-method sighash subscript trim (BIP-143 compliance)
3. **This PR (draft)** — compiler stack-cleanup gate (cross-compiler issue)

Each PR is independent and can land on its own merits.

## Minimal repro (also in linked issue)

The fix unblocks the contract shape `extends StatefulSmartContract` + 0 mutable fields + readonly-binding pattern. See #44 for a self-contained reproduction contract and a discussion of why alternative patterns (switching to `SmartContract`, dropping the binding workaround, inlining identity fields into assertions) don't fully address the underlying compiler edge case.
