### PR TITLE
ci: harden integration oracle to mainnet ARC standardness (acceptnonstdtxn=0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1003,7 +1003,14 @@ jobs:
             'maxscriptnumlengthpolicy=0' 'maxstackmemoryusagepolicy=100000000' \
             'maxtxsizepolicy=0' 'genesisactivationheight=1' 'chronicleactivationheight=1' \
             'minminingtxfee=0.00000001' \
+            'acceptnonstdtxn=0' \
             > integration/regtest-data/n1/bitcoin.conf
+          # acceptnonstdtxn=0 hardens the CI oracle (issues #40/#42/#44): with
+          # genesisactivationheight=1 the node enforces post-Genesis script-verify
+          # standardness (CLEANSTACK, NULLFAIL, NULLDUMMY, minimal-push) at
+          # sendrawtransaction acceptance — matching mainnet ARC. Large post-Genesis
+          # scripts (SLH-DSA/Schnorr) stay acceptable. Keep in sync with
+          # integration/regtest.sh.
 
       - name: Start BSV regtest node
         run: cd integration && ./regtest.sh start

--- a/integration/regtest.sh
+++ b/integration/regtest.sh
@@ -97,6 +97,14 @@ maxtxsizepolicy=0
 genesisactivationheight=1
 chronicleactivationheight=1
 minminingtxfee=0.00000001
+# Oracle hardening (issues #40/#42/#44): enforce post-Genesis script-verify
+# standardness at mempool acceptance so sendrawtransaction rejects exactly what
+# mainnet ARC broadcasters reject — CLEANSTACK, NULLFAIL, NULLDUMMY,
+# minimal-push. bitcoin-sv defaults acceptnonstdtxn to TRUE on regtest, which
+# let CLEANSTACK/NULLFAIL bugs (#42, #44) pass green CI while failing on mainnet.
+# genesisactivationheight=1 (above) keeps post-Genesis rules, so large scripts
+# (SLH-DSA/Schnorr) remain acceptable while the script-verify flags are enforced.
+acceptnonstdtxn=0
 zmqpubhashblock=tcp://*:$ZMQ_PORT
 zmqpubhashtx=tcp://*:$ZMQ_PORT
 zmqpubdiscardedfrommempool=tcp://*:$ZMQ_PORT


### PR DESCRIPTION
## Summary
Makes the integration CI oracle as strict as mainnet ARC broadcasters, so "regtest-green" means "ARC-green". One-line policy change in both config sites (`integration/regtest.sh` for local runs, `.github/workflows/ci.yml` for CI, which pre-writes its own `bitcoin.conf`).

## Root cause (the gap behind #40/#42/#44)
Integration tests broadcast via `sendrawtransaction` (mempool acceptance) — `packages/runar-rs/src/sdk/rpc_provider.rs:148`, Go `helpers/rpc.go`. But the regtest node had **no `acceptnonstdtxn` setting**, and bitcoin-sv defaults it to *accept non-standard* on regtest. So script-verify **standardness** (CLEANSTACK, NULLFAIL, NULLDUMMY, minimal-push) was never enforced. Those exact rules are what mainnet ARC enforces — and what caught:
- **#42** terminal-method sighash → `NULLFAIL` (arc error 461)
- **#44** all-readonly stateful → `CLEANSTACK` ("did not clean its stack")

Both passed green CI and failed only on mainnet. They were found by an external contributor broadcasting real transactions, not by us.

## Fix
`acceptnonstdtxn=0`. With `genesisactivationheight=1` (already set), the node enforces **post-Genesis** script-verify standardness at mempool acceptance — matching mainnet ARC — while large post-Genesis scripts (SLH-DSA 188 KB, Schnorr-ZKP 877 KB) remain acceptable.

## ⚠️ Sequencing — this must land AFTER (or with) the fixes
This is the oracle finally doing its job, so on **unfixed** code it will turn the affected integration tests **red** — that is the intended signal. It should merge after / alongside:
- #46 (issue #40 locktime), #47 (issue #42 sighash), #48 (issue #44 cleanstack)

Merging this before them will (correctly) fail CI.

## Validation still needed (not done locally — requires the Docker node)
CI on this branch (stacked on the fix PRs) must confirm:
1. The #42 / #44 bug shapes are now **rejected** at `sendrawtransaction` on unfixed code (oracle bites), and **accepted** once fixed.
2. Legitimate large-script contracts (SLH-DSA, Schnorr-ZKP, WOTS+) still **pass** under `acceptnonstdtxn=0` + post-Genesis. If any legitimately-large contract is rejected, the standardness flag set needs tuning (the goal is the script-verify flags, not datacarrier/size limits).

I did not spin up the regtest node locally (heavy/shared); CI is the right validator here.

## Recommended follow-ups (separate PRs)
- Remove the `deadline=0` workaround in `integration/rust/tests/auction.rs:117,122,159` once #40 lands, so the terminal path is actually exercised against the strict oracle.
- Add targeted `AssertTxRejected` regression tests (the harness exists at `integration/go/helpers/assert.go`) for the #42/#44 shapes, so the gap can never silently reopen.