### PR TITLE
fix: issue #40 — CallOptions.locktime across all 7 SDKs

### DIFF
--- a/packages/runar-go/sdk_calling.go
+++ b/packages/runar-go/sdk_calling.go
@@ -19,6 +19,11 @@ type BuildCallOptions struct {
 	// declaration order — matching the order the compiler's auto-injected
 	// continuation-hash check expects.
 	DataOutputs []ContractOutput
+	// Locktime overrides the call tx's nLockTime. nil → defaults to 0 (legacy).
+	// Non-nil writes the value into the locktime field. Required for contracts
+	// that assert extractLocktime(preimage) >= deadline (e.g. auction
+	// close/claim).
+	Locktime *uint32
 }
 
 // ContractOutput describes one contract continuation output.
@@ -62,10 +67,14 @@ func BuildCallTransaction(
 	var extraContractInputs []AdditionalContractInput
 	var contractOutputs []ContractOutput
 	var dataOutputs []ContractOutput
+	var locktime uint32
 	if len(opts) > 0 && opts[0] != nil {
 		extraContractInputs = opts[0].AdditionalContractInputs
 		contractOutputs = opts[0].ContractOutputs
 		dataOutputs = opts[0].DataOutputs
+		if opts[0].Locktime != nil {
+			locktime = *opts[0].Locktime
+		}
 	}
 
 	// Build full input list: primary contract, extra contract inputs, P2PKH funding
@@ -130,6 +139,10 @@ func BuildCallTransaction(
 
 	// Build Transaction object
 	tx = transaction.NewTransaction()
+
+	// Locktime: default 0 (legacy); overridable via BuildCallOptions.Locktime
+	// for contracts asserting extractLocktime(preimage) >= deadline.
+	tx.LockTime = locktime
 
 	// Input 0: primary contract UTXO with unlocking script
 	unlockLS, _ := sdkscript.NewFromHex(unlockingScript)

--- a/packages/runar-go/sdk_contract.go
+++ b/packages/runar-go/sdk_contract.go
@@ -760,6 +760,11 @@ func (c *RunarContract) PrepareCall(
 	if len(resolvedDataOutputs) > 0 {
 		buildOpts.DataOutputs = resolvedDataOutputs
 	}
+	// Thread CallOptions.Locktime through so contracts asserting
+	// extractLocktime(preimage) can succeed. nil → 0 (legacy behavior).
+	if options != nil {
+		buildOpts.Locktime = options.Locktime
+	}
 	if len(extraContractUtxos) > 0 {
 		buildOpts.AdditionalContractInputs = make([]AdditionalContractInput, len(extraContractUtxos))
 		for i, utxo := range extraContractUtxos {
@@ -901,6 +906,11 @@ func (c *RunarContract) PrepareCall(
 		}
 		if len(resolvedDataOutputs) > 0 {
 			rebuildOpts.DataOutputs = resolvedDataOutputs
+		}
+		// Rebuild path must honor the override too: a preimage computed on a
+		// rebuilt tx with locktime 0 would mismatch the final on-chain tx.
+		if options != nil {
+			rebuildOpts.Locktime = options.Locktime
 		}
 		if len(extraContractUtxos) > 0 {
 			rebuildOpts.AdditionalContractInputs = make([]AdditionalContractInput, len(extraContractUtxos))
@@ -1661,9 +1671,18 @@ func (c *RunarContract) prepareCallTerminal(
 	}
 	termUnlockScript += witnessHex
 
+	// Terminal calls (auction close/claim/withdraw) typically assert
+	// extractLocktime(preimage) >= deadline. Default 0 preserves legacy
+	// behavior for contracts that don't check locktime.
+	var terminalLocktime uint32
+	if options.Locktime != nil {
+		terminalLocktime = *options.Locktime
+	}
+
 	// Build terminal transaction using go-sdk Transaction
 	buildTerminalTx := func(unlock string) *transaction.Transaction {
 		ttx := transaction.NewTransaction()
+		ttx.LockTime = terminalLocktime
 		unlockLS, _ := sdkscript.NewFromHex(unlock)
 		ttx.AddInput(&transaction.TransactionInput{
 			SourceTXID:       txidToChainHash(contractUtxo.Txid),

--- a/packages/runar-go/sdk_test.go
+++ b/packages/runar-go/sdk_test.go
@@ -1017,6 +1017,28 @@ func TestBuildCallTransaction_BasicStructure(t *testing.T) {
 	}
 }
 
+func TestBuildCallTransaction_LocktimeOverride(t *testing.T) {
+	// Issue #40: a caller-supplied non-zero locktime must appear in the
+	// built call tx's nLockTime field.
+	utxo := makeUtxo(100000, 0)
+	lt := uint32(800000)
+	callTxObj, _, _ := BuildCallTransaction(utxo, "51", "", 0, "", "", nil, 100, &BuildCallOptions{Locktime: &lt})
+	parsed := parseTxHex(callTxObj.Hex())
+	if parsed.locktime != 800000 {
+		t.Errorf("expected locktime 800000, got %d", parsed.locktime)
+	}
+}
+
+func TestBuildCallTransaction_LocktimeDefaultZero(t *testing.T) {
+	// Default (unset) must still write 0 — back-compatible.
+	utxo := makeUtxo(100000, 0)
+	callTxObj, _, _ := BuildCallTransaction(utxo, "51", "", 0, "", "", nil, 100, &BuildCallOptions{})
+	parsed := parseTxHex(callTxObj.Hex())
+	if parsed.locktime != 0 {
+		t.Errorf("expected locktime 0, got %d", parsed.locktime)
+	}
+}
+
 func TestBuildCallTransaction_UnlockingScriptInInput0(t *testing.T) {
 	utxo := makeUtxo(100000, 0)
 	callTxObj, _, _ := BuildCallTransaction(utxo, "aabb", "", 0, "", "", nil, 100)

--- a/packages/runar-go/sdk_types.go
+++ b/packages/runar-go/sdk_types.go
@@ -103,6 +103,12 @@ type CallOptions struct {
 	// knows the exact (satoshis, script) pairs and does not want the SDK
 	// to re-derive them from method arguments.
 	DataOutputs []ContractOutput `json:"dataOutputs,omitempty"`
+
+	// Locktime overrides the call tx's nLockTime field. nil → SDK uses 0
+	// (legacy behavior, preserves existing contracts). Set for contracts that
+	// assert extractLocktime(preimage) >= deadline (e.g. auction close/claim).
+	// Threaded through both the non-terminal and terminal call-tx build sites.
+	Locktime *uint32 `json:"locktime,omitempty"`
 }
 
 // TerminalOutput specifies an exact output for a terminal method call.

--- a/packages/runar-java/src/main/java/runar/lang/sdk/CallOptions.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/CallOptions.java
@@ -46,14 +46,33 @@ public final class CallOptions {
      */
     public final List<UTXO> fundingUtxos;
 
+    /**
+     * Override the call tx's nLockTime field. {@code null} → SDK uses 0
+     * (legacy behavior, preserves existing contracts). Set for contracts
+     * that assert {@code extractLocktime(preimage) >= deadline} (e.g.
+     * auction {@code close}/{@code claim} methods). Threaded through both
+     * the non-terminal and terminal call-tx build sites.
+     */
+    public final Integer locktime;
+
     public CallOptions(
         Map<String, Object> newState,
         List<TerminalOutput> terminalOutputs,
         List<UTXO> fundingUtxos
     ) {
+        this(newState, terminalOutputs, fundingUtxos, null);
+    }
+
+    public CallOptions(
+        Map<String, Object> newState,
+        List<TerminalOutput> terminalOutputs,
+        List<UTXO> fundingUtxos,
+        Integer locktime
+    ) {
         this.newState = newState;
         this.terminalOutputs = terminalOutputs;
         this.fundingUtxos = fundingUtxos;
+        this.locktime = locktime;
     }
 
     /** Convenience factory for the common terminal-call case. */

--- a/packages/runar-java/src/main/java/runar/lang/sdk/RunarContract.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/RunarContract.java
@@ -415,10 +415,13 @@ public final class RunarContract {
         // legacy paths and routes to the dedicated terminal builder.
         // ------------------------------------------------------------
         if (terminalOutputs != null) {
+            int terminalLocktime = (options != null && options.locktime != null)
+                ? options.locktime : 0;
             return callTerminal(
                 m, methodName, resolved, sigIndices,
                 methodNeedsChange, methodNeedsNewAmount,
-                isStateful, terminalOutputs, fundingUtxos, provider, signer
+                isStateful, terminalOutputs, fundingUtxos, provider, signer,
+                terminalLocktime
             );
         }
 
@@ -434,10 +437,12 @@ public final class RunarContract {
         // funding inputs, OP_PUSH_TX prefix, preimage push, method
         // selector.
         // ------------------------------------------------------------
+        int pushTxLocktime = (options != null && options.locktime != null)
+            ? options.locktime : 0;
         return callWithPushTx(
             m, methodName, resolved, sigIndices,
             methodNeedsChange, methodNeedsNewAmount,
-            isStateful, resolvedDataOutputs, provider, signer
+            isStateful, resolvedDataOutputs, provider, signer, pushTxLocktime
         );
     }
 
@@ -500,7 +505,8 @@ public final class RunarContract {
         boolean isStateful,
         List<TransactionBuilder.DataOutput> dataOutputs,
         Provider provider,
-        Signer signer
+        Signer signer,
+        int locktime
     ) {
         // Pre-resolve intent-intrinsic witness hex. Throws
         // WitnessValueMissingError if a `_prevOutScript_<i>` or
@@ -561,10 +567,14 @@ public final class RunarContract {
             intentWitnessHex
         );
 
+        // Thread CallOptions.locktime so contracts asserting
+        // extractLocktime(preimage) can succeed. 0 → legacy. The rebuild path
+        // below must honor the same value or its preimage would mismatch the
+        // final on-chain tx.
         TransactionBuilder.CallTxResult firstPass =
             TransactionBuilder.buildCallTransactionFull(
                 currentUtxo, placeholderUnlock, newLockingScript, newSats,
-                dataOutputs, additional, funderAddress, feeRate
+                dataOutputs, additional, funderAddress, feeRate, locktime
             );
         long changeAmount = firstPass.changeAmount();
 
@@ -583,7 +593,7 @@ public final class RunarContract {
         TransactionBuilder.CallTxResult secondPass =
             TransactionBuilder.buildCallTransactionFull(
                 currentUtxo, secondPassUnlock, newLockingScript, newSats,
-                dataOutputs, additional, funderAddress, feeRate
+                dataOutputs, additional, funderAddress, feeRate, locktime
             );
         long finalChangeAmount = secondPass.changeAmount();
         RawTx tx = secondPass.tx();
@@ -678,7 +688,8 @@ public final class RunarContract {
         List<CallOptions.TerminalOutput> terminalOutputs,
         List<UTXO> fundingUtxos,
         Provider provider,
-        Signer signer
+        Signer signer,
+        int locktime
     ) {
         // Pre-resolve intent-intrinsic witness hex. Throws
         // WitnessValueMissingError BEFORE any signing / broadcast.
@@ -717,6 +728,10 @@ public final class RunarContract {
         // the final tx bytes.
         java.util.function.Supplier<RawTx> buildTx = () -> {
             RawTx t = new RawTx();
+            // Terminal calls (auction close/claim/withdraw) typically assert
+            // extractLocktime(preimage) >= deadline. Default 0 preserves legacy
+            // behavior for contracts that don't check locktime.
+            t.locktime = locktime;
             t.addInput(currentUtxo.txid(), currentUtxo.outputIndex(), "");
             for (UTXO fu : fundingUtxos) {
                 t.addInput(fu.txid(), fu.outputIndex(), "");
@@ -1224,8 +1239,12 @@ public final class RunarContract {
         // change, no automatic funding selection.
         long contractSats = currentUtxo.satoshis();
         List<UTXO> fundingUtxos = options.fundingUtxos == null ? List.of() : options.fundingUtxos;
+        // Terminal calls typically assert extractLocktime(preimage) >= deadline.
+        // Default 0 preserves legacy behavior for non-locktime contracts.
+        int terminalLocktime = options.locktime != null ? options.locktime : 0;
         java.util.function.Supplier<RawTx> buildTx = () -> {
             RawTx t = new RawTx();
+            t.locktime = terminalLocktime;
             t.addInput(currentUtxo.txid(), currentUtxo.outputIndex(), "");
             for (UTXO fu : fundingUtxos) {
                 t.addInput(fu.txid(), fu.outputIndex(), "");

--- a/packages/runar-java/src/main/java/runar/lang/sdk/TransactionBuilder.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/TransactionBuilder.java
@@ -231,6 +231,29 @@ public final class TransactionBuilder {
         String changeAddress,
         long feeRate
     ) {
+        return buildCallTransactionFull(
+            currentUtxo, unlockingScriptHex, newLockingScriptHex, newSatoshis,
+            dataOutputs, additionalUtxos, changeAddress, feeRate, 0
+        );
+    }
+
+    /**
+     * Variant that additionally sets the tx's nLockTime field. {@code locktime}
+     * defaults to 0 (legacy) via the overloads above; pass a non-zero value
+     * for contracts that assert {@code extractLocktime(preimage) >= deadline}
+     * (e.g. auction close/claim).
+     */
+    public static CallTxResult buildCallTransactionFull(
+        UTXO currentUtxo,
+        String unlockingScriptHex,
+        String newLockingScriptHex,
+        long newSatoshis,
+        List<DataOutput> dataOutputs,
+        List<UTXO> additionalUtxos,
+        String changeAddress,
+        long feeRate,
+        int locktime
+    ) {
         long rate = feeRate > 0 ? feeRate : FeeEstimator.DEFAULT_FEE_RATE;
         if (dataOutputs == null) dataOutputs = List.of();
 
@@ -291,6 +314,9 @@ public final class TransactionBuilder {
         }
 
         RawTx tx = new RawTx();
+        // Locktime: default 0 (legacy); overridable via CallOptions.locktime
+        // for contracts asserting extractLocktime(preimage) >= deadline.
+        tx.locktime = locktime;
         tx.addInput(currentUtxo.txid(), currentUtxo.outputIndex(), unlockingScriptHex);
         for (UTXO f : selected) {
             tx.addInput(f.txid(), f.outputIndex(), "");

--- a/packages/runar-java/src/test/java/runar/lang/sdk/TransactionBuilderTest.java
+++ b/packages/runar-java/src/test/java/runar/lang/sdk/TransactionBuilderTest.java
@@ -61,6 +61,45 @@ class TransactionBuilderTest {
     }
 
     @Test
+    void callTxLocktimeOverrideAppearsInTx() {
+        // Issue #40: a caller-supplied non-zero locktime must appear in the
+        // built call tx's nLockTime field.
+        UTXO contractUtxo = new UTXO("ab".repeat(32), 0, 100_000L,
+            ScriptUtils.buildP2PKHScript("00".repeat(20)));
+        UTXO funding = new UTXO("cd".repeat(32), 0, 50_000L,
+            ScriptUtils.buildP2PKHScript("11".repeat(20)));
+
+        TransactionBuilder.CallTxResult result =
+            TransactionBuilder.buildCallTransactionFull(
+                contractUtxo, "51", null, 0L, List.of(),
+                List.of(funding), "22".repeat(20),
+                100L, 800_000
+            );
+
+        RawTx parsed = RawTxParser.parse(result.tx().toHex());
+        assertEquals(800_000, parsed.locktime);
+    }
+
+    @Test
+    void callTxLocktimeDefaultsToZero() {
+        // Default (no locktime arg) must still write 0 — back-compatible.
+        UTXO contractUtxo = new UTXO("ab".repeat(32), 0, 100_000L,
+            ScriptUtils.buildP2PKHScript("00".repeat(20)));
+        UTXO funding = new UTXO("cd".repeat(32), 0, 50_000L,
+            ScriptUtils.buildP2PKHScript("11".repeat(20)));
+
+        TransactionBuilder.CallTxResult result =
+            TransactionBuilder.buildCallTransactionFull(
+                contractUtxo, "51", null, 0L, List.of(),
+                List.of(funding), "22".repeat(20),
+                100L
+            );
+
+        RawTx parsed = RawTxParser.parse(result.tx().toHex());
+        assertEquals(0, parsed.locktime);
+    }
+
+    @Test
     void deployUsesDefaultChangeAddressFromSignerWhenUnspecified() {
         LocalSigner signer = new LocalSigner(PRIV);
         MockProvider provider = new MockProvider();

--- a/packages/runar-py/runar/sdk/calling.py
+++ b/packages/runar-py/runar/sdk/calling.py
@@ -20,6 +20,7 @@ def build_call_transaction(
     contract_outputs: list[dict] | None = None,
     additional_contract_inputs: list[dict] | None = None,
     data_outputs: list[dict] | None = None,
+    locktime: int | None = None,
 ) -> tuple[str, int, int]:
     """Build a raw transaction that spends a contract UTXO.
 
@@ -30,6 +31,9 @@ def build_call_transaction(
         `this.addDataOutput(...)` in the method body. Emitted between
         contract (state) outputs and the change output in declaration
         order — matching the compile-time continuation-hash layout.
+    locktime: override the call tx's nLockTime. None → defaults to 0 (legacy).
+        Set for contracts that assert extractLocktime(preimage) >= deadline
+        (e.g. auction close/claim).
 
     Returns (tx_hex, input_count, change_amount).
     """
@@ -149,8 +153,9 @@ def build_call_transaction(
         tx += _encode_varint(len(actual_change_script) // 2)
         tx += actual_change_script
 
-    # Locktime
-    tx += _to_le32(0)
+    # Locktime: default 0 (legacy); overridable via locktime for contracts
+    # asserting extractLocktime(preimage) >= deadline.
+    tx += _to_le32(locktime if locktime is not None else 0)
 
     return tx, len(all_utxos), change if change > 0 else 0
 

--- a/packages/runar-py/runar/sdk/contract.py
+++ b/packages/runar-py/runar/sdk/contract.py
@@ -665,6 +665,9 @@ class RunarContract:
                 for i, u in enumerate(extra_contract_utxos)
             ] if extra_contract_utxos else None,
             data_outputs=resolved_data_outputs or None,
+            # Thread CallOptions.locktime so contracts asserting
+            # extractLocktime(preimage) can succeed. None → 0 (legacy).
+            locktime=opts.locktime,
         )
 
         # Sign P2PKH funding inputs (after contract inputs)
@@ -752,6 +755,9 @@ class RunarContract:
                     for i, u in enumerate(extra_contract_utxos)
                 ] if extra_contract_utxos else None,
                 data_outputs=resolved_data_outputs or None,
+                # Rebuild path must honor the override too: a preimage computed
+                # on a rebuilt tx with locktime 0 would mismatch the final tx.
+                locktime=opts.locktime,
             )
             signed_tx = tx_hex
 
@@ -1119,6 +1125,11 @@ class RunarContract:
         # Resolve funding UTXOs for terminal methods
         funding_utxos = opts.funding_utxos or []
 
+        # Terminal calls (auction close/claim/withdraw) typically assert
+        # extractLocktime(preimage) >= deadline. Default 0 preserves legacy
+        # behavior for contracts that don't check locktime.
+        terminal_locktime = opts.locktime if opts.locktime is not None else 0
+
         # Build raw terminal transaction: contract input + optional funding inputs, exact outputs
         def build_terminal_tx(unlock: str) -> str:
             num_inputs = 1 + len(funding_utxos)
@@ -1142,7 +1153,7 @@ class RunarContract:
                 tx += _to_le64(out.satoshis)
                 tx += _encode_varint(len(out.script_hex) // 2)
                 tx += out.script_hex
-            tx += _to_le32(0)  # locktime
+            tx += _to_le32(terminal_locktime)  # locktime
             return tx
 
         term_tx = build_terminal_tx(term_unlock_script)

--- a/packages/runar-py/runar/sdk/types.py
+++ b/packages/runar-py/runar/sdk/types.py
@@ -218,6 +218,11 @@ class CallOptions:
     # SDK resolves data outputs automatically by running the ANF interpreter.
     # Entries are {"script": hex, "satoshis": int}.
     data_outputs: list[dict] | None = None
+    # Override the call tx's nLockTime field. None → SDK uses 0 (legacy
+    # behavior, preserves existing contracts). Set for contracts that assert
+    # extractLocktime(preimage) >= deadline (e.g. auction close/claim).
+    # Threaded through both the non-terminal and terminal call-tx build sites.
+    locktime: int | None = None
 
 
 @dataclass

--- a/packages/runar-py/tests/test_sdk_calling.py
+++ b/packages/runar-py/tests/test_sdk_calling.py
@@ -266,6 +266,39 @@ class TestBuildCallTransaction:
 
 
 # ---------------------------------------------------------------------------
+# Issue #40: caller-supplied nLockTime override
+# ---------------------------------------------------------------------------
+
+class TestBuildCallTransactionLocktime:
+    def test_locktime_override_appears_in_tx(self):
+        """A caller-supplied non-zero locktime appears in the tx's nLockTime."""
+        utxo = _make_utxo(100_000)
+        tx_hex, _, _ = build_call_transaction(
+            current_utxo=utxo,
+            unlocking_script='51',
+            new_locking_script='',
+            new_satoshis=0,
+            change_address='',
+            locktime=800_000,
+        )
+        parsed = _parse_tx(tx_hex)
+        assert parsed['locktime'] == 800_000
+
+    def test_locktime_default_is_zero(self):
+        """Default (unset) still writes 0 — back-compatible."""
+        utxo = _make_utxo(100_000)
+        tx_hex, _, _ = build_call_transaction(
+            current_utxo=utxo,
+            unlocking_script='51',
+            new_locking_script='',
+            new_satoshis=0,
+            change_address='',
+        )
+        parsed = _parse_tx(tx_hex)
+        assert parsed['locktime'] == 0
+
+
+# ---------------------------------------------------------------------------
 # insert_unlocking_script
 # ---------------------------------------------------------------------------
 

--- a/packages/runar-rb/lib/runar/sdk/calling.rb
+++ b/packages/runar-rb/lib/runar/sdk/calling.rb
@@ -37,6 +37,9 @@ module Runar
     #     +this.addDataOutput(...)+ in the method body. Each +{script:, satoshis:}+.
     #     Emitted between the contract (state) outputs and the change output, in
     #     declaration order — matching the compile-time continuation-hash layout.
+    #   - +:locktime+ [Integer, nil] override the call tx's nLockTime. nil →
+    #     defaults to 0 (legacy). Set for contracts that assert
+    #     +extractLocktime(preimage) >= deadline+ (e.g. auction close/claim).
     # @return [Array(String, Integer, Integer)] [tx_hex, input_count, change_amount]
     def build_call_transaction(
       current_utxo,
@@ -171,8 +174,9 @@ module Runar
         tx << actual_change_script
       end
 
-      # Locktime
-      tx << to_le32(0)
+      # Locktime: default 0 (legacy); overridable via options[:locktime] for
+      # contracts asserting extractLocktime(preimage) >= deadline.
+      tx << to_le32(opts[:locktime] || 0)
 
       [tx, all_utxos.length, has_change ? change : 0]
     end

--- a/packages/runar-rb/lib/runar/sdk/contract.rb
+++ b/packages/runar-rb/lib/runar/sdk/contract.rb
@@ -510,6 +510,9 @@ module Runar
         call_options = {}
         call_options[:contract_outputs] = contract_outputs if contract_outputs
         call_options[:data_outputs] = resolved_data_outputs if resolved_data_outputs.any?
+        # Thread CallOptions#locktime so contracts asserting
+        # extractLocktime(preimage) can succeed. nil → 0 (legacy).
+        call_options[:locktime] = opts.locktime unless opts.locktime.nil?
         if extra_contract_utxos.any?
           call_options[:additional_contract_inputs] = extra_contract_utxos.each_with_index.map do |utxo, i|
             { utxo: utxo, unlocking_script: extra_unlock_placeholders[i] }
@@ -540,7 +543,8 @@ module Runar
             extra_contract_utxos: extra_contract_utxos,
             resolved_per_input_args: resolved_per_input_args,
             prevouts_indices: prevouts_indices,
-            intent_witness_hex: intent_witness_hex
+            intent_witness_hex: intent_witness_hex,
+            locktime: opts.locktime
           )
 
         sighash = final_preimage.empty? ? '' : Digest::SHA256.hexdigest([final_preimage].pack('H*'))
@@ -889,6 +893,11 @@ module Runar
                                  intent_witness_hex
                              end
 
+        # Terminal calls (auction close/claim/withdraw) typically assert
+        # extractLocktime(preimage) >= deadline. Default 0 preserves legacy
+        # behavior for contracts that don't check locktime.
+        terminal_locktime = opts.locktime || 0
+
         # Build raw terminal transaction: single input, exact outputs, no change.
         build_terminal_tx = lambda do |unlock|
           tx = +''
@@ -905,7 +914,7 @@ module Runar
             tx << SDK.encode_varint(out.script_hex.length / 2)
             tx << out.script_hex
           end
-          tx << SDK.to_le32(0)
+          tx << SDK.to_le32(terminal_locktime)
           tx
         end
 
@@ -1090,7 +1099,8 @@ module Runar
         extra_contract_utxos: [],
         resolved_per_input_args: [],
         prevouts_indices: [],
-        intent_witness_hex: ''
+        intent_witness_hex: '',
+        locktime: nil
       )
         final_op_push_tx_sig = ''
         final_preimage       = ''
@@ -1108,7 +1118,8 @@ module Runar
               extra_contract_utxos: extra_contract_utxos,
               resolved_per_input_args: resolved_per_input_args,
               prevouts_indices: prevouts_indices,
-              intent_witness_hex: intent_witness_hex
+              intent_witness_hex: intent_witness_hex,
+              locktime: locktime
             )
 
           # Update resolved_args with final prevouts so finalize_call can rebuild
@@ -1143,7 +1154,8 @@ module Runar
         extra_contract_utxos: [],
         resolved_per_input_args: [],
         prevouts_indices: [],
-        intent_witness_hex: ''
+        intent_witness_hex: '',
+        locktime: nil
       )
         pub_key     = signer.get_public_key
         p2pkh_start = 1 + extra_contract_utxos.length
@@ -1151,6 +1163,9 @@ module Runar
         call_opts = {}
         call_opts[:contract_outputs] = contract_outputs if contract_outputs
         call_opts[:data_outputs] = data_outputs if data_outputs && !data_outputs.empty?
+        # Rebuild path must honor the override too: a preimage computed on a
+        # rebuilt tx with locktime 0 would mismatch the final on-chain tx.
+        call_opts[:locktime] = locktime unless locktime.nil?
 
         # First pass — build unlock with placeholder Sig/prevouts params.
         input0_unlock, = build_stateful_unlock(

--- a/packages/runar-rb/lib/runar/sdk/types.rb
+++ b/packages/runar-rb/lib/runar/sdk/types.rb
@@ -240,6 +240,7 @@ module Runar
       :terminal_outputs,
       :funding_utxos,
       :data_outputs,
+      :locktime,
       keyword_init: true
     ) do
       def initialize(
@@ -252,7 +253,11 @@ module Runar
         additional_contract_input_args: nil,
         terminal_outputs: nil,
         funding_utxos: nil,
-        data_outputs: nil
+        data_outputs: nil,
+        # Override the call tx's nLockTime field. nil → SDK uses 0 (legacy
+        # behavior). Set for contracts that assert
+        # extractLocktime(preimage) >= deadline (e.g. auction close/claim).
+        locktime: nil
       )
         super
       end

--- a/packages/runar-rb/spec/sdk/calling_spec.rb
+++ b/packages/runar-rb/spec/sdk/calling_spec.rb
@@ -283,6 +283,30 @@ RSpec.describe 'Runar::SDK calling helpers' do
   end
 
   # ---------------------------------------------------------------------------
+  # build_call_transaction — locktime override (issue #40)
+  # ---------------------------------------------------------------------------
+  describe 'build_call_transaction with locktime override' do
+    let(:contract_utxo) { make_utxo(CONTRACT_TXID, 1_000_000) }
+
+    it 'writes a caller-supplied non-zero locktime into the tx' do
+      tx_hex, = Runar::SDK.build_call_transaction(
+        contract_utxo, '', CONTRACT_SCRIPT, 10_000, CALL_ADDRESS, '',
+        nil, options: { locktime: 800_000 }
+      )
+      # 800000 = 0x000C3500 → little-endian hex "00350c00"
+      expect(tx_hex).to end_with('00350c00')
+    end
+
+    it 'defaults to locktime 00000000 when the option is unset (back-compatible)' do
+      tx_hex, = Runar::SDK.build_call_transaction(
+        contract_utxo, '', CONTRACT_SCRIPT, 10_000, CALL_ADDRESS, '',
+        nil, options: {}
+      )
+      expect(tx_hex).to end_with('00000000')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # insert_unlocking_script
   # ---------------------------------------------------------------------------
   describe 'insert_unlocking_script' do

--- a/packages/runar-rs/src/sdk/calling.rs
+++ b/packages/runar-rs/src/sdk/calling.rs
@@ -29,6 +29,10 @@ pub struct CallTxOptions {
     /// output, in declaration order — matching the order the compiler's
     /// auto-injected continuation-hash check expects.
     pub data_outputs: Option<Vec<ContractOutput>>,
+    /// Override the call tx's nLockTime. `None` → defaults to `0` (legacy).
+    /// `Some(N)` writes `N` as little-endian `u32` in the locktime field.
+    /// Required for contracts that assert `extractLocktime(preimage) >= deadline`.
+    pub locktime: Option<u32>,
 }
 
 /// Build a raw transaction that spends a contract UTXO (method call).
@@ -216,8 +220,13 @@ pub fn build_call_transaction_ext(
         tx.push_str(&actual_change_script);
     }
 
-    // Locktime
-    tx.push_str(&to_little_endian_32(0));
+    // Locktime: default `0` (legacy behavior); overridable via
+    // `CallTxOptions.locktime`. Contracts asserting
+    // `extractLocktime(preimage) >= deadline` (e.g. auction `close`/`claim`)
+    // require this override; the previously hardcoded `0` caused NULLFAIL
+    // on every terminal call with a non-zero deadline.
+    let locktime_value = options.and_then(|o| o.locktime).unwrap_or(0);
+    tx.push_str(&to_little_endian_32(locktime_value));
 
     let change_amount = if change > 0 { change } else { 0 };
     (tx, all_utxos.len(), change_amount)
@@ -397,6 +406,42 @@ mod tests {
         let (tx_hex, _, _) = build_call_transaction(&utxo, "51", None, None, None, None, None, None);
         let parsed = parse_tx_hex(&tx_hex);
         assert_eq!(parsed.version, 1);
+        assert_eq!(parsed.locktime, 0);
+    }
+
+    #[test]
+    fn locktime_override_appears_in_tx() {
+        // Issue #40: a caller-supplied non-zero locktime must appear in the
+        // built call tx's nLockTime field (contracts asserting
+        // `extractLocktime(preimage) >= deadline`).
+        let utxo = make_utxo(100_000, 0);
+        let options = CallTxOptions {
+            contract_outputs: None,
+            additional_contract_inputs: None,
+            data_outputs: None,
+            locktime: Some(800_000),
+        };
+        let (tx_hex, _, _) = build_call_transaction_ext(
+            &utxo, "51", None, None, None, None, None, None, Some(&options),
+        );
+        let parsed = parse_tx_hex(&tx_hex);
+        assert_eq!(parsed.locktime, 800_000);
+    }
+
+    #[test]
+    fn locktime_default_is_zero() {
+        // Default (unset) must still write 0 — back-compatible.
+        let utxo = make_utxo(100_000, 0);
+        let options = CallTxOptions {
+            contract_outputs: None,
+            additional_contract_inputs: None,
+            data_outputs: None,
+            locktime: None,
+        };
+        let (tx_hex, _, _) = build_call_transaction_ext(
+            &utxo, "51", None, None, None, None, None, None, Some(&options),
+        );
+        let parsed = parse_tx_hex(&tx_hex);
         assert_eq!(parsed.locktime, 0);
     }
 

--- a/packages/runar-rs/src/sdk/contract.rs
+++ b/packages/runar-rs/src/sdk/contract.rs
@@ -798,6 +798,10 @@ impl RunarContract {
                     satoshis: co.satoshis,
                 }).collect())
             },
+            // Thread `CallOptions.locktime` through to the tx builder so contracts
+            // asserting `extractLocktime(preimage)` can succeed. Default `None` → `0`
+            // (legacy behavior preserved).
+            locktime: options.and_then(|o| o.locktime),
         };
 
         let (tx_hex, input_count, mut change_amount) = build_call_transaction_ext(
@@ -957,6 +961,10 @@ impl RunarContract {
                         satoshis: co.satoshis,
                     }).collect())
                 },
+                // Rebuild path must also honor the override: a preimage computed
+                // on a rebuilt tx with `locktime = 0` would mismatch what
+                // `extractLocktime` sees in the final on-chain tx.
+                locktime: options.and_then(|o| o.locktime),
             };
 
             let (rebuilt_tx, _, rebuilt_change) = build_call_transaction_ext(
@@ -1205,7 +1213,7 @@ impl RunarContract {
         method_name: &str,
         resolved_args: &mut Vec<SdkValue>,
         _signer: &dyn Signer,
-        _options: Option<&CallOptions>,
+        options: Option<&CallOptions>,
         terminal_outputs: &[TerminalOutput],
         current_utxo: &Utxo,
         is_stateful: bool,
@@ -1219,6 +1227,13 @@ impl RunarContract {
         witness_hex: &str,
     ) -> Result<PreparedCall, String> {
         let term_code_sep_idx = self.get_code_sep_index(self.find_method_index(method_name));
+
+        // Terminal calls (auction `close`, `claim`, `withdraw`) typically assert
+        // `extractLocktime(preimage) >= deadline`. Without an override the SDK
+        // previously hardcoded `0` → every such call NULLFAILed. Default `None`
+        // preserves existing terminal-call behavior for contracts that don't
+        // check locktime.
+        let terminal_locktime = options.and_then(|o| o.locktime).unwrap_or(0);
 
         // Build placeholder unlocking script (witness_hex suffixed for sizing
         // — the real ABI-correct unlock is built by build_unlock below for
@@ -1255,7 +1270,7 @@ impl RunarContract {
                 tx.push_str(&encode_varint((out.script_hex.len() / 2) as u64));
                 tx.push_str(&out.script_hex);
             }
-            tx.push_str(&to_little_endian_32(0)); // locktime
+            tx.push_str(&to_little_endian_32(terminal_locktime)); // locktime
             tx
         };
 

--- a/packages/runar-rs/src/sdk/types.rs
+++ b/packages/runar-rs/src/sdk/types.rs
@@ -92,6 +92,13 @@ pub struct CallOptions {
     /// on the method body (the common case). Pass a non-empty `Vec` to
     /// bypass the interpreter.
     pub data_outputs: Option<Vec<ContractDataOutput>>,
+    /// Override the call tx's nLockTime field. Defaults to `None` → SDK uses
+    /// `0` (legacy behavior, preserves existing contracts). Set to `Some(height)`
+    /// for contracts that assert `extractLocktime(preimage) >= deadline`
+    /// (e.g., auction `close`/`claim` methods). Threaded through to both the
+    /// non-terminal (`build_call_transaction_ext`) and terminal call-tx
+    /// build sites.
+    pub locktime: Option<u32>,
 }
 
 /// A data output entry — hex-encoded script + satoshis — for the

--- a/packages/runar-sdk/src/__tests__/build-call-transaction.test.ts
+++ b/packages/runar-sdk/src/__tests__/build-call-transaction.test.ts
@@ -480,6 +480,31 @@ describe('buildCallTransaction — stateless call', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #40: caller-supplied nLockTime override
+// ---------------------------------------------------------------------------
+
+describe('buildCallTransaction — locktime override (issue #40)', () => {
+  it('writes a caller-supplied non-zero locktime into the tx', () => {
+    const utxo = makeUtxo(100000);
+    const { tx } = buildCallTransaction(
+      utxo, '51', undefined, undefined, undefined, undefined, undefined, 100,
+      { locktime: 800000 },
+    );
+    const parsed = parseTxHex(tx.toHex());
+    expect(parsed.locktime).toBe(800000);
+  });
+
+  it('defaults to locktime 0 when the option is unset (back-compatible)', () => {
+    const utxo = makeUtxo(100000);
+    const { tx } = buildCallTransaction(
+      utxo, '51', undefined, undefined, undefined, undefined, undefined, 100, {},
+    );
+    const parsed = parseTxHex(tx.toHex());
+    expect(parsed.locktime).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Fix #18: P2PKH address should use Base58Check decoding, not deterministicHash20
 // ---------------------------------------------------------------------------
 

--- a/packages/runar-sdk/src/calling.ts
+++ b/packages/runar-sdk/src/calling.ts
@@ -39,6 +39,10 @@ export function buildCallTransaction(
      * in declaration order — matching the compile-time continuation-hash
      * layout. */
     dataOutputs?: Array<{ script: string; satoshis: number }>;
+    /** Override the call tx's nLockTime. Unset → defaults to 0 (legacy).
+     * Set to a non-zero value for contracts that assert
+     * `extractLocktime(preimage) >= deadline` (e.g. auction close/claim). */
+    locktime?: number;
   },
 ): { tx: Transaction; inputCount: number; changeAmount: number } {
   const extraContractInputs = options?.additionalContractInputs ?? [];
@@ -87,6 +91,10 @@ export function buildCallTransaction(
 
   // Build Transaction object
   const tx = new Transaction();
+
+  // Locktime: default 0 (legacy); overridable via options.locktime for
+  // contracts asserting `extractLocktime(preimage) >= deadline`.
+  tx.lockTime = options?.locktime ?? 0;
 
   // Input 0: primary contract UTXO with unlocking script
   tx.addInput({

--- a/packages/runar-sdk/src/contract.ts
+++ b/packages/runar-sdk/src/contract.ts
@@ -628,6 +628,10 @@ export class RunarContract {
 
       const buildTerminalTx = (unlock: string): BsvTransaction => {
         const ttx = new BsvTransaction();
+        // Terminal calls (auction close/claim/withdraw) typically assert
+        // `extractLocktime(preimage) >= deadline`. Default 0 preserves legacy
+        // behavior for contracts that don't check locktime.
+        ttx.lockTime = options?.locktime ?? 0;
         ttx.addInput({
           sourceTXID: contractUtxo.txid,
           sourceOutputIndex: contractUtxo.outputIndex,
@@ -877,6 +881,9 @@ export class RunarContract {
           ? extraContractUtxos.map((utxo, i) => ({ utxo, unlockingScript: extraUnlockPlaceholders[i]! }))
           : undefined,
         dataOutputs: resolvedDataOutputs.length > 0 ? resolvedDataOutputs : undefined,
+        // Thread CallOptions.locktime so contracts asserting
+        // extractLocktime(preimage) can succeed. Default unset → 0.
+        locktime: options?.locktime,
       },
     );
 
@@ -976,6 +983,9 @@ export class RunarContract {
             ? extraContractUtxos.map((utxo, i) => ({ utxo, unlockingScript: extraUnlocks[i]! }))
             : undefined,
           dataOutputs: resolvedDataOutputs.length > 0 ? resolvedDataOutputs : undefined,
+          // Rebuild path must honor the override too: a preimage computed on a
+          // rebuilt tx with locktime 0 would mismatch the final on-chain tx.
+          locktime: options?.locktime,
         },
       ));
 

--- a/packages/runar-sdk/src/types.ts
+++ b/packages/runar-sdk/src/types.ts
@@ -154,4 +154,11 @@ export interface CallOptions {
    * the interpreter.
    */
   dataOutputs?: Array<{ script: string; satoshis: number | bigint }>;
+  /**
+   * Override the call tx's nLockTime field. Defaults to unset → SDK uses 0
+   * (legacy behavior, preserves existing contracts). Set for contracts that
+   * assert `extractLocktime(preimage) >= deadline` (e.g. auction close/claim).
+   * Threaded through both the non-terminal and terminal call-tx build sites.
+   */
+  locktime?: number;
 }

--- a/packages/runar-zig/src/sdk_call.zig
+++ b/packages/runar-zig/src/sdk_call.zig
@@ -24,6 +24,11 @@ pub const CallBuildOptions = struct {
     /// P2PKH funding inputs. Mirrors Go's `AdditionalContractInputs`
     /// inside `BuildCallOptions`.
     additional_contract_inputs: []const AdditionalContractInput = &.{},
+    /// Override the call tx's nLockTime. `null` → defaults to 0 (legacy).
+    /// Non-null writes the value into the locktime field. Required for
+    /// contracts that assert `extractLocktime(preimage) >= deadline`
+    /// (e.g. auction close/claim).
+    locktime: ?u32 = null,
 };
 
 /// AdditionalContractInput pairs an extra contract UTXO with its
@@ -120,6 +125,12 @@ pub fn buildCallTransaction(
     // Build transaction using bsvz Builder
     var builder = bsvz.transaction.Builder.init(allocator);
     defer builder.deinit();
+
+    // Locktime: default 0 (legacy); overridable via CallBuildOptions.locktime
+    // for contracts asserting extractLocktime(preimage) >= deadline.
+    if (opts) |o| {
+        if (o.locktime) |lt| builder.lock_time = lt;
+    }
 
     // Input 0: contract UTXO with unlocking script
     {
@@ -334,6 +345,66 @@ test "buildCallTransaction with stateless contract" {
 
     try std.testing.expect(result.tx_hex.len > 0);
     try std.testing.expectEqual(@as(usize, 1), result.input_count);
+}
+
+test "buildCallTransaction locktime override appears in tx (issue #40)" {
+    const allocator = std.testing.allocator;
+
+    const contract_utxo = types.UTXO{
+        .txid = "aa" ** 32,
+        .output_index = 0,
+        .satoshis = 1000,
+        .script = "5100",
+    };
+
+    // Caller-supplied non-zero locktime must appear in the tx's nLockTime
+    // (the last 4 bytes / 8 hex chars of the serialized tx).
+    const opts = CallBuildOptions{ .locktime = 800_000 };
+    var result = try buildCallTransaction(
+        allocator,
+        contract_utxo,
+        "51",
+        "",
+        0,
+        null,
+        &.{},
+        100,
+        &opts,
+    );
+    defer result.deinit(allocator);
+
+    const tail = result.tx_hex[result.tx_hex.len - 8 ..];
+    // 800000 = 0x000C3500 → little-endian hex "00350c00"
+    try std.testing.expectEqualStrings("00350c00", tail);
+}
+
+test "buildCallTransaction locktime defaults to zero (issue #40)" {
+    const allocator = std.testing.allocator;
+
+    const contract_utxo = types.UTXO{
+        .txid = "aa" ** 32,
+        .output_index = 0,
+        .satoshis = 1000,
+        .script = "5100",
+    };
+
+    // Default (unset) must still write 0 — back-compatible.
+    const opts = CallBuildOptions{};
+    var result = try buildCallTransaction(
+        allocator,
+        contract_utxo,
+        "51",
+        "",
+        0,
+        null,
+        &.{},
+        100,
+        &opts,
+    );
+    defer result.deinit(allocator);
+
+    const tail = result.tx_hex[result.tx_hex.len - 8 ..];
+    try std.testing.expectEqualStrings("00000000", tail);
 }
 
 test "estimateCallFee mirrors TS semantics" {

--- a/packages/runar-zig/src/sdk_contract.zig
+++ b/packages/runar-zig/src/sdk_contract.zig
@@ -788,11 +788,14 @@ pub const RunarContract = struct {
             // inputs are the caller-supplied funding_utxos. No change.
             const stateless_build_opts: call_mod.CallBuildOptions = .{
                 .contract_outputs = terminal_outputs,
+                // Thread CallOptions.locktime so contracts asserting
+                // extractLocktime(preimage) can succeed. null → 0 (legacy).
+                .locktime = if (options) |o| o.locktime else null,
             };
             const stateless_change_address: ?[]const u8 =
                 if (is_terminal_call) null else change_address;
             const stateless_build_opts_ptr: ?*const call_mod.CallBuildOptions =
-                if (is_terminal_call) &stateless_build_opts else null;
+                if (is_terminal_call or (if (options) |o| o.locktime != null else false)) &stateless_build_opts else null;
 
             var call_result = call_mod.buildCallTransaction(
                 self.allocator,
@@ -948,9 +951,12 @@ pub const RunarContract = struct {
             .contract_outputs = stateful_contract_outputs,
             .data_outputs = stateful_data_outputs,
             .additional_contract_inputs = extra_call_inputs.items,
+            // Thread CallOptions.locktime through the stateful build + rebuild
+            // path so the preimage's locktime matches the final on-chain tx.
+            .locktime = if (options) |o| o.locktime else null,
         };
         const build_opts_ptr: ?*const call_mod.CallBuildOptions =
-            if (is_terminal_call or has_multi_output or data_outputs_hex.items.len > 0 or extra_call_inputs.items.len > 0) &build_opts else null;
+            if (is_terminal_call or has_multi_output or data_outputs_hex.items.len > 0 or extra_call_inputs.items.len > 0 or (if (options) |o| o.locktime != null else false)) &build_opts else null;
 
         var call_result = call_mod.buildCallTransaction(
             self.allocator,
@@ -1389,11 +1395,14 @@ pub const RunarContract = struct {
 
         const stateless_build_opts: call_mod.CallBuildOptions = .{
             .contract_outputs = terminal_outputs,
+            // Thread CallOptions.locktime so contracts asserting
+            // extractLocktime(preimage) can succeed. null → 0 (legacy).
+            .locktime = if (options) |o| o.locktime else null,
         };
         const stateless_change_address: ?[]const u8 =
             if (is_terminal_call) null else change_address;
         const stateless_build_opts_ptr: ?*const call_mod.CallBuildOptions =
-            if (is_terminal_call) &stateless_build_opts else null;
+            if (is_terminal_call or (if (options) |o| o.locktime != null else false)) &stateless_build_opts else null;
 
         var call_result = call_mod.buildCallTransaction(
             self.allocator,
@@ -1646,9 +1655,12 @@ pub const RunarContract = struct {
             if (is_terminal_call) null else change_address;
         const stateful_build_opts: call_mod.CallBuildOptions = .{
             .contract_outputs = terminal_outputs,
+            // Thread CallOptions.locktime through both the prepare build and
+            // rebuild paths so the preimage matches the final on-chain tx.
+            .locktime = if (options) |o| o.locktime else null,
         };
         const stateful_build_opts_ptr: ?*const call_mod.CallBuildOptions =
-            if (is_terminal_call) &stateful_build_opts else null;
+            if (is_terminal_call or (if (options) |o| o.locktime != null else false)) &stateful_build_opts else null;
 
         // ---- Compute change PKH for stateful methods needing it ----------
         var change_pkh_buf: []u8 = &.{};

--- a/packages/runar-zig/src/sdk_types.zig
+++ b/packages/runar-zig/src/sdk_types.zig
@@ -121,6 +121,12 @@ pub const CallOptions = struct {
     /// its own `otherBalance` value). Mirrors Go's
     /// `AdditionalContractInputArgs`.
     additional_contract_input_args: ?[]const []const StateValue = null,
+    /// Override the call tx's nLockTime field. `null` → SDK uses 0 (legacy
+    /// behavior, preserves existing contracts). Set for contracts that assert
+    /// `extractLocktime(preimage) >= deadline` (e.g. auction close/claim).
+    /// Threaded through every call-tx build site (stateless, stateful,
+    /// rebuild, terminal).
+    locktime: ?u32 = null,
 };
 
 /// OutputSpec describes one continuation output for a multi-output method.


### PR DESCRIPTION
## Summary

The SDK call-tx builders hardcoded `nLockTime = 0`, so contracts that assert `extractLocktime(txPreimage) >= deadline` (auctions, time-locks) always NULLFAILed on call. This adds an optional caller-supplied `locktime` override to each tier's call-options type, threaded through:

- the non-terminal call-tx build site,
- the rebuild path (so the OP_PUSH_TX preimage's locktime matches the final on-chain tx),
- the terminal call-tx build site.

Default (unset) still writes `0`, so existing contracts are completely unaffected — the change is purely additive and back-compatible.

## Credit

The Rust implementation was authored by **Elis Jackson** in #41 (Rust-only, from a fork). This PR re-applies that change cleanly onto current `main` (the base had drifted — `CallTxOptions`/`CallOptions` gained `data_outputs` since #41) and ports the same logical change to the other six SDK tiers. It **supersedes / extends #41**.

## Per-tier status

| Tier | Implemented | Test (failing-first → passing) | Verified |
|------|:----------:|:------------------------------:|----------|
| TypeScript (`runar-sdk`) | ✅ | ✅ `build-call-transaction.test.ts` | `npx vitest run` — 418 passed |
| Go (`runar-go`)          | ✅ | ✅ `sdk_test.go` (2 tests) | `go test ./...` — ok |
| Rust (`runar-rs`)        | ✅ | ✅ `calling.rs` (2 tests) | `cargo test --lib` — 387 passed |
| Python (`runar-py`)      | ✅ | ✅ `test_sdk_calling.py` (2 tests) | `pytest` — 512 passed |
| Zig (`runar-zig`)        | ✅ | ✅ `sdk_call.zig` (2 tests) | `zig build test` — 207 passed |
| Ruby (`runar-rb`)        | ✅ | ✅ `calling_spec.rb` (2 examples) | `rspec` — 921 examples, 0 failures |
| Java (`runar-java`)      | ✅ | ✅ `TransactionBuilderTest.java` (2 tests) | `gradle test` — BUILD SUCCESSFUL |

Each tier's test asserts (a) a caller-supplied non-zero locktime appears in the built call tx's `nLockTime` field, and (b) the default (unset) is still `0`.

## API shape per tier

- **TS**: `CallOptions.locktime?: number`; `buildCallTransaction(... , { locktime })`.
- **Go**: `CallOptions.Locktime *uint32`; `BuildCallOptions.Locktime *uint32`.
- **Rust**: `CallOptions.locktime: Option<u32>`; `CallTxOptions.locktime: Option<u32>`.
- **Python**: `CallOptions.locktime: int | None`; `build_call_transaction(..., locktime=)`.
- **Zig**: `CallOptions.locktime: ?u32`; `CallBuildOptions.locktime: ?u32`.
- **Ruby**: `CallOptions#locktime`; `build_call_transaction(options: { locktime: })`.
- **Java**: `CallOptions.locktime` (nullable `Integer`, new 4-arg ctor; 3-arg ctor preserved); `buildCallTransactionFull(..., int locktime)` overload (old overloads delegate with `0`).

## Divergences

None. All seven tiers implement the override with byte-identical semantics (LE-u32 in the locktime field; default 0). No tier was faked or forced.

Note (Zig/Java) some build sites previously only attached an options object for terminal/multi-output cases; the gating conditions were widened so a standalone `locktime` override still attaches options on the non-terminal stateful path.

## Test plan

- [x] TS: `npx vitest run packages/runar-sdk/`
- [x] Go: `cd packages/runar-go && go test ./...`
- [x] Rust: `cd packages/runar-rs && cargo test --lib`
- [x] Python: `cd packages/runar-py && PYTHONPATH=. python3 -m pytest tests/`
- [x] Zig: `cd packages/runar-zig && zig build test`
- [x] Ruby: `cd packages/runar-rb && bundle exec rspec`
- [x] Java: `cd packages/runar-java && gradle test`

Closes #40