### PR TITLE
fix: issue #42 — terminal-method BIP-143 sighash subscript across all 7 SDKs

### DIFF
--- a/packages/runar-go/sdk_codesep_offsets_test.go
+++ b/packages/runar-go/sdk_codesep_offsets_test.go
@@ -1,0 +1,55 @@
+package runar
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Issue #42: terminal-method sighash subscript byte-walker.
+//
+// The on-chain script trims its sighash subscript at the method's
+// OP_CODESEPARATOR. findCodesepOffsets must recover the true byte position by
+// walking the script, correctly skipping push-data (which may itself contain a
+// 0xab byte) and all BSV push opcodes.
+
+func TestFindCodesepOffsets_RealBytePosition(t *testing.T) {
+	// 51            OP_1
+	// 02 ab cd      push 2 bytes (0xab inside push-data, must be ignored)
+	// ab            OP_CODESEPARATOR  <- real, byte offset 4
+	// ac            OP_CHECKSIG
+	got := findCodesepOffsets("5102abcdabac")
+	want := []int{4}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("findCodesepOffsets = %v, want %v (must skip 0xab inside push-data)", got, want)
+	}
+}
+
+func TestFindCodesepOffsets_PushData1(t *testing.T) {
+	// 4c (OP_PUSHDATA1) 02 (len) abab (data, contains 0xab) ab (real codesep)
+	got := findCodesepOffsets("4c02ababab")
+	want := []int{4}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("findCodesepOffsets = %v, want %v", got, want)
+	}
+}
+
+func TestSighashSubscriptTrimmedAtRealCodesepBytePosition(t *testing.T) {
+	// Issue #42: the user-sig subscript for a stateful terminal method
+	// (e.g. Auction.close) must be trimmed at the real on-chain codesep byte
+	// position recovered by findCodesepOffsets — even when push-data contains a
+	// stray 0xab byte.
+	fullScript := "5102abcdabac" // real codesep at byte index 4
+	offsets := findCodesepOffsets(fullScript)
+	if len(offsets) != 1 || offsets[0] != 4 {
+		t.Fatalf("expected codesep at byte 4, got %v", offsets)
+	}
+	codeSepIdx := offsets[0]
+
+	subscript := fullScript
+	if codeSepIdx >= 0 {
+		subscript = subscript[(codeSepIdx+1)*2:]
+	}
+	if subscript != "ac" {
+		t.Fatalf("subscript = %q, want %q (only OP_CHECKSIG after the codesep)", subscript, "ac")
+	}
+}

--- a/packages/runar-go/sdk_contract.go
+++ b/packages/runar-go/sdk_contract.go
@@ -394,10 +394,14 @@ func (c *RunarContract) Call(
 
 	signatures := make(map[int]string)
 	for _, idx := range prepared.SigIndices {
-		// In stateful contracts, user checkSig executes AFTER OP_CODESEPARATOR
-		// (checkPreimage is auto-injected at method entry), so use trimmed script.
-		// In stateless contracts, user checkSig executes BEFORE OP_CODESEPARATOR,
-		// so use the full locking script.
+		// Stateful contracts: checkPreimage is auto-injected at method entry, so
+		// the user checkSig executes AFTER the OP_CODESEPARATOR — the sighash
+		// must be computed over the subscript trimmed at that separator. Issue
+		// #42: the trim must land at the *real* on-chain codesep byte position,
+		// which getCodeSepIndex now recovers via findCodesepOffsets.
+		// Stateless contracts: the user controls statement order and may place
+		// checkSig BEFORE the codesep (e.g. CovenantVault) — those must use the
+		// FULL script, so the trim stays gated on isStateful.
 		subscript := prepared.contractUtxo.Script
 		if prepared.isStateful && prepared.codeSepIdx >= 0 {
 			subscript = subscript[(prepared.codeSepIdx+1)*2:]
@@ -1543,9 +1547,37 @@ func (c *RunarContract) resolvedCodeSepSlotValues() []struct {
 	return out
 }
 
-// getCodeSepIndex returns the adjusted code separator byte offset for a
-// given method index, or -1 if no OP_CODESEPARATOR is present.
+// getCodeSepIndex returns the byte offset of an OP_CODESEPARATOR for the given
+// method index, or -1 if no OP_CODESEPARATOR is present.
+//
+// When codeScript is set (i.e. the contract is loaded from chain, or the deploy
+// script has already been built from real constructor args), we walk the actual
+// script and return the true on-chain byte position. This is required because
+// FromTxid populates constructor args with dummy placeholders — the real arg
+// bytes are already baked into the on-chain locking script — so
+// adjustCodeSepOffset computes a shift of zero and returns the wrong offset
+// whenever the OP_CODESEPARATOR sits after constructor slots that expand at
+// deploy time (e.g. PubKey args = 1 → 34 bytes). The symptom of using the wrong
+// offset is NULLFAIL at OP_CHECKSIG for terminal methods.
+//
+// Falls back to the legacy template-adjusted offset for synthetic / unit-test
+// paths that have no codeScript available.
 func (c *RunarContract) getCodeSepIndex(methodIndex int) int {
+	if c.codeScript != "" {
+		if c.Artifact.CodeSeparatorIndices != nil {
+			realOffsets := findCodesepOffsets(c.codeScript)
+			if methodIndex >= 0 && methodIndex < len(c.Artifact.CodeSeparatorIndices) && methodIndex < len(realOffsets) {
+				return realOffsets[methodIndex]
+			}
+		}
+		if c.Artifact.CodeSeparatorIndex != nil {
+			realOffsets := findCodesepOffsets(c.codeScript)
+			if len(realOffsets) > 0 {
+				return realOffsets[0]
+			}
+		}
+	}
+
 	if c.Artifact.CodeSeparatorIndices != nil && methodIndex >= 0 && methodIndex < len(c.Artifact.CodeSeparatorIndices) {
 		return c.adjustCodeSepOffset(c.Artifact.CodeSeparatorIndices[methodIndex])
 	}
@@ -1553,6 +1585,65 @@ func (c *RunarContract) getCodeSepIndex(methodIndex int) int {
 		return c.adjustCodeSepOffset(*c.Artifact.CodeSeparatorIndex)
 	}
 	return -1
+}
+
+// findCodesepOffsets walks a hex-encoded script and returns the byte offsets of
+// every OP_CODESEPARATOR (0xab) that sits at a real opcode boundary (i.e. not
+// inside push-data). Correctly skips all BSV push opcodes (0x01..0x4b,
+// OP_PUSHDATA1/2/4).
+//
+// Used by getCodeSepIndex to recover the true on-chain byte offsets when the
+// in-memory constructor args don't reflect what was actually baked into the
+// locking script (e.g. after FromTxid populates dummy placeholders).
+func findCodesepOffsets(scriptHex string) []int {
+	out := []int{}
+	off := 0
+	n := len(scriptHex)
+	parseByte := func(i int) int {
+		v, err := strconv.ParseUint(scriptHex[i:i+2], 16, 16)
+		if err != nil {
+			return 0
+		}
+		return int(v)
+	}
+	for off+2 <= n {
+		op := parseByte(off)
+		bytePos := off / 2
+		switch {
+		case op == 0xab:
+			out = append(out, bytePos)
+			off += 2
+		case op >= 0x01 && op <= 0x4b:
+			off += 2 + op*2
+		case op == 0x4c:
+			if off+4 > n {
+				return out
+			}
+			pushLen := parseByte(off + 2)
+			off += 4 + pushLen*2
+		case op == 0x4d:
+			if off+6 > n {
+				return out
+			}
+			lo := parseByte(off + 2)
+			hi := parseByte(off + 4)
+			pushLen := lo | (hi << 8)
+			off += 6 + pushLen*2
+		case op == 0x4e:
+			if off+10 > n {
+				return out
+			}
+			b0 := parseByte(off + 2)
+			b1 := parseByte(off + 4)
+			b2 := parseByte(off + 6)
+			b3 := parseByte(off + 8)
+			pushLen := b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+			off += 10 + pushLen*2
+		default:
+			off += 2
+		}
+	}
+	return out
 }
 
 // hasCodeSeparator returns true if the artifact has OP_CODESEPARATOR support.

--- a/packages/runar-java/src/main/java/runar/lang/sdk/RunarContract.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/RunarContract.java
@@ -920,7 +920,37 @@ public final class RunarContract {
         return -1;
     }
 
+    /**
+     * Returns the byte offset of an {@code OP_CODESEPARATOR} for the given
+     * method index, or -1 if none is present.
+     *
+     * <p>When the contract has a live on-chain script ({@code currentUtxo} set),
+     * walk the actual script and return the true on-chain byte position. This is
+     * required because a contract reconnected from chain (or deployed from real
+     * constructor args) carries args already baked into the locking script — so
+     * {@link #adjustCodeSepOffset} computes a shift of zero and returns the
+     * wrong offset whenever the {@code OP_CODESEPARATOR} sits after constructor
+     * slots that expand at deploy time (issue #42: NULLFAIL at OP_CHECKSIG for
+     * terminal methods).
+     *
+     * <p>Falls back to the legacy template-adjusted offset for synthetic /
+     * unit-test paths that have no live script available.
+     */
     private int getCodeSepIndex(int methodIndex) {
+        if (currentUtxo != null && currentUtxo.scriptHex() != null) {
+            java.util.List<Integer> realOffsets =
+                findCodesepOffsets(currentUtxo.scriptHex());
+            if (artifact.codeSeparatorIndices() != null
+                && methodIndex >= 0
+                && methodIndex < artifact.codeSeparatorIndices().size()
+                && methodIndex < realOffsets.size()) {
+                return realOffsets.get(methodIndex);
+            }
+            if (artifact.codeSeparatorIndex() != null && !realOffsets.isEmpty()) {
+                return realOffsets.get(0);
+            }
+        }
+
         if (artifact.codeSeparatorIndices() != null
             && methodIndex >= 0
             && methodIndex < artifact.codeSeparatorIndices().size()) {
@@ -930,6 +960,62 @@ public final class RunarContract {
             return adjustCodeSepOffset(artifact.codeSeparatorIndex());
         }
         return -1;
+    }
+
+    /**
+     * Walks a hex-encoded script and returns the byte offsets of every
+     * {@code OP_CODESEPARATOR} (0xab) that sits at a real opcode boundary
+     * (i.e. not inside push-data). Correctly skips all BSV push opcodes
+     * (0x01..0x4b, OP_PUSHDATA1/2/4).
+     *
+     * <p>Used by {@link #getCodeSepIndex} to recover the true on-chain byte
+     * offsets when the in-memory constructor args don't reflect what was
+     * actually baked into the locking script.
+     */
+    static java.util.List<Integer> findCodesepOffsets(String scriptHex) {
+        java.util.List<Integer> out = new java.util.ArrayList<>();
+        int off = 0;
+        int n = scriptHex.length();
+        while (off + 2 <= n) {
+            int op = byteAt(scriptHex, off);
+            int bytePos = off / 2;
+            if (op == 0xab) {
+                out.add(bytePos);
+                off += 2;
+            } else if (op >= 0x01 && op <= 0x4b) {
+                off += 2 + op * 2;
+            } else if (op == 0x4c) {
+                if (off + 4 > n) break;
+                int pushLen = byteAt(scriptHex, off + 2);
+                off += 4 + pushLen * 2;
+            } else if (op == 0x4d) {
+                if (off + 6 > n) break;
+                int lo = byteAt(scriptHex, off + 2);
+                int hi = byteAt(scriptHex, off + 4);
+                int pushLen = lo | (hi << 8);
+                off += 6 + pushLen * 2;
+            } else if (op == 0x4e) {
+                if (off + 10 > n) break;
+                int b0 = byteAt(scriptHex, off + 2);
+                int b1 = byteAt(scriptHex, off + 4);
+                int b2 = byteAt(scriptHex, off + 6);
+                int b3 = byteAt(scriptHex, off + 8);
+                int pushLen = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+                off += 10 + pushLen * 2;
+            } else {
+                off += 2;
+            }
+        }
+        return out;
+    }
+
+    private static int byteAt(String hex, int pos) {
+        if (pos + 2 > hex.length()) return 0;
+        try {
+            return Integer.parseInt(hex.substring(pos, pos + 2), 16);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     /**

--- a/packages/runar-java/src/test/java/runar/lang/sdk/CodesepOffsetsTest.java
+++ b/packages/runar-java/src/test/java/runar/lang/sdk/CodesepOffsetsTest.java
@@ -1,0 +1,50 @@
+package runar.lang.sdk;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #42: terminal-method sighash subscript byte-walker.
+ *
+ * <p>The on-chain script trims its sighash subscript at the method's
+ * OP_CODESEPARATOR. {@link RunarContract#findCodesepOffsets(String)} must
+ * recover the true byte position by walking the script, correctly skipping
+ * push-data (which may itself contain a 0xab byte) and all BSV push opcodes.
+ */
+class CodesepOffsetsTest {
+
+    @Test
+    void returnsRealBytePositionSkippingPushData() {
+        // 51            OP_1
+        // 02 ab cd      push 2 bytes (0xab inside push-data, must be ignored)
+        // ab            OP_CODESEPARATOR  <- real, byte offset 4
+        // ac            OP_CHECKSIG
+        assertEquals(List.of(4), RunarContract.findCodesepOffsets("5102abcdabac"));
+    }
+
+    @Test
+    void handlesPushData1() {
+        // 4c (OP_PUSHDATA1) 02 (len) abab (data, contains 0xab) ab (real codesep)
+        assertEquals(List.of(4), RunarContract.findCodesepOffsets("4c02ababab"));
+    }
+
+    @Test
+    void trimsSubscriptAtRealCodesepBytePosition() {
+        String fullScript = "5102abcdabac"; // real codesep at byte index 4
+        List<Integer> offsets = RunarContract.findCodesepOffsets(fullScript);
+        assertEquals(List.of(4), offsets);
+        int codeSepIdx = offsets.get(0);
+        String subscript = fullScript.substring((codeSepIdx + 1) * 2);
+        // Only the OP_CHECKSIG (ac) after the separator remains.
+        assertEquals("ac", subscript);
+    }
+
+    @Test
+    void returnsEmptyWhenNoCodesep() {
+        assertEquals(List.of(),
+            RunarContract.findCodesepOffsets("76a914" + "00".repeat(20) + "88ac"));
+    }
+}

--- a/packages/runar-py/runar/sdk/contract.py
+++ b/packages/runar-py/runar/sdk/contract.py
@@ -330,8 +330,15 @@ class RunarContract:
         prepared = self.prepare_call(method_name, args, provider, signer, options)
         signatures: dict[int, str] = {}
         for idx in prepared.sig_indices:
-            # Stateful: user checkSig is AFTER OP_CODESEPARATOR — trim subscript
-            # Stateless: user checkSig is BEFORE — use full script
+            # Stateful contracts: checkPreimage is auto-injected at method entry,
+            # so the user checkSig executes AFTER the OP_CODESEPARATOR — the
+            # sighash must be computed over the subscript trimmed at that
+            # separator. Issue #42: the trim must land at the *real* on-chain
+            # codesep byte position, which _get_code_sep_index now recovers via
+            # _find_codesep_offsets.
+            # Stateless contracts: the user controls statement order and may
+            # place checkSig BEFORE the codesep (e.g. CovenantVault) — those must
+            # use the FULL script, so the trim stays gated on is_stateful.
             subscript = prepared.contract_utxo.script
             if prepared.is_stateful and prepared.code_sep_idx >= 0:
                 trim_pos = (prepared.code_sep_idx + 1) * 2
@@ -1303,7 +1310,32 @@ class RunarContract:
         return result
 
     def _get_code_sep_index(self, method_index: int) -> int:
-        """Get the adjusted code separator index for a method, or -1 if none."""
+        """Get the byte offset of an OP_CODESEPARATOR for a method, or -1 if none.
+
+        When ``_code_script`` is set (the contract is loaded from chain, or the
+        deploy script has already been built from real constructor args), walk
+        the actual script and return the true on-chain byte position. This is
+        required because ``from_txid`` populates constructor args with dummy
+        placeholders — the real arg bytes are already baked into the on-chain
+        locking script — so ``_adjust_code_sep_offset`` computes a shift of zero
+        and returns the wrong offset whenever the OP_CODESEPARATOR sits after
+        constructor slots that expand at deploy time (e.g. PubKey args = 1 → 34
+        bytes). The symptom of using the wrong offset is NULLFAIL at OP_CHECKSIG
+        for terminal methods.
+
+        Falls back to the legacy template-adjusted offset for synthetic /
+        unit-test paths that have no ``_code_script`` available.
+        """
+        if self._code_script:
+            if self.artifact.code_separator_indices:
+                real_offsets = _find_codesep_offsets(self._code_script)
+                if 0 <= method_index < len(self.artifact.code_separator_indices) and method_index < len(real_offsets):
+                    return real_offsets[method_index]
+            if self.artifact.code_separator_index is not None:
+                real_offsets = _find_codesep_offsets(self._code_script)
+                if real_offsets:
+                    return real_offsets[0]
+
         if self.artifact.code_separator_indices and 0 <= method_index < len(self.artifact.code_separator_indices):
             return self._adjust_code_sep_offset(self.artifact.code_separator_indices[method_index])
         if self.artifact.code_separator_index is not None:
@@ -1576,6 +1608,61 @@ def _build_named_args(user_params: list, resolved_args: list) -> dict:
         if i < len(resolved_args):
             result[param.name] = resolved_args[i]
     return result
+
+
+def _find_codesep_offsets(script_hex: str) -> list[int]:
+    """Walk a hex-encoded script and return the byte offsets of every
+    OP_CODESEPARATOR (0xab) that sits at a real opcode boundary (i.e. not inside
+    push-data). Correctly skips all BSV push opcodes (0x01..0x4b,
+    OP_PUSHDATA1/2/4).
+
+    Used by ``_get_code_sep_index`` to recover the true on-chain byte offsets
+    when the in-memory constructor args don't reflect what was actually baked
+    into the locking script (e.g. after ``from_txid`` populates dummy
+    placeholders).
+    """
+    out: list[int] = []
+    off = 0
+    n = len(script_hex)
+
+    def _b(i: int) -> int:
+        try:
+            return int(script_hex[i:i + 2], 16)
+        except ValueError:
+            return 0
+
+    while off + 2 <= n:
+        op = _b(off)
+        byte_pos = off // 2
+        if op == 0xAB:
+            out.append(byte_pos)
+            off += 2
+        elif 0x01 <= op <= 0x4B:
+            off += 2 + op * 2
+        elif op == 0x4C:
+            if off + 4 > n:
+                break
+            push_len = _b(off + 2)
+            off += 4 + push_len * 2
+        elif op == 0x4D:
+            if off + 6 > n:
+                break
+            lo = _b(off + 2)
+            hi = _b(off + 4)
+            push_len = lo | (hi << 8)
+            off += 6 + push_len * 2
+        elif op == 0x4E:
+            if off + 10 > n:
+                break
+            b0 = _b(off + 2)
+            b1 = _b(off + 4)
+            b2 = _b(off + 6)
+            b3 = _b(off + 8)
+            push_len = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+            off += 10 + push_len * 2
+        else:
+            off += 2
+    return out
 
 
 def _encode_script_number(n: int) -> str:

--- a/packages/runar-py/tests/test_codesep_offsets.py
+++ b/packages/runar-py/tests/test_codesep_offsets.py
@@ -1,0 +1,41 @@
+"""Issue #42: terminal-method sighash subscript byte-walker.
+
+The on-chain script trims its sighash subscript at the method's
+OP_CODESEPARATOR. ``_find_codesep_offsets`` must recover the true byte position
+by walking the script, correctly skipping push-data (which may itself contain a
+0xab byte) and all BSV push opcodes.
+"""
+
+from runar.sdk.contract import _find_codesep_offsets
+
+
+def test_find_codesep_offsets_real_byte_position():
+    # 51            OP_1
+    # 02 ab cd      push 2 bytes (0xab inside push-data, must be ignored)
+    # ab            OP_CODESEPARATOR  <- real, byte offset 4
+    # ac            OP_CHECKSIG
+    assert _find_codesep_offsets('5102abcdabac') == [4]
+
+
+def test_find_codesep_offsets_pushdata1():
+    # 4c (OP_PUSHDATA1) 02 (len) abab (data, contains 0xab) ab (real codesep)
+    assert _find_codesep_offsets('4c02ababab') == [4]
+
+
+def test_sighash_subscript_trimmed_at_real_codesep_byte_position():
+    # Issue #42: the user-sig subscript for a stateful terminal method
+    # (e.g. Auction.close) must be trimmed at the real on-chain codesep byte
+    # position recovered by _find_codesep_offsets — even when push-data contains
+    # a stray 0xab byte.
+    full_script = '5102abcdabac'  # real codesep at byte index 4
+    offsets = _find_codesep_offsets(full_script)
+    assert offsets == [4]
+    code_sep_idx = offsets[0]
+
+    subscript = full_script
+    if code_sep_idx >= 0:
+        trim_pos = (code_sep_idx + 1) * 2
+        if trim_pos <= len(subscript):
+            subscript = subscript[trim_pos:]
+    # Only the OP_CHECKSIG (ac) after the separator remains.
+    assert subscript == 'ac'

--- a/packages/runar-rb/lib/runar/sdk/contract.rb
+++ b/packages/runar-rb/lib/runar/sdk/contract.rb
@@ -275,6 +275,15 @@ module Runar
         prepared   = prepare_call(method_name, args, provider, signer, options)
         signatures = {}
         prepared.sig_indices.each do |idx|
+          # Stateful contracts: checkPreimage is auto-injected at method entry,
+          # so the user checkSig executes AFTER the OP_CODESEPARATOR — the
+          # sighash must be computed over the subscript trimmed at that
+          # separator. Issue #42: the trim must land at the *real* on-chain
+          # codesep byte position, which get_code_sep_index now recovers via
+          # find_codesep_offsets.
+          # Stateless contracts: the user controls statement order and may place
+          # checkSig BEFORE the codesep (e.g. CovenantVault) — those must use the
+          # FULL script, so the trim stays gated on is_stateful.
           subscript = prepared.contract_utxo.script
           if prepared.is_stateful && prepared.code_sep_idx >= 0
             trim_pos  = (prepared.code_sep_idx + 1) * 2
@@ -1433,7 +1442,30 @@ module Runar
         end
       end
 
+      # Get the byte offset of an OP_CODESEPARATOR for a method, or -1 if none.
+      #
+      # When @code_script is set (the contract is loaded from chain, or the
+      # deploy script has already been built from real constructor args), walk
+      # the actual script and return the true on-chain byte position. This is
+      # required because from_txid populates constructor args with dummy
+      # placeholders — the real arg bytes are already baked into the on-chain
+      # locking script — so adjust_code_sep_offset computes a shift of zero and
+      # returns the wrong offset whenever the OP_CODESEPARATOR sits after
+      # constructor slots that expand at deploy time (issue #42: NULLFAIL at
+      # OP_CHECKSIG for terminal methods).
+      #
+      # Falls back to the legacy template-adjusted offset for synthetic /
+      # unit-test paths that have no @code_script available.
       def get_code_sep_index(method_index)
+        unless @code_script.nil? || @code_script.empty?
+          indices = @artifact.code_separator_indices
+          real_offsets = find_codesep_offsets(@code_script)
+          if indices && method_index >= 0 && method_index < indices.length && method_index < real_offsets.length
+            return real_offsets[method_index]
+          end
+          return real_offsets.first if !@artifact.code_separator_index.nil? && !real_offsets.empty?
+        end
+
         indices = @artifact.code_separator_indices
         if indices && method_index >= 0 && method_index < indices.length
           return adjust_code_sep_offset(indices[method_index])
@@ -1443,6 +1475,58 @@ module Runar
         return -1 if base.nil?
 
         adjust_code_sep_offset(base)
+      end
+
+      # Walk a hex-encoded script and return the byte offsets of every
+      # OP_CODESEPARATOR (0xab) that sits at a real opcode boundary (i.e. not
+      # inside push-data). Correctly skips all BSV push opcodes (0x01..0x4b,
+      # OP_PUSHDATA1/2/4).
+      #
+      # Used by get_code_sep_index to recover the true on-chain byte offsets
+      # when the in-memory constructor args don't reflect what was actually
+      # baked into the locking script (e.g. after from_txid populates dummy
+      # placeholders).
+      def find_codesep_offsets(script_hex)
+        out = []
+        off = 0
+        n = script_hex.length
+        byte_at = lambda do |i|
+          (script_hex[i, 2] || '').to_i(16)
+        end
+        while off + 2 <= n
+          op = byte_at.call(off)
+          byte_pos = off / 2
+          if op == 0xAB
+            out << byte_pos
+            off += 2
+          elsif op >= 0x01 && op <= 0x4B
+            off += 2 + op * 2
+          elsif op == 0x4C
+            break if off + 4 > n
+
+            push_len = byte_at.call(off + 2)
+            off += 4 + push_len * 2
+          elsif op == 0x4D
+            break if off + 6 > n
+
+            lo = byte_at.call(off + 2)
+            hi = byte_at.call(off + 4)
+            push_len = lo | (hi << 8)
+            off += 6 + push_len * 2
+          elsif op == 0x4E
+            break if off + 10 > n
+
+            b0 = byte_at.call(off + 2)
+            b1 = byte_at.call(off + 4)
+            b2 = byte_at.call(off + 6)
+            b3 = byte_at.call(off + 8)
+            push_len = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+            off += 10 + push_len * 2
+          else
+            off += 2
+          end
+        end
+        out
       end
 
       def has_code_separator?

--- a/packages/runar-rb/spec/sdk/codesep_offsets_spec.rb
+++ b/packages/runar-rb/spec/sdk/codesep_offsets_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'runar/sdk'
+
+# Issue #42: terminal-method sighash subscript byte-walker.
+#
+# The on-chain script trims its sighash subscript at the method's
+# OP_CODESEPARATOR. #find_codesep_offsets must recover the true byte position by
+# walking the script, correctly skipping push-data (which may itself contain a
+# 0xab byte) and all BSV push opcodes.
+RSpec.describe Runar::SDK::RunarContract, '#find_codesep_offsets (issue #42)' do
+  let(:artifact_json) do
+    JSON.generate(
+      version: '1.0',
+      compilerVersion: '0.1.0',
+      contractName: 'Test',
+      abi: { constructor: { params: [] }, methods: [{ name: 'unlock', params: [], isPublic: true }] },
+      script: '51',
+      asm: '',
+      stateFields: [],
+      constructorSlots: []
+    )
+  end
+
+  let(:contract) do
+    described_class.new(Runar::SDK::RunarArtifact.from_json(artifact_json), [])
+  end
+
+  it 'returns the real byte position, skipping 0xab inside push-data' do
+    # 51            OP_1
+    # 02 ab cd      push 2 bytes (0xab inside push-data, must be ignored)
+    # ab            OP_CODESEPARATOR  <- real, byte offset 4
+    # ac            OP_CHECKSIG
+    expect(contract.send(:find_codesep_offsets, '5102abcdabac')).to eq([4])
+  end
+
+  it 'handles OP_PUSHDATA1' do
+    # 4c (OP_PUSHDATA1) 02 (len) abab (data, contains 0xab) ab (real codesep)
+    expect(contract.send(:find_codesep_offsets, '4c02ababab')).to eq([4])
+  end
+
+  it 'trims the subscript at the real codesep byte position' do
+    full_script = '5102abcdabac' # real codesep at byte index 4
+    offsets = contract.send(:find_codesep_offsets, full_script)
+    expect(offsets).to eq([4])
+    code_sep_idx = offsets.first
+    trim_pos = (code_sep_idx + 1) * 2
+    subscript = full_script[trim_pos..]
+    # Only the OP_CHECKSIG (ac) after the separator remains.
+    expect(subscript).to eq('ac')
+  end
+
+  it 'returns empty for a script with no OP_CODESEPARATOR' do
+    expect(contract.send(:find_codesep_offsets, "76a914#{'00' * 20}88ac")).to eq([])
+  end
+end

--- a/packages/runar-rs/src/sdk/contract.rs
+++ b/packages/runar-rs/src/sdk/contract.rs
@@ -424,8 +424,15 @@ impl RunarContract {
         let mut signatures = HashMap::new();
         let contract_utxo = prepared.contract_utxo.clone();
         for &idx in &prepared.sig_indices {
-            // Stateful: user checkSig is AFTER OP_CODESEPARATOR — trim subscript.
-            // Stateless: user checkSig is BEFORE — use full script.
+            // Stateful contracts: checkPreimage is auto-injected at method
+            // entry, so the user checkSig executes AFTER the OP_CODESEPARATOR —
+            // the sighash must be computed over the subscript trimmed at that
+            // separator. Issue #42: the trim must land at the *real* on-chain
+            // codesep byte position, which `get_code_sep_index` now recovers via
+            // `find_codesep_offsets`.
+            // Stateless contracts: the user controls statement order and may
+            // place checkSig BEFORE the codesep (e.g. CovenantVault) — those
+            // must use the FULL script, so the trim stays gated on `is_stateful`.
             let mut subscript = contract_utxo.script.clone();
             if prepared.is_stateful && prepared.code_sep_idx >= 0 {
                 let trim_pos = ((prepared.code_sep_idx as usize) + 1) * 2;
@@ -1762,8 +1769,37 @@ impl RunarContract {
         result
     }
 
-    /// Get the adjusted code separator index for a method.
+    /// Get the byte offset of an `OP_CODESEPARATOR` for a given method index.
+    ///
+    /// When `code_script` is set (i.e., the contract is loaded from chain, OR
+    /// the deploy script has already been built from real constructor args),
+    /// we walk the actual script and return the true on-chain byte position.
+    /// This is required because `from_txid` populates `constructor_args` with
+    /// dummy `SdkValue::Int(0)` placeholders — the real arg bytes are already
+    /// baked into the on-chain locking script — so `adjust_code_sep_offset()`
+    /// computes a shift of zero and returns the wrong offset whenever the
+    /// `OP_CODESEPARATOR` sits after constructor slots that expand at deploy
+    /// time (e.g. PubKey args = 1 → 34 bytes). The symptom of using the wrong
+    /// offset is NULLFAIL at `OP_CHECKSIG` for terminal methods.
+    ///
+    /// Falls back to the legacy template-adjusted offset for synthetic /
+    /// unit-test paths that have no `code_script` available.
     fn get_code_sep_index(&self, method_index: usize) -> i64 {
+        if let Some(ref code_script) = self.code_script {
+            if let Some(ref indices) = self.artifact.code_separator_indices {
+                let real_offsets = find_codesep_offsets(code_script);
+                if method_index < indices.len() && method_index < real_offsets.len() {
+                    return real_offsets[method_index] as i64;
+                }
+            }
+            if self.artifact.code_separator_index.is_some() {
+                let real_offsets = find_codesep_offsets(code_script);
+                if let Some(&off) = real_offsets.first() {
+                    return off as i64;
+                }
+            }
+        }
+
         if let Some(ref indices) = self.artifact.code_separator_indices {
             if method_index < indices.len() {
                 return self.adjust_code_sep_offset(indices[method_index]) as i64;
@@ -1801,6 +1837,51 @@ impl RunarContract {
 // ---------------------------------------------------------------------------
 // Encoding helpers
 // ---------------------------------------------------------------------------
+
+/// Walk a hex-encoded script and return the byte offsets of every
+/// `OP_CODESEPARATOR` (`0xab`) that sits at a real opcode boundary
+/// (i.e., not inside push-data).
+///
+/// Used by `get_code_sep_index` to recover the true on-chain byte offsets
+/// when the in-memory constructor args don't reflect what was actually
+/// baked into the locking script (e.g. after `from_txid` populates dummy
+/// `Int(0)` placeholders).
+fn find_codesep_offsets(script_hex: &str) -> Vec<usize> {
+    let mut out = Vec::new();
+    let mut off = 0usize;
+    let len = script_hex.len();
+    while off + 2 <= len {
+        let op = u8::from_str_radix(&script_hex[off..off + 2], 16).unwrap_or(0);
+        let byte_pos = off / 2;
+        if op == 0xab {
+            out.push(byte_pos);
+            off += 2;
+        } else if (0x01..=0x4b).contains(&op) {
+            off += 2 + (op as usize) * 2;
+        } else if op == 0x4c {
+            if off + 4 > len { break; }
+            let push_len = u8::from_str_radix(&script_hex[off + 2..off + 4], 16).unwrap_or(0) as usize;
+            off += 4 + push_len * 2;
+        } else if op == 0x4d {
+            if off + 6 > len { break; }
+            let lo = u8::from_str_radix(&script_hex[off + 2..off + 4], 16).unwrap_or(0) as usize;
+            let hi = u8::from_str_radix(&script_hex[off + 4..off + 6], 16).unwrap_or(0) as usize;
+            let push_len = lo | (hi << 8);
+            off += 6 + push_len * 2;
+        } else if op == 0x4e {
+            if off + 10 > len { break; }
+            let b0 = u8::from_str_radix(&script_hex[off + 2..off + 4], 16).unwrap_or(0) as usize;
+            let b1 = u8::from_str_radix(&script_hex[off + 4..off + 6], 16).unwrap_or(0) as usize;
+            let b2 = u8::from_str_radix(&script_hex[off + 6..off + 8], 16).unwrap_or(0) as usize;
+            let b3 = u8::from_str_radix(&script_hex[off + 8..off + 10], 16).unwrap_or(0) as usize;
+            let push_len = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+            off += 10 + push_len * 2;
+        } else {
+            off += 2;
+        }
+    }
+    out
+}
 
 /// Extract all input outpoints from a raw tx hex as a concatenated hex string.
 /// Each outpoint is txid (32 bytes LE) + vout (4 bytes LE) = 36 bytes.
@@ -3416,5 +3497,55 @@ mod tests {
         assert!(json_str.contains(r#""p":"bsv-20""#));
         assert!(json_str.contains(r#""op":"deploy""#));
         assert!(json_str.contains(r#""tick":"RUNAR""#));
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #42: terminal-method sighash subscript byte-walker
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn find_codesep_offsets_returns_real_byte_position() {
+        // Push-data contains a 0xab byte that MUST be skipped; only the real
+        // OP_CODESEPARATOR at an opcode boundary should be reported:
+        //   51            OP_1
+        //   02 ab cd      push 2 bytes (0xab inside push-data, must be ignored)
+        //   ab            OP_CODESEPARATOR  <- real, byte offset 4
+        //   ac            OP_CHECKSIG
+        let script = "5102abcdabac";
+        let offsets = find_codesep_offsets(script);
+        assert_eq!(offsets, vec![4], "must find only the real OP_CODESEPARATOR, skipping push-data");
+    }
+
+    #[test]
+    fn find_codesep_offsets_handles_pushdata1() {
+        // 4c (OP_PUSHDATA1) 02 (len) abab (data, contains 0xab) ab (real codesep)
+        let script = "4c02ababab";
+        let offsets = find_codesep_offsets(script);
+        // OP_PUSHDATA1 consumes bytes 0..3 (4c 02 ab ab), real codesep at byte 4.
+        assert_eq!(offsets, vec![4]);
+    }
+
+    #[test]
+    fn sighash_subscript_trimmed_at_real_codesep_byte_position() {
+        // Issue #42 root cause: the user-sig subscript for a stateful terminal
+        // method (e.g. Auction.close) must be trimmed at the *real* on-chain
+        // OP_CODESEPARATOR byte position. The byte-walker recovers it correctly
+        // even when push-data contains a stray 0xab byte that a naive scan would
+        // mistake for the separator.
+        let full_script = "5102abcdabac"; // real codesep at byte index 4
+        let code_sep_idx: i64 = *find_codesep_offsets(full_script).first().unwrap() as i64;
+        assert_eq!(code_sep_idx, 4);
+
+        // Replicate the trim used before signing (gated on is_stateful at the
+        // call site; here we exercise the offset arithmetic only).
+        let mut subscript = full_script.to_string();
+        if code_sep_idx >= 0 {
+            let trim_pos = ((code_sep_idx as usize) + 1) * 2;
+            if trim_pos <= subscript.len() {
+                subscript = subscript[trim_pos..].to_string();
+            }
+        }
+        // Only the OP_CHECKSIG (ac) after the separator remains.
+        assert_eq!(subscript, "ac");
     }
 }

--- a/packages/runar-sdk/src/__tests__/codesep-offsets.test.ts
+++ b/packages/runar-sdk/src/__tests__/codesep-offsets.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #42: terminal-method sighash subscript byte-walker.
+ *
+ * The on-chain script trims its sighash subscript at the method's
+ * OP_CODESEPARATOR. `findCodesepOffsets` must recover the true byte position by
+ * walking the script, correctly skipping push-data (which may itself contain a
+ * 0xab byte) and all BSV push opcodes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { findCodesepOffsets } from '../contract.js';
+
+describe('findCodesepOffsets (issue #42)', () => {
+  it('returns the real byte position, skipping 0xab inside push-data', () => {
+    // 51            OP_1
+    // 02 ab cd      push 2 bytes (0xab inside push-data, must be ignored)
+    // ab            OP_CODESEPARATOR  <- real, byte offset 4
+    // ac            OP_CHECKSIG
+    expect(findCodesepOffsets('5102abcdabac')).toEqual([4]);
+  });
+
+  it('handles OP_PUSHDATA1', () => {
+    // 4c (OP_PUSHDATA1) 02 (len) abab (data, contains 0xab) ab (real codesep)
+    expect(findCodesepOffsets('4c02ababab')).toEqual([4]);
+  });
+
+  it('trims the subscript at the real codesep byte position', () => {
+    const fullScript = '5102abcdabac'; // real codesep at byte index 4
+    const offsets = findCodesepOffsets(fullScript);
+    expect(offsets).toEqual([4]);
+    const codeSepIdx = offsets[0]!;
+    const subscript = fullScript.slice((codeSepIdx + 1) * 2);
+    // Only the OP_CHECKSIG (ac) after the separator remains.
+    expect(subscript).toBe('ac');
+  });
+
+  it('returns empty for a script with no OP_CODESEPARATOR', () => {
+    expect(findCodesepOffsets('76a91400000000000000000000000000000000000000000088ac')).toEqual([]);
+  });
+});

--- a/packages/runar-sdk/src/contract.ts
+++ b/packages/runar-sdk/src/contract.ts
@@ -32,6 +32,57 @@ function invalidateTxCache(tx: BsvTransaction): void {
 }
 
 /**
+ * Walk a hex-encoded script and return the byte offsets of every
+ * OP_CODESEPARATOR (0xab) that sits at a real opcode boundary (i.e. not inside
+ * push-data). Correctly skips all BSV push opcodes (0x01..0x4b,
+ * OP_PUSHDATA1/2/4).
+ *
+ * Used by getSubscriptForSigning to recover the true on-chain byte offsets when
+ * the in-memory constructor args don't reflect what was actually baked into the
+ * locking script (e.g. after fromTxid populates dummy placeholders).
+ */
+export function findCodesepOffsets(scriptHex: string): number[] {
+  const out: number[] = [];
+  let off = 0;
+  const n = scriptHex.length;
+  const b = (i: number): number => {
+    const v = parseInt(scriptHex.slice(i, i + 2), 16);
+    return Number.isNaN(v) ? 0 : v;
+  };
+  while (off + 2 <= n) {
+    const op = b(off);
+    const bytePos = off / 2;
+    if (op === 0xab) {
+      out.push(bytePos);
+      off += 2;
+    } else if (op >= 0x01 && op <= 0x4b) {
+      off += 2 + op * 2;
+    } else if (op === 0x4c) {
+      if (off + 4 > n) break;
+      const pushLen = b(off + 2);
+      off += 4 + pushLen * 2;
+    } else if (op === 0x4d) {
+      if (off + 6 > n) break;
+      const lo = b(off + 2);
+      const hi = b(off + 4);
+      const pushLen = lo | (hi << 8);
+      off += 6 + pushLen * 2;
+    } else if (op === 0x4e) {
+      if (off + 10 > n) break;
+      const b0 = b(off + 2);
+      const b1 = b(off + 4);
+      const b2 = b(off + 6);
+      const b3 = b(off + 8);
+      const pushLen = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+      off += 10 + pushLen * 2;
+    } else {
+      off += 2;
+    }
+  }
+  return out;
+}
+
+/**
  * Runtime wrapper for a compiled Runar contract.
  *
  * Handles deployment, method invocation, state tracking, and script
@@ -451,9 +502,14 @@ export class RunarContract {
     const prepared = await this.prepareCall(methodName, args, options);
     const signer = this._signer!;
 
-    // In stateful contracts, user checkSig executes AFTER OP_CODESEPARATOR
-    // (checkPreimage is auto-injected at method entry), so use trimmed script.
-    // In stateless contracts, user checkSig is BEFORE OP_CODESEPARATOR, so use full script.
+    // Stateful contracts: checkPreimage is auto-injected at method entry, so
+    // the user checkSig executes AFTER the OP_CODESEPARATOR — the sighash must
+    // be computed over the subscript trimmed at that separator (issue #42: the
+    // trim must land at the *real* on-chain codesep byte position, recovered by
+    // getSubscriptForSigning's byte-walker).
+    // Stateless contracts: the user controls statement order and may place
+    // checkSig BEFORE the codesep (e.g. CovenantVault) — those must use the
+    // FULL script, so the trim stays gated on `_isStateful`.
     let mIdx = 0;
     if (prepared._isStateful) {
       const pubMethods = this.artifact.abi.methods.filter((m) => m.isPublic);
@@ -1480,10 +1536,39 @@ export class RunarContract {
 
   /**
    * Get the subscript trimmed at the OP_CODESEPARATOR for a given method.
-   * Used for BIP-143 sighash computation for user CHECKSIG in stateful contracts
-   * (where checkSig executes AFTER OP_CODESEPARATOR).
+   * Used for BIP-143 sighash computation for the user CHECKSIG whenever the
+   * script contains an OP_CODESEPARATOR before it (per BIP-143 / BSV consensus,
+   * for stateful AND terminal methods alike). Returns the full script unchanged
+   * when no OP_CODESEPARATOR is present.
+   *
+   * When `_codeScript` is set (the contract is loaded from chain, or the deploy
+   * script has already been built from real constructor args), walk the actual
+   * script and trim at the true on-chain byte position. This is required
+   * because `fromTxid` populates constructorArgs with dummy placeholders — the
+   * real arg bytes are already baked into the on-chain locking script — so
+   * `adjustCodeSepOffset` computes a shift of zero and returns the wrong offset
+   * whenever the OP_CODESEPARATOR sits after constructor slots that expand at
+   * deploy time. The symptom of using the wrong offset is NULLFAIL at
+   * OP_CHECKSIG for terminal methods.
    */
   private getSubscriptForSigning(fullScript: string, methodIndex?: number): string {
+    if (this._codeScript !== null) {
+      const realOffsets = findCodesepOffsets(this._codeScript);
+      if (realOffsets.length > 0) {
+        const indices = this.artifact.codeSeparatorIndices;
+        let off: number | undefined;
+        if (indices && methodIndex !== undefined && methodIndex < indices.length
+            && methodIndex < realOffsets.length) {
+          off = realOffsets[methodIndex];
+        } else if (this.artifact.codeSeparatorIndex !== undefined) {
+          off = realOffsets[0];
+        }
+        if (off !== undefined) {
+          return fullScript.slice((off + 1) * 2);
+        }
+      }
+    }
+
     const indices = this.artifact.codeSeparatorIndices;
     let codeSepIdx: number | undefined;
     if (indices && methodIndex !== undefined && methodIndex < indices.length) {

--- a/packages/runar-zig/src/sdk_contract.zig
+++ b/packages/runar-zig/src/sdk_contract.zig
@@ -2582,7 +2582,35 @@ pub const RunarContract = struct {
 
     /// getCodeSepIndex returns the adjusted code separator byte offset for a
     /// given method index, or null if no OP_CODESEPARATOR is present.
+    /// getCodeSepIndex returns the byte offset of an OP_CODESEPARATOR for the
+    /// given method index, or null if none is present.
+    ///
+    /// When code_script is set (the contract is loaded from chain, or the deploy
+    /// script has already been built from real constructor args), walk the
+    /// actual script and return the true on-chain byte position. This is
+    /// required because fromTxid populates constructor args with dummy
+    /// placeholders — the real arg bytes are already baked into the on-chain
+    /// locking script — so adjustCodeSepOffset computes a shift of zero and
+    /// returns the wrong offset whenever the OP_CODESEPARATOR sits after
+    /// constructor slots that expand at deploy time (issue #42: NULLFAIL at
+    /// OP_CHECKSIG for terminal methods).
+    ///
+    /// Falls back to the legacy template-adjusted offset for synthetic /
+    /// unit-test paths that have no code_script available.
     pub fn getCodeSepIndex(self: *const RunarContract, method_index: usize) !?i32 {
+        if (self.code_script) |cs| {
+            const real_offsets = try findCodesepOffsets(self.allocator, cs);
+            defer self.allocator.free(real_offsets);
+            if (self.artifact.code_separator_indices.len > 0) {
+                if (method_index < self.artifact.code_separator_indices.len and method_index < real_offsets.len) {
+                    return real_offsets[method_index];
+                }
+            }
+            if (self.artifact.code_separator_index != null and real_offsets.len > 0) {
+                return real_offsets[0];
+            }
+        }
+
         if (self.artifact.code_separator_indices.len > 0 and method_index < self.artifact.code_separator_indices.len) {
             return try self.adjustCodeSepOffset(self.artifact.code_separator_indices[method_index]);
         }
@@ -2888,6 +2916,52 @@ fn hexNibble(c: u8) u4 {
     };
 }
 
+/// Walk a hex-encoded script and return the byte offsets of every
+/// OP_CODESEPARATOR (0xab) that sits at a real opcode boundary (i.e. not inside
+/// push-data). Correctly skips all BSV push opcodes (0x01..0x4b,
+/// OP_PUSHDATA1/2/4). Caller owns the returned slice.
+///
+/// Used by getCodeSepIndex to recover the true on-chain byte offsets when the
+/// in-memory constructor args don't reflect what was actually baked into the
+/// locking script (e.g. after fromTxid populates dummy placeholders).
+pub fn findCodesepOffsets(allocator: std.mem.Allocator, script_hex: []const u8) ![]i32 {
+    var out: std.ArrayListUnmanaged(i32) = .empty;
+    errdefer out.deinit(allocator);
+    var off: usize = 0;
+    const n = script_hex.len;
+    while (off + 2 <= n) {
+        const op = hexByteAt(script_hex, off);
+        const byte_pos: i32 = @intCast(off / 2);
+        if (op == 0xab) {
+            try out.append(allocator, byte_pos);
+            off += 2;
+        } else if (op >= 0x01 and op <= 0x4b) {
+            off += 2 + op * 2;
+        } else if (op == 0x4c) {
+            if (off + 4 > n) break;
+            const push_len = hexByteAt(script_hex, off + 2);
+            off += 4 + push_len * 2;
+        } else if (op == 0x4d) {
+            if (off + 6 > n) break;
+            const lo = hexByteAt(script_hex, off + 2);
+            const hi = hexByteAt(script_hex, off + 4);
+            const push_len = lo | (hi << 8);
+            off += 6 + push_len * 2;
+        } else if (op == 0x4e) {
+            if (off + 10 > n) break;
+            const b0 = hexByteAt(script_hex, off + 2);
+            const b1 = hexByteAt(script_hex, off + 4);
+            const b2 = hexByteAt(script_hex, off + 6);
+            const b3 = hexByteAt(script_hex, off + 8);
+            const push_len = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+            off += 10 + push_len * 2;
+        } else {
+            off += 2;
+        }
+    }
+    return out.toOwnedSlice(allocator);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -2909,6 +2983,39 @@ test "RunarContract.init and getLockingScript for stateless contract" {
     defer allocator.free(ls);
     // Stateless with no constructor slots appends args: "76a914" + push("aabbccdd") = "76a914" + "04aabbccdd"
     try std.testing.expect(std.mem.startsWith(u8, ls, "76a914"));
+}
+
+// Issue #42: terminal-method sighash subscript byte-walker.
+test "findCodesepOffsets returns real byte position, skipping push-data" {
+    const allocator = std.testing.allocator;
+    // 51            OP_1
+    // 02 ab cd      push 2 bytes (0xab inside push-data, must be ignored)
+    // ab            OP_CODESEPARATOR  <- real, byte offset 4
+    // ac            OP_CHECKSIG
+    const offsets = try findCodesepOffsets(allocator, "5102abcdabac");
+    defer allocator.free(offsets);
+    try std.testing.expectEqual(@as(usize, 1), offsets.len);
+    try std.testing.expectEqual(@as(i32, 4), offsets[0]);
+}
+
+test "findCodesepOffsets handles OP_PUSHDATA1" {
+    const allocator = std.testing.allocator;
+    // 4c (OP_PUSHDATA1) 02 (len) abab (data, contains 0xab) ab (real codesep)
+    const offsets = try findCodesepOffsets(allocator, "4c02ababab");
+    defer allocator.free(offsets);
+    try std.testing.expectEqual(@as(usize, 1), offsets.len);
+    try std.testing.expectEqual(@as(i32, 4), offsets[0]);
+}
+
+test "findCodesepOffsets trims subscript at real codesep byte position" {
+    const allocator = std.testing.allocator;
+    const full_script = "5102abcdabac"; // real codesep at byte index 4
+    const offsets = try findCodesepOffsets(allocator, full_script);
+    defer allocator.free(offsets);
+    try std.testing.expectEqual(@as(i32, 4), offsets[0]);
+    const hex_offset: usize = @intCast((@as(usize, @intCast(offsets[0])) + 1) * 2);
+    const subscript = full_script[hex_offset..];
+    try std.testing.expectEqualStrings("ac", subscript);
 }
 
 test "RunarContract.init and getLockingScript for stateful contract" {


### PR DESCRIPTION
## Summary

Terminal methods on `StatefulSmartContract` subclasses (e.g. `Auction.close`) produced a BIP-143 user-sig sighash whose subscript did not match what the on-chain script hashes at validation, failing `CHECKSIG` with NULLFAIL on mainnet ARC broadcasters.

Root cause: the code-separator index lookup fell back to a template-adjusted offset (`adjustCodeSepOffset`) that is wrong for contracts reconnected from chain or deployed from real constructor args — the real arg bytes are already baked into the on-chain locking script, so the adjustment computes a zero shift and the subscript gets trimmed at the wrong byte.

Fix (all seven tiers): a byte-walker `findCodesepOffsets` walks the actual on-chain locking script byte-by-byte, correctly handling every BSV push opcode (`0x01..0x4b`, `OP_PUSHDATA1/2/4`), and returns the true byte position of each `OP_CODESEPARATOR`. `getCodeSepIndex` now uses it whenever a live on-chain script is available, falling back to the legacy adjusted offset only for synthetic/unit-test paths.

Credit: the reference Rust fix was authored by **Elis Jackson** (PR #43). This PR re-applies it by hand and ports the same logical fix to the other six tiers. **Supersedes #43.**

`Closes #42`

## Per-tier status

| Tier | Trim condition | Byte-walker | Test (TDD) | Suite result |
|------|----------------|-------------|------------|--------------|
| TypeScript | `_isStateful` (kept) | `findCodesepOffsets` | `codesep-offsets.test.ts` (4) | 420 passed / 2 skipped |
| Go | `isStateful` (kept) | `findCodesepOffsets` | `sdk_codesep_offsets_test.go` (3) | `go test ./...` ok |
| Rust | `is_stateful` (kept) | `find_codesep_offsets` | 3 unit tests | 388+ passed |
| Python | `is_stateful` (kept) | `_find_codesep_offsets` | `test_codesep_offsets.py` (3) | 513 passed / 2 skipped |
| Zig | gated upstream (kept) | `findCodesepOffsets` | 3 unit tests | 208 passed |
| Ruby | `is_stateful` (kept) | `find_codesep_offsets` | `codesep_offsets_spec.rb` (4) | 923 examples, 0 failures |
| Java | `codeSepIdx >= 0` (pre-existing, unchanged) | `findCodesepOffsets` | `CodesepOffsetsTest.java` (4) | BUILD SUCCESSFUL |

## Divergences from PR #43

1. **`is_stateful` trim gate retained (intentional).** PR #43 also dropped the `is_stateful` term from the subscript-trim condition. That regresses **stateless covenant contracts** whose user `checkSig` executes *before* the `OP_CODESEPARATOR` (e.g. `examples/ts/covenant-vault/CovenantVault.runar.ts`, where `checkSig(sig, owner)` precedes `checkPreimage`). For those, the user sig must hash the **full** script; trimming at the codesep yields a wrong sighash. The BSV rule is "OP_CHECKSIG uses the subscript from the most recent codesep *executed so far*" — for stateless contracts the codesep hasn't executed yet at the user checkSig. `is_stateful` is the correct proxy ("checkPreimage is auto-injected at method entry, so user checkSig always runs after the codesep"). For the `Auction.close` case `is_stateful` is already `true`, so dropping it was a no-op for the reported bug; **part 2 (the byte-walker) is the real fix**. Keeping the gate is strictly safer with no downside for the reported case.

2. **Java trim condition unchanged.** Java's `runPushTxCall` already trims the user-sig subscript whenever `codeSepIdx >= 0` (not gated on `isStateful`) — pre-existing behavior. This carries the same stateless-covenant risk as #43's change, but altering it is out of scope for #42 and risks Java's currently-passing tests. Left as-is and flagged here for a follow-up.

## Verification honesty

- Local test suites (above) all pass; the byte-walker is covered failing-first per tier.
- The unit/integration suites and the `ScriptVM` wrappers do **not** validate the actual BIP-143 user-sig sighash against real on-chain CHECKSIG (MockProvider doesn't run consensus; ScriptVM's checkSig is mocked). The ground-truth validation of the fix is the on-chain mainnet broadcast cited in #42. The byte-walker correctness (the substantive logic) is fully unit-tested.

## Test plan

- [ ] CI: TS vitest, Go `go test ./...`, Rust `cargo test`, Python pytest, Zig `zig build test`, Ruby `bundle exec rspec`, Java `gradle test`
- [ ] Confirm SDK-output + cross-tier conformance unaffected (no locking-script generation changed)
- [ ] Maintainer review of divergence #1 (keep `is_stateful` gate) and #2 (Java follow-up)