### PR TITLE
fix: carry parentClass in artifact so terminal sighash trim fires for zero-mutable-field stateful contracts (7 compilers + 7 SDKs)

### DIFF
--- a/compilers/go/compiler/compiler.go
+++ b/compilers/go/compiler/compiler.go
@@ -104,6 +104,7 @@ type Artifact struct {
 	Version                string            `json:"version"`
 	CompilerVersion        string            `json:"compilerVersion"`
 	ContractName           string            `json:"contractName"`
+	ParentClass            string            `json:"parentClass,omitempty"`
 	ABI                    ABI               `json:"abi"`
 	Script                 string            `json:"script"`
 	ASM                    string            `json:"asm"`
@@ -321,6 +322,7 @@ func assembleArtifact(program *ir.ANFProgram, scriptHex, scriptAsm string, const
 		Version:         schemaVersion,
 		CompilerVersion: compilerVersion,
 		ContractName:    program.ContractName,
+		ParentClass:     program.ParentClass,
 		ABI: ABI{
 			Constructor: ABIConstructor{Params: constructorParams},
 			Methods:     methods,

--- a/compilers/go/frontend/anf_lower.go
+++ b/compilers/go/frontend/anf_lower.go
@@ -30,6 +30,7 @@ func LowerToANF(contract *ContractNode) *ir.ANFProgram {
 		ContractName: contract.Name,
 		Properties:   properties,
 		Methods:      methods,
+		ParentClass:  contract.ParentClass,
 	}
 }
 

--- a/compilers/go/ir/types.go
+++ b/compilers/go/ir/types.go
@@ -18,6 +18,15 @@ type ANFProgram struct {
 	ContractName string        `json:"contractName"`
 	Properties   []ANFProperty `json:"properties"`
 	Methods      []ANFMethod   `json:"methods"`
+	// ParentClass is the base class the source contract extends
+	// ("SmartContract" | "StatefulSmartContract" | "UnsafeSmartContract").
+	// It is an in-memory carrier ONLY (json:"-") so it never appears in the
+	// emitted ANF IR JSON that the conformance suite compares cross-tier.
+	// The artifact assembler copies it to the top-level artifact field so
+	// SDKs can gate the issue-#42/#44 terminal sighash subscript trim on the
+	// authoritative parent class (a StatefulSmartContract with zero mutable
+	// fields still needs the trim even though stateFields is empty).
+	ParentClass string `json:"-"`
 }
 
 // ANFSyntheticArrayLevel is one level of the synthetic FixedArray chain

--- a/compilers/python/runar_compiler/__main__.py
+++ b/compilers/python/runar_compiler/__main__.py
@@ -217,6 +217,9 @@ _IR_EXCLUDED_FIELDS = frozenset({
     # Python-only metadata used internally by expand_fixed_arrays.
     # Other compilers don't emit this field in --emit-ir output.
     "synthetic_array_chain",
+    # In-memory carrier for the artifact's top-level parentClass field.
+    # Excluded from --emit-ir so it never affects cross-tier ANF parity.
+    "parent_class",
 })
 
 

--- a/compilers/python/runar_compiler/compiler.py
+++ b/compilers/python/runar_compiler/compiler.py
@@ -84,6 +84,10 @@ class Artifact:
     version: str = ""
     compiler_version: str = ""
     contract_name: str = ""
+    # Base class the source contract extends. Authoritative stateful signal
+    # for the issue-#42/#44 terminal sighash subscript trim (a
+    # StatefulSmartContract with zero mutable fields still needs the trim).
+    parent_class: str = ""
     abi: ABI = field(default_factory=ABI)
     script: str = ""
     asm: str = ""
@@ -588,6 +592,7 @@ def _assemble_artifact(
         version=SCHEMA_VERSION,
         compiler_version=COMPILER_VERSION,
         contract_name=program.contract_name,
+        parent_class=program.parent_class,
         abi=ABI(
             constructor=ABIConstructor(params=constructor_params),
             methods=methods,
@@ -634,6 +639,9 @@ def artifact_to_json(artifact: Artifact) -> str:
         "version": artifact.version,
         "compilerVersion": artifact.compiler_version,
         "contractName": artifact.contract_name,
+        # parentClass (when present) is inserted here so it sits right after
+        # contractName, matching the other tiers' artifact field order.
+        **({"parentClass": artifact.parent_class} if artifact.parent_class else {}),
         "abi": {
             "constructor": {
                 "params": [

--- a/compilers/python/runar_compiler/frontend/anf_lower.py
+++ b/compilers/python/runar_compiler/frontend/anf_lower.py
@@ -83,6 +83,7 @@ def lower_to_anf(contract: ContractNode) -> ANFProgram:
         contract_name=contract.name,
         properties=properties,
         methods=methods,
+        parent_class=contract.parent_class,
     )
 
 

--- a/compilers/python/runar_compiler/frontend/constant_fold.py
+++ b/compilers/python/runar_compiler/frontend/constant_fold.py
@@ -544,4 +544,5 @@ def fold_constants(program: ANFProgram) -> ANFProgram:
         contract_name=program.contract_name,
         properties=list(program.properties),
         methods=[_fold_method(m) for m in program.methods],
+        parent_class=program.parent_class,
     )

--- a/compilers/python/runar_compiler/ir/types.py
+++ b/compilers/python/runar_compiler/ir/types.py
@@ -38,6 +38,14 @@ class ANFProgram:
     contract_name: str = ""
     properties: list[ANFProperty] = field(default_factory=list)
     methods: list[ANFMethod] = field(default_factory=list)
+    # Base class the source contract extends. In-memory carrier ONLY: it is
+    # excluded from the emitted ANF IR JSON (see _IR_EXCLUDED_FIELDS in
+    # __main__.py) so it never affects cross-tier conformance parity. The
+    # artifact assembler copies it to the top-level artifact field so SDKs can
+    # gate the issue-#42/#44 terminal sighash subscript trim on the parent
+    # class (a StatefulSmartContract with zero mutable fields still needs the
+    # trim even though state_fields is empty).
+    parent_class: str = ""
 
 
 @dataclass

--- a/compilers/ruby/lib/runar_compiler/cli.rb
+++ b/compilers/ruby/lib/runar_compiler/cli.rb
@@ -39,6 +39,7 @@ module RunarCompiler
     IR_EXCLUDED_FIELDS = Set.new(%w[
       const_string const_big_int const_bool const_int
       source_loc
+      parent_class
     ]).freeze
 
     module_function

--- a/compilers/ruby/lib/runar_compiler/compiler.rb
+++ b/compilers/ruby/lib/runar_compiler/compiler.rb
@@ -65,6 +65,7 @@ module RunarCompiler
     :version,
     :compiler_version,
     :contract_name,
+    :parent_class,
     :abi,
     :script,
     :asm,
@@ -84,6 +85,7 @@ module RunarCompiler
       version: "",
       compiler_version: "",
       contract_name: "",
+      parent_class: "",
       abi: ABI.new,
       script: "",
       asm: "",
@@ -699,6 +701,10 @@ module RunarCompiler
       version: SCHEMA_VERSION,
       compiler_version: COMPILER_VERSION,
       contract_name: program.contract_name,
+      # Base class the source contract extends. Authoritative stateful signal
+      # for the issue-#42/#44 terminal sighash subscript trim (a
+      # StatefulSmartContract with zero mutable fields still needs the trim).
+      parent_class: program.parent_class,
       abi: ABI.new(
         constructor: ABIConstructor.new(params: constructor_params),
         methods: methods
@@ -749,6 +755,11 @@ module RunarCompiler
       "version" => artifact.version,
       "compilerVersion" => artifact.compiler_version,
       "contractName" => artifact.contract_name,
+    }
+    # parentClass (when present) sits right after contractName, matching the
+    # other tiers' artifact field order. Omitted when empty (older fixtures).
+    d["parentClass"] = artifact.parent_class if artifact.parent_class && !artifact.parent_class.empty?
+    d.merge!({
       "abi" => {
         "constructor" => {
           "params" => artifact.abi.constructor.params.map(&abi_param_to_hash),
@@ -765,7 +776,7 @@ module RunarCompiler
       },
       "script" => artifact.script,
       "asm" => artifact.asm,
-    }
+    })
 
     if artifact.source_map && !artifact.source_map.empty?
       require_relative "codegen/emit"

--- a/compilers/ruby/lib/runar_compiler/frontend/anf_lower.rb
+++ b/compilers/ruby/lib/runar_compiler/frontend/anf_lower.rb
@@ -38,7 +38,8 @@ module RunarCompiler
       IR::ANFProgram.new(
         contract_name: contract.name,
         properties: properties,
-        methods: methods
+        methods: methods,
+        parent_class: contract.parent_class
       )
     end
 

--- a/compilers/ruby/lib/runar_compiler/frontend/anf_optimize.rb
+++ b/compilers/ruby/lib/runar_compiler/frontend/anf_optimize.rb
@@ -66,7 +66,8 @@ module RunarCompiler
         IR::ANFProgram.new(
           contract_name: program.contract_name,
           properties: program.properties.map(&:dup),
-          methods: program.methods.map { |m| deep_copy_method(m) }
+          methods: program.methods.map { |m| deep_copy_method(m) },
+          parent_class: program.parent_class
         )
       end
       private_class_method :deep_copy_program

--- a/compilers/ruby/lib/runar_compiler/frontend/constant_fold.rb
+++ b/compilers/ruby/lib/runar_compiler/frontend/constant_fold.rb
@@ -579,7 +579,8 @@ module RunarCompiler
         IR::ANFProgram.new(
           contract_name: program.contract_name,
           properties: program.properties.dup,
-          methods: program.methods.map { |m| fold_method(m) }
+          methods: program.methods.map { |m| fold_method(m) },
+          parent_class: program.parent_class
         )
       end
     end

--- a/compilers/ruby/lib/runar_compiler/ir/types.rb
+++ b/compilers/ruby/lib/runar_compiler/ir/types.rb
@@ -26,9 +26,18 @@ module RunarCompiler
     # Program structure
     # -------------------------------------------------------------------
 
-    ANFProgram = Struct.new(:contract_name, :properties, :methods, keyword_init: true) do
-      def initialize(contract_name: "", properties: [], methods: [])
-        super(contract_name: contract_name, properties: properties, methods: methods)
+    # +parent_class+ is the base class the source contract extends
+    # ("SmartContract" | "StatefulSmartContract" | "UnsafeSmartContract"). It is
+    # an in-memory carrier ONLY -- it is never written into the emitted ANF IR
+    # JSON that the conformance suite compares cross-tier (see
+    # +_serialize_anf_program+ in compiler.rb, which omits it). The artifact
+    # assembler copies it to the top-level artifact field so SDKs can gate the
+    # issue-#42/#44 terminal sighash subscript trim on the authoritative parent
+    # class (a StatefulSmartContract with zero mutable fields still needs the
+    # trim even though stateFields is empty).
+    ANFProgram = Struct.new(:contract_name, :properties, :methods, :parent_class, keyword_init: true) do
+      def initialize(contract_name: "", properties: [], methods: [], parent_class: "")
+        super(contract_name: contract_name, properties: properties, methods: methods, parent_class: parent_class)
       end
     end
 

--- a/compilers/rust/src/artifact.rs
+++ b/compilers/rust/src/artifact.rs
@@ -97,6 +97,11 @@ pub struct RunarArtifact {
     pub compiler_version: String,
     #[serde(rename = "contractName")]
     pub contract_name: String,
+    /// Base class the source contract extends. Authoritative stateful signal
+    /// for the issue-#42/#44 terminal sighash subscript trim (a
+    /// StatefulSmartContract with zero mutable fields still needs the trim).
+    #[serde(rename = "parentClass", skip_serializing_if = "String::is_empty", default)]
+    pub parent_class: String,
     pub abi: ABI,
     pub script: String,
     pub asm: String,
@@ -258,6 +263,7 @@ pub fn assemble_artifact(
         version: SCHEMA_VERSION.to_string(),
         compiler_version: COMPILER_VERSION.to_string(),
         contract_name: program.contract_name.clone(),
+        parent_class: program.parent_class.clone(),
         abi: ABI {
             constructor: ABIConstructor {
                 params: constructor_params,

--- a/compilers/rust/src/codegen/emit.rs
+++ b/compilers/rust/src/codegen/emit.rs
@@ -823,6 +823,7 @@ mod tests {
 
         let program = ANFProgram {
             contract_name: "Multi".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![
                 ANFMethod {
@@ -991,6 +992,7 @@ mod tests {
 
         let program = ANFProgram {
             contract_name: "P2PKH".to_string(),
+            parent_class: String::new(),
             properties: vec![ANFProperty {
                 name: "pubKeyHash".to_string(),
                 prop_type: "Addr".to_string(),
@@ -1140,6 +1142,7 @@ mod tests {
 
         let program = ANFProgram {
             contract_name: "Sha256Test".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -1260,6 +1263,7 @@ mod tests {
         // A program with a single public method (plus constructor) — no method dispatch needed
         let program = ANFProgram {
             contract_name: "Single".to_string(),
+            parent_class: String::new(),
             properties: vec![ANFProperty {
                 name: "x".to_string(),
                 prop_type: "bigint".to_string(),

--- a/compilers/rust/src/codegen/stack.rs
+++ b/compilers/rust/src/codegen/stack.rs
@@ -4652,6 +4652,7 @@ mod tests {
     fn p2pkh_program() -> ANFProgram {
         ANFProgram {
             contract_name: "P2PKH".to_string(),
+            parent_class: String::new(),
             properties: vec![ANFProperty {
                 name: "pubKeyHash".to_string(),
                 prop_type: "Addr".to_string(),
@@ -4897,6 +4898,7 @@ mod tests {
         // Build a stateful contract that calls extractOutputHash on a preimage
         let program = ANFProgram {
             contract_name: "TestExtract".to_string(),
+            parent_class: String::new(),
             properties: vec![ANFProperty {
                 name: "val".to_string(),
                 prop_type: "bigint".to_string(),
@@ -4964,6 +4966,7 @@ mod tests {
         // The terminal asserts in both branches should NOT emit OP_VERIFY.
         let program = ANFProgram {
             contract_name: "TerminalIf".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5068,6 +5071,7 @@ mod tests {
     fn test_unpack_emits_bin2num() {
         let program = ANFProgram {
             contract_name: "TestUnpack".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5128,6 +5132,7 @@ mod tests {
     fn test_pack_is_noop() {
         let program = ANFProgram {
             contract_name: "TestPack".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5184,6 +5189,7 @@ mod tests {
     fn test_to_byte_string_is_noop() {
         let program = ANFProgram {
             contract_name: "TestToByteString".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5239,6 +5245,7 @@ mod tests {
     fn test_sqrt_has_zero_guard() {
         let program = ANFProgram {
             contract_name: "TestSqrt".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5317,6 +5324,7 @@ mod tests {
         // so it should be dropped. The TS reference does this cleanup.
         let program = ANFProgram {
             contract_name: "TestLoopCleanup".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5436,6 +5444,7 @@ mod tests {
     fn test_log2_uses_bit_scanning_not_byte_approx() {
         let program = ANFProgram {
             contract_name: "TestLog2".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5526,6 +5535,7 @@ mod tests {
     fn test_reverse_bytes_uses_split_cat_not_op_reverse() {
         let program = ANFProgram {
             contract_name: "TestReverse".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5622,6 +5632,7 @@ mod tests {
     fn test_multi_method_dispatch() {
         let program = ANFProgram {
             contract_name: "Multi".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![
                 ANFMethod {
@@ -5725,6 +5736,7 @@ mod tests {
     fn test_extract_outputs_uses_offset_40() {
         let program = ANFProgram {
             contract_name: "OutputsCheck".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),
@@ -5784,6 +5796,7 @@ mod tests {
         // Contract: verify(a, b) { assert(a + b === target) }
         let program = ANFProgram {
             contract_name: "ArithCheck".to_string(),
+            parent_class: String::new(),
             properties: vec![ANFProperty {
                 name: "target".to_string(),
                 prop_type: "bigint".to_string(),
@@ -5913,6 +5926,7 @@ mod tests {
     fn test_bytestring_concat_emits_op_cat() {
         let program = ANFProgram {
             contract_name: "CatCheck".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "verify".to_string(),
@@ -5991,6 +6005,7 @@ mod tests {
     fn test_log2_emits_64_if_ops() {
         let program = ANFProgram {
             contract_name: "TestLog2Count".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "check".to_string(),

--- a/compilers/rust/src/frontend/anf_lower.rs
+++ b/compilers/rust/src/frontend/anf_lower.rs
@@ -49,6 +49,7 @@ pub fn lower_to_anf(contract: &ContractNode) -> ANFProgram {
         contract_name: contract.name.clone(),
         properties,
         methods,
+        parent_class: contract.parent_class.clone(),
     }
 }
 

--- a/compilers/rust/src/frontend/anf_optimize.rs
+++ b/compilers/rust/src/frontend/anf_optimize.rs
@@ -589,6 +589,7 @@ pub fn optimize_ec(program: ANFProgram) -> ANFProgram {
         contract_name: program.contract_name,
         properties: program.properties,
         methods: cleaned_methods,
+        parent_class: program.parent_class,
     }
 }
 

--- a/compilers/rust/src/frontend/anf_optimize.rs
+++ b/compilers/rust/src/frontend/anf_optimize.rs
@@ -609,6 +609,7 @@ mod tests {
     fn make_program(bindings: Vec<ANFBinding>) -> ANFProgram {
         ANFProgram {
             contract_name: "Test".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "test".to_string(),
@@ -1053,6 +1054,7 @@ mod tests {
     fn test_contract_name_preserved() {
         let program = ANFProgram {
             contract_name: "MyContract".to_string(),
+            parent_class: String::new(),
             properties: vec![ANFProperty {
                 name: "x".to_string(),
                 prop_type: "bigint".to_string(),
@@ -1087,6 +1089,7 @@ mod tests {
     fn test_multiple_methods_all_optimized() {
         let program = ANFProgram {
             contract_name: "Test".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![
                 ANFMethod {

--- a/compilers/rust/src/frontend/constant_fold.rs
+++ b/compilers/rust/src/frontend/constant_fold.rs
@@ -499,6 +499,7 @@ pub fn fold_constants(program: &ANFProgram) -> ANFProgram {
         contract_name: program.contract_name.clone(),
         properties: program.properties.clone(),
         methods: program.methods.iter().map(|m| fold_method(m)).collect(),
+        parent_class: program.parent_class.clone(),
     }
 }
 
@@ -518,6 +519,7 @@ mod tests {
             contract_name: "Test".to_string(),
             properties: vec![],
             methods,
+            parent_class: String::new(),
         }
     }
 

--- a/compilers/rust/src/ir/loader.rs
+++ b/compilers/rust/src/ir/loader.rs
@@ -462,6 +462,7 @@ mod tests {
     fn test_round_trip_serialize_deserialize() {
         let program = ANFProgram {
             contract_name: "RoundTrip".to_string(),
+            parent_class: String::new(),
             properties: vec![ANFProperty {
                 name: "count".to_string(),
                 prop_type: "bigint".to_string(),
@@ -536,6 +537,7 @@ mod tests {
     fn test_round_trip_with_initial_value() {
         let program = ANFProgram {
             contract_name: "InitTest".to_string(),
+            parent_class: String::new(),
             properties: vec![ANFProperty {
                 name: "value".to_string(),
                 prop_type: "bigint".to_string(),
@@ -576,6 +578,7 @@ mod tests {
     fn test_round_trip_if_and_loop() {
         let program = ANFProgram {
             contract_name: "Nested".to_string(),
+            parent_class: String::new(),
             properties: vec![],
             methods: vec![ANFMethod {
                 name: "test".to_string(),

--- a/compilers/rust/src/ir/mod.rs
+++ b/compilers/rust/src/ir/mod.rs
@@ -34,6 +34,16 @@ pub struct ANFProgram {
     pub contract_name: String,
     pub properties: Vec<ANFProperty>,
     pub methods: Vec<ANFMethod>,
+    /// Base class the source contract extends ("SmartContract" |
+    /// "StatefulSmartContract" | "UnsafeSmartContract"). In-memory carrier
+    /// ONLY (`#[serde(skip)]`) so it never appears in the emitted ANF IR JSON
+    /// that the conformance suite compares cross-tier. The artifact assembler
+    /// copies it to the top-level artifact field so SDKs can gate the
+    /// issue-#42/#44 terminal sighash subscript trim on the authoritative
+    /// parent class (a StatefulSmartContract with zero mutable fields still
+    /// needs the trim even though state_fields is empty).
+    #[serde(skip, default)]
+    pub parent_class: String,
 }
 
 /// One level of a synthetic-array chain attached to expanded leaf

--- a/compilers/rust/tests/ec_optimizer_tests.rs
+++ b/compilers/rust/tests/ec_optimizer_tests.rs
@@ -27,6 +27,7 @@ fn some_point_hex() -> String {
 fn make_program(bindings: Vec<ANFBinding>) -> ANFProgram {
     ANFProgram {
         contract_name: "Test".to_string(),
+        parent_class: String::new(),
         properties: vec![],
         methods: vec![ANFMethod {
             name: "test".to_string(),
@@ -494,6 +495,7 @@ fn test_contract_metadata_preserved() {
 
     let program = ANFProgram {
         contract_name: "P2PKH".to_string(),
+        parent_class: String::new(),
         properties: vec![
             ANFProperty {
                 name: "pubKeyHash".to_string(),
@@ -542,6 +544,7 @@ fn test_multiple_methods_all_optimized() {
     ];
     let program = ANFProgram {
         contract_name: "TwoMethods".to_string(),
+        parent_class: String::new(),
         properties: vec![],
         methods: vec![
             ANFMethod {
@@ -593,6 +596,7 @@ fn test_multiple_methods_all_optimized() {
 fn test_empty_method_body_unchanged() {
     let program = ANFProgram {
         contract_name: "Empty".to_string(),
+        parent_class: String::new(),
         properties: vec![],
         methods: vec![ANFMethod {
             name: "check".to_string(),

--- a/compilers/zig/src/codegen/emit.zig
+++ b/compilers/zig/src/codegen/emit.zig
@@ -540,6 +540,15 @@ pub fn emitArtifact(
     try writeJsonString(w, stack_program.contract_name);
     try w.writeByte(',');
 
+    // parentClass — authoritative stateful signal for the issue-#42/#44
+    // terminal sighash subscript trim (a StatefulSmartContract with zero
+    // mutable fields still needs the trim). Sourced from the ANF program; it
+    // is deliberately NOT part of the emitted ANF IR JSON, so cross-tier
+    // conformance parity is unaffected.
+    try w.writeAll("\"parentClass\":");
+    try writeJsonString(w, anf_program.parent_class.toTsString());
+    try w.writeByte(',');
+
     // abi
     try w.writeAll("\"abi\":{");
 

--- a/integration/rust/Cargo.lock
+++ b/integration/rust/Cargo.lock
@@ -969,8 +969,9 @@ dependencies = [
 
 [[package]]
 name = "runar-compiler-rust"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
+ "bsv-sdk",
  "clap",
  "hex",
  "num-bigint",
@@ -1001,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "runar-lang"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bs58",
  "bsv-sdk",
@@ -1021,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "runar-lang-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/integration/rust/tests/all_readonly_cleanstack.rs
+++ b/integration/rust/tests/all_readonly_cleanstack.rs
@@ -1,0 +1,91 @@
+//! AllReadonlyCleanstack integration test — issue #44 / parentClass pipeline.
+//!
+//! ## What this proves
+//!
+//! `AllReadonlyCleanstack` is a `StatefulSmartContract` with ZERO mutable
+//! fields (only a `readonly owner`). Its `claim(sig)` method is terminal: the
+//! contract is fully spent, the user `checkSig` runs AFTER the auto-injected
+//! `checkPreimage` / OP_CODESEPARATOR.
+//!
+//! Before the parentClass fix, the SDK derived `is_stateful` purely from
+//! non-empty `state_fields`. With zero mutable fields, `state_fields` is empty,
+//! so the SDK mistook the contract for stateless and SKIPPED the issue-#42/#44
+//! terminal sighash subscript trim. The user `sig` was then signed over the
+//! FULL locking script instead of the codesep-trimmed subscript, so the spend
+//! NULLFAILed on a strict node (`acceptnonstdtxn=0`).
+//!
+//! The fix carries `parentClass` in the artifact and gates the trim on
+//! `parent_class == "StatefulSmartContract"`. This test deploys the contract
+//! and spends its terminal `claim()`, asserting the spend is ACCEPTED.
+//!
+//! `claim(sig)` has the `sig` user param plus the compiler-injected
+//! `txPreimage` (SigHashPreimage). A zero-mutable-field stateful contract has
+//! `is_stateful == false`, so the SDK does NOT strip `txPreimage` from the
+//! user-facing params — hence the call passes two `Auto` args (sig, txPreimage).
+//!
+//! **Gating**: the on-chain test is gated with
+//! `#[cfg_attr(not(feature = "regtest"), ignore)]`. It requires a local Bitcoin
+//! regtest node (see `integration/rust/README.md`). Run with:
+//!     cargo test --features regtest
+
+use crate::helpers::*;
+use runar_lang::sdk::{DeployOptions, RunarContract, SdkValue};
+
+const SOURCE: &str = "examples/ts/all-readonly-cleanstack/AllReadonlyCleanstack.runar.ts";
+
+#[test]
+fn test_all_readonly_cleanstack_compile() {
+    let artifact = compile_contract(SOURCE);
+    assert_eq!(artifact.contract_name, "AllReadonlyCleanstack");
+    // parentClass must be carried so the SDK can gate the terminal trim even
+    // though there are no mutable state fields.
+    assert_eq!(
+        artifact.parent_class.as_deref(),
+        Some("StatefulSmartContract"),
+        "artifact must carry parentClass=StatefulSmartContract"
+    );
+    assert!(
+        artifact.state_fields.as_ref().map_or(true, |f| f.is_empty()),
+        "AllReadonlyCleanstack has zero mutable state fields"
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "regtest"), ignore)]
+fn test_all_readonly_cleanstack_claim_accepted() {
+    skip_if_no_node();
+
+    let artifact = compile_contract(SOURCE);
+    let mut provider = create_provider();
+    // The funded wallet's pubkey IS the contract owner, so checkSig passes.
+    let (signer, owner_wallet) = create_funded_wallet(&mut provider);
+
+    // Constructor: (owner: PubKey)
+    let mut contract = RunarContract::new(
+        artifact,
+        vec![SdkValue::Bytes(owner_wallet.pub_key_hex.clone())],
+    );
+
+    contract
+        .deploy(&mut provider, &*signer, &DeployOptions {
+            satoshis: 5000,
+            change_address: None,
+        })
+        .expect("deploy failed");
+
+    // Terminal claim(sig). Two Auto args: the declared `sig` plus the
+    // compiler-injected `txPreimage` (not stripped for a zero-mutable-field
+    // stateful contract). Before the parentClass fix this NULLFAILed under
+    // strict policy; it MUST now be accepted.
+    let (claim_txid, _tx) = contract
+        .call(
+            "claim",
+            &[SdkValue::Auto, SdkValue::Auto],
+            &mut provider,
+            &*signer,
+            None,
+        )
+        .expect("claim spend must be accepted by a strict node");
+    assert!(!claim_txid.is_empty());
+    assert_eq!(claim_txid.len(), 64, "expected a 64-hex-char txid");
+}

--- a/integration/rust/tests/integration.rs
+++ b/integration/rust/tests/integration.rs
@@ -33,3 +33,10 @@ mod data_outputs;
 mod nullfail_multimethod;
 mod message_board;
 mod ordinals;
+
+// Issue #44 / parentClass pipeline (2026-05-24): a StatefulSmartContract with
+// ZERO mutable fields NULLFAILed on spend under strict policy because the SDK
+// derived is_stateful from non-empty state_fields and skipped the terminal
+// sighash subscript trim. The fix carries parentClass in the artifact and gates
+// the trim on it. This test proves the terminal claim() is now ACCEPTED.
+mod all_readonly_cleanstack;

--- a/packages/runar-compiler/src/artifact/assembler.ts
+++ b/packages/runar-compiler/src/artifact/assembler.ts
@@ -135,6 +135,13 @@ export interface RunarArtifact {
   /** Name of the compiled contract */
   contractName: string;
 
+  /**
+   * The base class the contract extends. Authoritative stateful signal for
+   * the issue-#42 terminal sighash subscript trim (a StatefulSmartContract
+   * with zero mutable fields still needs the trim).
+   */
+  parentClass?: 'SmartContract' | 'StatefulSmartContract' | 'UnsafeSmartContract';
+
   /** Public ABI (constructor + methods) */
   abi: ABI;
 
@@ -630,6 +637,7 @@ export function assembleArtifact(
     version: ARTIFACT_VERSION,
     compilerVersion,
     contractName: contract.name,
+    parentClass: contract.parentClass,
     abi,
     script: scriptHex,
     asm: scriptAsm,

--- a/packages/runar-compiler/src/ir/artifact.ts
+++ b/packages/runar-compiler/src/ir/artifact.ts
@@ -145,6 +145,13 @@ export interface RunarArtifact {
   /** Name of the compiled contract */
   contractName: string;
 
+  /**
+   * The base class the contract extends. Authoritative stateful signal for
+   * the issue-#42 terminal sighash subscript trim (a StatefulSmartContract
+   * with zero mutable fields still needs the trim).
+   */
+  parentClass?: 'SmartContract' | 'StatefulSmartContract' | 'UnsafeSmartContract';
+
   /** Public ABI (constructor + methods) */
   abi: ABI;
 

--- a/packages/runar-go/sdk_contract.go
+++ b/packages/runar-go/sdk_contract.go
@@ -401,9 +401,12 @@ func (c *RunarContract) Call(
 		// which getCodeSepIndex now recovers via findCodesepOffsets.
 		// Stateless contracts: the user controls statement order and may place
 		// checkSig BEFORE the codesep (e.g. CovenantVault) — those must use the
-		// FULL script, so the trim stays gated on isStateful.
+		// FULL script, so the trim stays gated on the parent class. A stateful
+		// contract with ZERO mutable fields (empty StateFields) still injects
+		// checkPreimage at entry, so the trim is gated on parentStateful
+		// (artifact ParentClass), NOT isStateful (issue #44).
 		subscript := prepared.contractUtxo.Script
-		if prepared.isStateful && prepared.codeSepIdx >= 0 {
+		if prepared.parentStateful && prepared.codeSepIdx >= 0 {
 			subscript = subscript[(prepared.codeSepIdx+1)*2:]
 		}
 		sig, sigErr := signer.Sign(prepared.TxHex, 0, subscript, prepared.contractUtxo.Satoshis, nil)
@@ -451,6 +454,15 @@ func (c *RunarContract) PrepareCall(
 	}
 
 	isStateful := len(c.Artifact.StateFields) > 0
+	// parentStateful gates ONLY the issue-#42/#44 terminal sighash subscript
+	// trim. A StatefulSmartContract with zero mutable fields has empty
+	// StateFields yet still auto-injects checkPreimage at method entry, so its
+	// user checkSig runs after the OP_CODESEPARATOR. ParentClass is the
+	// authoritative signal; fall back to isStateful for older artifacts.
+	parentStateful := isStateful
+	if c.Artifact.ParentClass != "" {
+		parentStateful = c.Artifact.ParentClass == "StatefulSmartContract"
+	}
 	methodNeedsChange := false
 	methodNeedsNewAmount := false
 	for _, p := range method.Params {
@@ -607,7 +619,7 @@ func (c *RunarContract) PrepareCall(
 	if options != nil && len(options.TerminalOutputs) > 0 {
 		return c.prepareCallTerminal(
 			methodName, resolvedArgs, signer, options,
-			isStateful, needsOpPushTx, methodNeedsChange,
+			isStateful, parentStateful, needsOpPushTx, methodNeedsChange,
 			sigIndices, prevoutsIndices, preimageIndex,
 			methodSelectorHex, changePKHHex, contractUtxo, witnessHex,
 		)
@@ -1044,6 +1056,7 @@ func (c *RunarContract) PrepareCall(
 		resolvedArgs:      resolvedArgs,
 		methodSelectorHex: methodSelectorHex,
 		isStateful:        isStateful,
+		parentStateful:    parentStateful,
 		isTerminal:        false,
 		needsOpPushTx:     needsOpPushTx,
 		methodNeedsChange: methodNeedsChange,
@@ -1738,6 +1751,7 @@ func (c *RunarContract) prepareCallTerminal(
 	signer Signer,
 	options *CallOptions,
 	isStateful bool,
+	parentStateful bool,
 	needsOpPushTx bool,
 	methodNeedsChange bool,
 	sigIndices []int,
@@ -1918,6 +1932,7 @@ func (c *RunarContract) prepareCallTerminal(
 		resolvedArgs:      resolvedArgs,
 		methodSelectorHex: methodSelectorHex,
 		isStateful:        isStateful,
+		parentStateful:    parentStateful,
 		isTerminal:        true,
 		needsOpPushTx:     needsOpPushTx,
 		methodNeedsChange: methodNeedsChange,

--- a/packages/runar-go/sdk_types.go
+++ b/packages/runar-go/sdk_types.go
@@ -139,6 +139,10 @@ type PreparedCall struct {
 	resolvedArgs      []interface{}
 	methodSelectorHex string
 	isStateful        bool
+	// parentStateful is true when the contract extends StatefulSmartContract
+	// (from artifact ParentClass), independent of whether it has mutable
+	// state fields. Gates the issue-#42/#44 terminal sighash subscript trim.
+	parentStateful    bool
 	isTerminal        bool
 	needsOpPushTx     bool
 	methodNeedsChange bool
@@ -196,6 +200,12 @@ type RunarArtifact struct {
 	Version                string             `json:"version"`
 	CompilerVersion        string             `json:"compilerVersion"`
 	ContractName           string             `json:"contractName"`
+	// ParentClass is the base class the source contract extends. It is the
+	// authoritative stateful signal for the issue-#42/#44 terminal sighash
+	// subscript trim: a StatefulSmartContract with zero mutable fields still
+	// needs the trim even though StateFields is empty. Older artifacts that
+	// predate this field leave it empty.
+	ParentClass            string             `json:"parentClass,omitempty"`
 	ABI                    ABI                `json:"abi"`
 	Script                 string             `json:"script"`
 	ASM                    string             `json:"asm"`

--- a/packages/runar-ir-schema/src/artifact.ts
+++ b/packages/runar-ir-schema/src/artifact.ts
@@ -157,6 +157,18 @@ export interface RunarArtifact {
   /** Name of the compiled contract */
   contractName: string;
 
+  /**
+   * The base class the contract extends. Distinguishes stateful contracts
+   * (which auto-inject `checkPreimage` at method entry, placing the user
+   * `checkSig` AFTER the OP_CODESEPARATOR) from stateless / unsafe contracts.
+   *
+   * This is the authoritative stateful signal for the issue-#42 terminal
+   * sighash subscript trim: a `StatefulSmartContract` with zero mutable
+   * fields still needs the trim, even though its `stateFields` array is
+   * empty. Older artifacts that predate this field omit it.
+   */
+  parentClass?: 'SmartContract' | 'StatefulSmartContract' | 'UnsafeSmartContract';
+
   /** Public ABI (constructor + methods) */
   abi: ABI;
 

--- a/packages/runar-ir-schema/src/schemas/artifact.schema.json
+++ b/packages/runar-ir-schema/src/schemas/artifact.schema.json
@@ -27,6 +27,11 @@
       "type": "string",
       "minLength": 1
     },
+    "parentClass": {
+      "type": "string",
+      "enum": ["SmartContract", "StatefulSmartContract", "UnsafeSmartContract"],
+      "description": "Base class the contract extends; authoritative stateful signal for the terminal sighash subscript trim (a StatefulSmartContract with zero mutable fields still needs the trim)."
+    },
     "abi": { "$ref": "#/$defs/ABI" },
     "script": {
       "type": "string",

--- a/packages/runar-java/src/main/java/runar/lang/sdk/RunarArtifact.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/RunarArtifact.java
@@ -17,6 +17,14 @@ public record RunarArtifact(
     String version,
     String compilerVersion,
     String contractName,
+    /**
+     * Base class the source contract extends ("SmartContract" |
+     * "StatefulSmartContract" | "UnsafeSmartContract"). Authoritative stateful
+     * signal for the issue-#42/#44 terminal sighash subscript trim: a
+     * StatefulSmartContract with zero mutable fields still needs the trim even
+     * though {@code stateFields} is empty. Older artifacts omit it (empty/null).
+     */
+    String parentClass,
     ABI abi,
     String scriptHex,
     String asm,
@@ -36,7 +44,10 @@ public record RunarArtifact(
         codeSeparatorIndices = codeSeparatorIndices == null ? List.of() : Collections.unmodifiableList(codeSeparatorIndices);
     }
 
-    /** Backwards-compatible constructor without {@code anf} (defaults to {@code null}). */
+    /**
+     * Backwards-compatible constructor without {@code parentClass} / {@code anf}
+     * (both default to {@code null}). Pre-parentClass callers keep compiling.
+     */
     public RunarArtifact(
         String version,
         String compilerVersion,
@@ -52,14 +63,50 @@ public record RunarArtifact(
         List<Integer> codeSeparatorIndices
     ) {
         this(
-            version, compilerVersion, contractName, abi, scriptHex, asm, buildTimestamp,
+            version, compilerVersion, contractName, null, abi, scriptHex, asm, buildTimestamp,
             stateFields, constructorSlots, codeSepIndexSlots,
             codeSeparatorIndex, codeSeparatorIndices, null
         );
     }
 
+    /** Backwards-compatible constructor without {@code parentClass} but with {@code anf}. */
+    public RunarArtifact(
+        String version,
+        String compilerVersion,
+        String contractName,
+        ABI abi,
+        String scriptHex,
+        String asm,
+        String buildTimestamp,
+        List<StateField> stateFields,
+        List<ConstructorSlot> constructorSlots,
+        List<CodeSepIndexSlot> codeSepIndexSlots,
+        Integer codeSeparatorIndex,
+        List<Integer> codeSeparatorIndices,
+        Map<String, Object> anf
+    ) {
+        this(
+            version, compilerVersion, contractName, null, abi, scriptHex, asm, buildTimestamp,
+            stateFields, constructorSlots, codeSepIndexSlots,
+            codeSeparatorIndex, codeSeparatorIndices, anf
+        );
+    }
+
     public boolean isStateful() {
         return stateFields != null && !stateFields.isEmpty();
+    }
+
+    /**
+     * True when the contract extends {@code StatefulSmartContract} (from
+     * {@code parentClass}), independent of whether it has mutable state fields.
+     * Gates the issue-#42/#44 terminal sighash subscript trim. Falls back to
+     * {@link #isStateful()} for older artifacts that omit {@code parentClass}.
+     */
+    public boolean parentStateful() {
+        if (parentClass == null || parentClass.isEmpty()) {
+            return isStateful();
+        }
+        return "StatefulSmartContract".equals(parentClass);
     }
 
     // ------------------------------------------------------------------
@@ -85,6 +132,9 @@ public record RunarArtifact(
         String version = Json.asString(m.get("version"));
         String compilerVersion = Json.asString(m.get("compilerVersion"));
         String contractName = Json.asString(m.get("contractName"));
+        // parentClass is optional; absent on older artifacts. Gates the
+        // issue-#42/#44 terminal sighash subscript trim (see parentStateful()).
+        String parentClass = m.containsKey("parentClass") ? Json.asString(m.get("parentClass")) : null;
         ABI abi = ABI.fromMap(Json.asObject(m.get("abi")));
         String scriptHex = Json.asString(m.get("script"));
         String asm = Json.asString(m.get("asm"));
@@ -120,6 +170,7 @@ public record RunarArtifact(
             version,
             compilerVersion,
             contractName,
+            parentClass,
             abi,
             scriptHex,
             asm,

--- a/packages/runar-java/src/main/java/runar/lang/sdk/RunarContract.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/RunarContract.java
@@ -340,6 +340,13 @@ public final class RunarContract {
         }
 
         boolean isStateful = artifact.isStateful();
+        // parentStateful gates ONLY the issue-#42/#44 terminal sighash subscript
+        // trim (the OP_PUSH_TX / codesep-aware path). A StatefulSmartContract
+        // with zero mutable fields has empty stateFields yet still injects
+        // checkPreimage at method entry, so its user checkSig runs after the
+        // OP_CODESEPARATOR and must sign the trimmed subscript. parentClass is
+        // the authoritative signal; falls back to isStateful for older artifacts.
+        boolean parentStateful = artifact.parentStateful();
 
         // Identify the "user" params — every formal param except those the
         // compiler injects implicitly for stateful contracts. The args list
@@ -407,7 +414,10 @@ public final class RunarContract {
         // [user params...] [_changePKH] [_changeAmount] [_newAmount] [txPreimage].
         boolean methodNeedsChange = hasParam(m, "_changePKH");
         boolean methodNeedsNewAmount = hasParam(m, "_newAmount");
-        boolean needsOpPushTx = isStateful || hasParam(m, "txPreimage");
+        // parentStateful pulls a zero-mutable-field StatefulSmartContract into
+        // the OP_PUSH_TX / codesep-aware path so its user checkSig signs the
+        // trimmed subscript (issue #44). stateful+ txPreimage covers the rest.
+        boolean needsOpPushTx = parentStateful || isStateful || hasParam(m, "txPreimage");
 
         // ------------------------------------------------------------
         // Terminal call: contract fully spent into caller-supplied
@@ -420,7 +430,7 @@ public final class RunarContract {
             return callTerminal(
                 m, methodName, resolved, sigIndices,
                 methodNeedsChange, methodNeedsNewAmount,
-                isStateful, terminalOutputs, fundingUtxos, provider, signer,
+                isStateful, parentStateful, terminalOutputs, fundingUtxos, provider, signer,
                 terminalLocktime
             );
         }
@@ -442,7 +452,7 @@ public final class RunarContract {
         return callWithPushTx(
             m, methodName, resolved, sigIndices,
             methodNeedsChange, methodNeedsNewAmount,
-            isStateful, resolvedDataOutputs, provider, signer, pushTxLocktime
+            isStateful, parentStateful, resolvedDataOutputs, provider, signer, pushTxLocktime
         );
     }
 
@@ -503,6 +513,7 @@ public final class RunarContract {
         boolean methodNeedsChange,
         boolean methodNeedsNewAmount,
         boolean isStateful,
+        boolean parentStateful,
         List<TransactionBuilder.DataOutput> dataOutputs,
         Provider provider,
         Signer signer,
@@ -685,6 +696,7 @@ public final class RunarContract {
         boolean methodNeedsChange,
         boolean methodNeedsNewAmount,
         boolean isStateful,
+        boolean parentStateful,
         List<CallOptions.TerminalOutput> terminalOutputs,
         List<UTXO> fundingUtxos,
         Provider provider,
@@ -695,7 +707,10 @@ public final class RunarContract {
         // WitnessValueMissingError BEFORE any signing / broadcast.
         String intentWitnessHex = buildIntentWitnessHex(m);
 
-        boolean needsOpPushTx = isStateful || hasParam(m, "txPreimage");
+        // parentStateful pulls a zero-mutable-field StatefulSmartContract into
+        // the OP_PUSH_TX / codesep-aware path so the terminal user checkSig
+        // signs the trimmed subscript (issue #44).
+        boolean needsOpPushTx = parentStateful || isStateful || hasParam(m, "txPreimage");
         long contractSats = currentUtxo.satoshis();
 
         // Resolve user-facing outputs into hex-encoded scripts. Throws if
@@ -1300,7 +1315,10 @@ public final class RunarContract {
         boolean isStateful = artifact.isStateful();
         boolean methodNeedsChange = hasParam(m, "_changePKH");
         boolean methodNeedsNewAmount = hasParam(m, "_newAmount");
-        boolean needsOpPushTx = isStateful || hasParam(m, "txPreimage");
+        // parentStateful pulls a zero-mutable-field StatefulSmartContract into
+        // the OP_PUSH_TX / codesep-aware path so the prepared terminal sighash
+        // is computed over the trimmed subscript (issue #44).
+        boolean needsOpPushTx = artifact.parentStateful() || isStateful || hasParam(m, "txPreimage");
 
         // Pre-resolve intent-intrinsic witness hex (throws
         // WitnessValueMissingError if any auto-injected param wasn't set).

--- a/packages/runar-java/src/test/java/runar/lang/sdk/RunarArtifactTest.java
+++ b/packages/runar-java/src/test/java/runar/lang/sdk/RunarArtifactTest.java
@@ -49,6 +49,70 @@ class RunarArtifactTest {
     }
 
     @Test
+    void parentStatefulTrueForZeroMutableFieldStatefulContract() {
+        // Issue #44: a StatefulSmartContract with ZERO mutable fields has empty
+        // stateFields (isStateful() == false) yet still injects checkPreimage at
+        // entry, so the terminal sighash subscript trim must still fire. The
+        // authoritative signal is parentClass, surfaced via parentStateful().
+        String json = """
+            {
+              "version": "runar-v0.5.0",
+              "compilerVersion": "0.5.0",
+              "contractName": "AllReadonlyCleanstack",
+              "parentClass": "StatefulSmartContract",
+              "abi": { "constructor": { "params": [] }, "methods": [] },
+              "script": "6a",
+              "asm": "OP_RETURN"
+            }
+            """;
+        RunarArtifact art = RunarArtifact.fromJson(json);
+        assertEquals("StatefulSmartContract", art.parentClass());
+        assertFalse(art.isStateful(), "no mutable fields => isStateful is false");
+        assertTrue(art.parentStateful(), "parentClass drives the terminal trim gate");
+    }
+
+    @Test
+    void parentStatefulFalseForStatelessCovenant() {
+        // A stateless SmartContract (e.g. CovenantVault) must NOT trim: its
+        // user checkSig may run BEFORE the codesep, so it signs the full script.
+        String json = """
+            {
+              "version": "runar-v0.5.0",
+              "compilerVersion": "0.5.0",
+              "contractName": "CovenantVault",
+              "parentClass": "SmartContract",
+              "abi": { "constructor": { "params": [] }, "methods": [] },
+              "script": "6a",
+              "asm": "OP_RETURN"
+            }
+            """;
+        RunarArtifact art = RunarArtifact.fromJson(json);
+        assertEquals("SmartContract", art.parentClass());
+        assertFalse(art.parentStateful());
+    }
+
+    @Test
+    void parentStatefulFallsBackToIsStatefulWhenParentClassAbsent() {
+        // Older artifacts omit parentClass: fall back to the stateFields-based
+        // isStateful() so legacy behaviour is preserved.
+        String json = """
+            {
+              "version": "runar-v0.1.0",
+              "compilerVersion": "0.1.0",
+              "contractName": "Counter",
+              "abi": { "constructor": { "params": [] }, "methods": [] },
+              "script": "6a",
+              "asm": "OP_RETURN",
+              "stateFields": [ { "name": "count", "type": "bigint", "index": 0 } ]
+            }
+            """;
+        RunarArtifact art = RunarArtifact.fromJson(json);
+        assertNull(art.parentClass());
+        assertTrue(art.isStateful());
+        assertTrue(art.parentStateful(), "absent parentClass falls back to isStateful");
+    }
+
+    @Test
     void parsesJsonDirectlyWithoutArtifactWrapper() {
         String json = """
             {

--- a/packages/runar-py/runar/sdk/contract.py
+++ b/packages/runar-py/runar/sdk/contract.py
@@ -338,9 +338,12 @@ class RunarContract:
             # _find_codesep_offsets.
             # Stateless contracts: the user controls statement order and may
             # place checkSig BEFORE the codesep (e.g. CovenantVault) — those must
-            # use the FULL script, so the trim stays gated on is_stateful.
+            # use the FULL script, so the trim stays gated on the parent class.
+            # A stateful contract with ZERO mutable fields (empty state_fields)
+            # still injects checkPreimage at entry, so the trim is gated on
+            # parent_stateful (artifact parent_class), NOT is_stateful (issue #44).
             subscript = prepared.contract_utxo.script
-            if prepared.is_stateful and prepared.code_sep_idx >= 0:
+            if prepared.parent_stateful and prepared.code_sep_idx >= 0:
                 trim_pos = (prepared.code_sep_idx + 1) * 2
                 if trim_pos <= len(subscript):
                     subscript = subscript[trim_pos:]
@@ -387,6 +390,16 @@ class RunarContract:
             )
 
         is_stateful = bool(self.artifact.state_fields)
+        # parent_stateful gates ONLY the issue-#42/#44 terminal sighash subscript
+        # trim. A StatefulSmartContract with zero mutable fields has empty
+        # state_fields yet still injects checkPreimage at entry, so its user
+        # checkSig runs after the OP_CODESEPARATOR. parent_class is the
+        # authoritative signal; fall back to is_stateful for older artifacts.
+        parent_stateful = (
+            self.artifact.parent_class == 'StatefulSmartContract'
+            if self.artifact.parent_class
+            else is_stateful
+        )
 
         # For stateful contracts, the compiler injects implicit params into every
         # public method's ABI (SigHashPreimage, and for state-mutating methods:
@@ -501,7 +514,7 @@ class RunarContract:
         if opts.terminal_outputs:
             return self._prepare_terminal(
                 method_name, resolved_args, signer, opts,
-                is_stateful, needs_op_push_tx, method_needs_change,
+                is_stateful, parent_stateful, needs_op_push_tx, method_needs_change,
                 sig_indices, prevouts_indices, preimage_index,
                 method_selector_hex, change_pkh_hex, contract_utxo, witness_hex,
             )
@@ -853,6 +866,7 @@ class RunarContract:
             resolved_args=resolved_args,
             method_selector_hex=method_selector_hex,
             is_stateful=is_stateful,
+            parent_stateful=parent_stateful,
             is_terminal=False,
             needs_op_push_tx=needs_op_push_tx,
             method_needs_change=method_needs_change,
@@ -1095,6 +1109,7 @@ class RunarContract:
         signer: Signer,
         opts: CallOptions,
         is_stateful: bool,
+        parent_stateful: bool,
         needs_op_push_tx: bool,
         method_needs_change: bool,
         sig_indices: list[int],
@@ -1242,6 +1257,7 @@ class RunarContract:
             resolved_args=resolved_args,
             method_selector_hex=method_selector_hex,
             is_stateful=is_stateful,
+            parent_stateful=parent_stateful,
             is_terminal=True,
             needs_op_push_tx=needs_op_push_tx,
             method_needs_change=method_needs_change,

--- a/packages/runar-py/runar/sdk/types.py
+++ b/packages/runar-py/runar/sdk/types.py
@@ -106,6 +106,11 @@ class RunarArtifact:
     version: str = ''
     compiler_version: str = ''
     contract_name: str = ''
+    # Base class the source contract extends. Authoritative stateful signal
+    # for the issue-#42/#44 terminal sighash subscript trim: a
+    # StatefulSmartContract with zero mutable fields still needs the trim even
+    # though state_fields is empty. Older artifacts leave it empty.
+    parent_class: str = ''
     abi: Abi = field(default_factory=Abi)
     script: str = ''
     asm: str = ''
@@ -163,6 +168,7 @@ class RunarArtifact:
             version=d.get('version', ''),
             compiler_version=d.get('compilerVersion', ''),
             contract_name=d.get('contractName', ''),
+            parent_class=d.get('parentClass', ''),
             abi=Abi(constructor_params=ctor_params, methods=methods),
             script=d.get('script', ''),
             asm=d.get('asm', ''),
@@ -240,6 +246,10 @@ class PreparedCall:
     resolved_args: list = field(default_factory=list)
     method_selector_hex: str = ''
     is_stateful: bool = False
+    # True when the contract extends StatefulSmartContract (from artifact
+    # parent_class), independent of mutable state fields. Gates the
+    # issue-#42/#44 terminal sighash subscript trim.
+    parent_stateful: bool = False
     is_terminal: bool = False
     needs_op_push_tx: bool = False
     method_needs_change: bool = False

--- a/packages/runar-rb/lib/runar/sdk/contract.rb
+++ b/packages/runar-rb/lib/runar/sdk/contract.rb
@@ -283,9 +283,12 @@ module Runar
           # find_codesep_offsets.
           # Stateless contracts: the user controls statement order and may place
           # checkSig BEFORE the codesep (e.g. CovenantVault) — those must use the
-          # FULL script, so the trim stays gated on is_stateful.
+          # FULL script, so the trim stays gated on the parent class. A stateful
+          # contract with ZERO mutable fields (empty state_fields) still injects
+          # checkPreimage at entry, so the trim is gated on parent_stateful
+          # (artifact parent_class), NOT is_stateful (issue #44).
           subscript = prepared.contract_utxo.script
-          if prepared.is_stateful && prepared.code_sep_idx >= 0
+          if prepared.parent_stateful && prepared.code_sep_idx >= 0
             trim_pos  = (prepared.code_sep_idx + 1) * 2
             subscript = subscript[trim_pos..] if trim_pos <= subscript.length
           end
@@ -324,6 +327,13 @@ module Runar
         end
 
         is_stateful = !@artifact.state_fields.empty?
+        # parent_stateful gates ONLY the issue-#42/#44 terminal sighash subscript
+        # trim. A StatefulSmartContract with zero mutable fields has empty
+        # state_fields yet still injects checkPreimage at method entry, so its
+        # user checkSig runs after the OP_CODESEPARATOR. parent_class is the
+        # authoritative signal; fall back to is_stateful for older artifacts.
+        parent_class    = @artifact.respond_to?(:parent_class) ? @artifact.parent_class.to_s : ''
+        parent_stateful = parent_class.empty? ? is_stateful : parent_class == 'StatefulSmartContract'
 
         method_needs_change     = method.params.any? { |p| p.name == '_changePKH' }
         method_needs_new_amount = method.params.any? { |p| p.name == '_newAmount' }
@@ -425,7 +435,7 @@ module Runar
         if opts.terminal_outputs && !opts.terminal_outputs.empty?
           return prepare_terminal(
             method_name, resolved_args, signer, opts,
-            is_stateful, needs_op_push_tx, method_needs_change,
+            is_stateful, parent_stateful, needs_op_push_tx, method_needs_change,
             sig_indices, preimage_index,
             method_selector_hex, change_pkh_hex, contract_utxo, code_sep_idx,
             intent_witness_hex
@@ -566,7 +576,8 @@ module Runar
           contract_utxo, new_locking_script, code_sep_idx,
           has_multi_output: has_multi_output,
           contract_outputs: contract_outputs || [],
-          intent_witness_hex: intent_witness_hex
+          intent_witness_hex: intent_witness_hex,
+          parent_stateful: parent_stateful
         )
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -871,7 +882,7 @@ module Runar
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/ParameterLists
       def prepare_terminal(
         method_name, resolved_args, _signer, opts,
-        is_stateful, needs_op_push_tx, method_needs_change,
+        is_stateful, parent_stateful, needs_op_push_tx, method_needs_change,
         sig_indices, preimage_index,
         method_selector_hex, change_pkh_hex, contract_utxo, code_sep_idx,
         intent_witness_hex = ''
@@ -999,6 +1010,7 @@ module Runar
           resolved_args: resolved_args,
           method_selector_hex: method_selector_hex,
           is_stateful: is_stateful,
+          parent_stateful: parent_stateful,
           is_terminal: true,
           needs_op_push_tx: needs_op_push_tx,
           method_needs_change: method_needs_change,
@@ -1305,8 +1317,12 @@ module Runar
         contract_utxo, new_locking_script, code_sep_idx,
         has_multi_output: false,
         contract_outputs: [],
-        intent_witness_hex: ''
+        intent_witness_hex: '',
+        parent_stateful: nil
       )
+        # parent_stateful gates the issue-#42/#44 terminal sighash subscript
+        # trim; fall back to is_stateful when not passed (older callers).
+        parent_stateful = is_stateful if parent_stateful.nil?
         PreparedCall.new(
           sighash: sighash,
           preimage: final_preimage,
@@ -1317,6 +1333,7 @@ module Runar
           resolved_args: resolved_args,
           method_selector_hex: method_selector_hex,
           is_stateful: is_stateful,
+          parent_stateful: parent_stateful,
           is_terminal: false,
           needs_op_push_tx: needs_op_push_tx,
           method_needs_change: method_needs_change,

--- a/packages/runar-rb/lib/runar/sdk/types.rb
+++ b/packages/runar-rb/lib/runar/sdk/types.rb
@@ -85,7 +85,7 @@ module Runar
     # Use RunarArtifact.from_hash to load from a JSON-parsed Hash, or
     # RunarArtifact.from_json to parse a raw JSON string.
     class RunarArtifact
-      attr_reader :version, :compiler_version, :contract_name, :abi,
+      attr_reader :version, :compiler_version, :contract_name, :parent_class, :abi,
                   :script, :asm, :state_fields, :constructor_slots,
                   :code_sep_index_slots,
                   :build_timestamp, :code_separator_index, :code_separator_indices,
@@ -95,6 +95,11 @@ module Runar
         version: '',
         compiler_version: '',
         contract_name: '',
+        # Base class the source contract extends. Authoritative stateful signal
+        # for the issue-#42/#44 terminal sighash subscript trim: a
+        # StatefulSmartContract with zero mutable fields still needs the trim
+        # even though state_fields is empty. Older artifacts leave it empty.
+        parent_class: '',
         abi: ABI.new,
         script: '',
         asm: '',
@@ -109,6 +114,7 @@ module Runar
         @version                = version
         @compiler_version       = compiler_version
         @contract_name          = contract_name
+        @parent_class           = parent_class
         @abi                    = abi
         @script                 = script
         @asm                    = asm
@@ -186,6 +192,7 @@ module Runar
           version:                hash.fetch('version', ''),
           compiler_version:       hash.fetch('compilerVersion', ''),
           contract_name:          hash.fetch('contractName', ''),
+          parent_class:           hash.fetch('parentClass', ''),
           abi:                    ABI.new(constructor_params: ctor_params, methods: methods),
           script:                 hash.fetch('script', ''),
           asm:                    hash.fetch('asm', ''),
@@ -282,6 +289,10 @@ module Runar
       :resolved_args,
       :method_selector_hex,
       :is_stateful,
+      # True when the contract extends StatefulSmartContract (from artifact
+      # parent_class), independent of mutable state fields. Gates the
+      # issue-#42/#44 terminal sighash subscript trim.
+      :parent_stateful,
       :is_terminal,
       :needs_op_push_tx,
       :method_needs_change,
@@ -313,6 +324,7 @@ module Runar
         resolved_args: [],
         method_selector_hex: '',
         is_stateful: false,
+        parent_stateful: false,
         is_terminal: false,
         needs_op_push_tx: false,
         method_needs_change: false,

--- a/packages/runar-rb/spec/sdk/types_spec.rb
+++ b/packages/runar-rb/spec/sdk/types_spec.rb
@@ -143,6 +143,21 @@ RSpec.describe 'Runar::SDK types' do
         expect(param.type).to eq('Ripemd160')
       end
 
+      it 'defaults parent_class to empty string when parentClass is absent' do
+        expect(artifact.parent_class).to eq('')
+      end
+
+      it 'parses parentClass when present (issue #44 trim gate)' do
+        # A StatefulSmartContract with ZERO mutable fields has empty stateFields
+        # yet still injects checkPreimage at entry; parentClass is the
+        # authoritative signal for the terminal sighash subscript trim.
+        hash_with_parent = MINIMAL_ARTIFACT_HASH.dup
+        hash_with_parent['parentClass'] = 'StatefulSmartContract'
+        art = described_class.from_hash(hash_with_parent)
+        expect(art.parent_class).to eq('StatefulSmartContract')
+        expect(art.state_fields).to eq([])
+      end
+
       it 'parses ABI methods' do
         expect(artifact.abi.methods.length).to eq(1)
         method = artifact.abi.methods.first

--- a/packages/runar-rs/src/sdk/codegen.rs
+++ b/packages/runar-rs/src/sdk/codegen.rs
@@ -913,6 +913,7 @@ mod tests {
         RunarArtifact {
             version: "0.1.0".to_string(),
             contract_name: name.to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: ctor_params,

--- a/packages/runar-rs/src/sdk/contract.rs
+++ b/packages/runar-rs/src/sdk/contract.rs
@@ -432,9 +432,13 @@ impl RunarContract {
             // `find_codesep_offsets`.
             // Stateless contracts: the user controls statement order and may
             // place checkSig BEFORE the codesep (e.g. CovenantVault) — those
-            // must use the FULL script, so the trim stays gated on `is_stateful`.
+            // must use the FULL script, so the trim stays gated on the parent
+            // class. A stateful contract with ZERO mutable fields (empty
+            // state_fields) still injects checkPreimage at entry, so the trim
+            // is gated on `parent_stateful` (artifact parent_class), NOT
+            // `is_stateful` (issue #44).
             let mut subscript = contract_utxo.script.clone();
-            if prepared.is_stateful && prepared.code_sep_idx >= 0 {
+            if prepared.parent_stateful && prepared.code_sep_idx >= 0 {
                 let trim_pos = ((prepared.code_sep_idx as usize) + 1) * 2;
                 if trim_pos <= subscript.len() {
                     subscript = subscript[trim_pos..].to_string();
@@ -483,6 +487,15 @@ impl RunarContract {
             .state_fields
             .as_ref()
             .map_or(false, |f| !f.is_empty());
+        // parent_stateful gates ONLY the issue-#42/#44 terminal sighash
+        // subscript trim. A StatefulSmartContract with zero mutable fields has
+        // empty state_fields yet still injects checkPreimage at method entry,
+        // so its user checkSig runs after the OP_CODESEPARATOR. parent_class is
+        // the authoritative signal; fall back to is_stateful for older artifacts.
+        let parent_stateful = match self.artifact.parent_class.as_deref() {
+            Some(pc) => pc == "StatefulSmartContract",
+            None => is_stateful,
+        };
 
         // For stateful contracts, the compiler injects implicit params into every
         // public method's ABI (SigHashPreimage, and for state-mutating methods:
@@ -612,7 +625,7 @@ impl RunarContract {
             return self.prepare_call_terminal(
                 method_name, &mut resolved_args, signer,
                 options, terminal_outputs, &current_utxo,
-                is_stateful, needs_op_push_tx, method_needs_change,
+                is_stateful, parent_stateful, needs_op_push_tx, method_needs_change,
                 &sig_indices, &prevouts_indices, preimage_index,
                 &method_selector_hex, &change_pkh_hex, &witness_hex,
             );
@@ -1092,6 +1105,7 @@ impl RunarContract {
             resolved_args,
             method_selector_hex,
             is_stateful,
+            parent_stateful,
             is_terminal: false,
             needs_op_push_tx,
             method_needs_change,
@@ -1224,6 +1238,7 @@ impl RunarContract {
         terminal_outputs: &[TerminalOutput],
         current_utxo: &Utxo,
         is_stateful: bool,
+        parent_stateful: bool,
         needs_op_push_tx: bool,
         method_needs_change: bool,
         sig_indices: &[usize],
@@ -1383,6 +1398,7 @@ impl RunarContract {
             resolved_args: resolved_args.clone(),
             method_selector_hex: method_selector_hex.to_string(),
             is_stateful,
+            parent_stateful,
             is_terminal: true,
             needs_op_push_tx,
             method_needs_change,
@@ -2165,6 +2181,7 @@ mod tests {
         RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi,
             script: script.to_string(),
             state_fields: None,
@@ -2216,6 +2233,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![AbiParam {
@@ -2246,6 +2264,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "P2PKH".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![AbiParam {
@@ -2288,6 +2307,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "TwoKeys".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![
@@ -2325,6 +2345,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![AbiParam {
@@ -2360,6 +2381,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![AbiParam {
@@ -2390,6 +2412,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![AbiParam { name: "x".to_string(), param_type: "bigint".to_string(), fixed_array: None }],
@@ -2821,6 +2844,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![
@@ -2900,6 +2924,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![AbiParam { name: "count".to_string(), param_type: "bigint".to_string(), fixed_array: None }],
@@ -2934,6 +2959,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![
@@ -3160,6 +3186,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Counter".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -3187,6 +3214,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Counter".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -3214,6 +3242,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Counter".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -3241,6 +3270,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Counter".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -3287,6 +3317,7 @@ mod tests {
         RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Counter".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor {
                     params: vec![AbiParam { name: "count".to_string(), param_type: "bigint".to_string(), fixed_array: None }],

--- a/packages/runar-rs/src/sdk/script_utils.rs
+++ b/packages/runar-rs/src/sdk/script_utils.rs
@@ -309,6 +309,7 @@ mod tests {
         RunarArtifact {
             version: "0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: constructor_params },
                 methods: vec![AbiMethod {
@@ -368,6 +369,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -462,6 +464,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -499,6 +502,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: vec![] },
                 methods: vec![],

--- a/packages/runar-rs/src/sdk/state.rs
+++ b/packages/runar-rs/src/sdk/state.rs
@@ -957,6 +957,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: super::super::types::Abi {
                 constructor: super::super::types::AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -978,6 +979,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: super::super::types::Abi {
                 constructor: super::super::types::AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -1000,6 +1002,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: super::super::types::Abi {
                 constructor: super::super::types::AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -1031,6 +1034,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: super::super::types::Abi {
                 constructor: super::super::types::AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -1068,6 +1072,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: super::super::types::Abi {
                 constructor: super::super::types::AbiConstructor { params: vec![] },
                 methods: vec![],
@@ -1098,6 +1103,7 @@ mod tests {
         let artifact = RunarArtifact {
             version: "runar-v0.1.0".to_string(),
             contract_name: "Test".to_string(),
+            parent_class: None,
             abi: super::super::types::Abi {
                 constructor: super::super::types::AbiConstructor { params: vec![] },
                 methods: vec![],

--- a/packages/runar-rs/src/sdk/token_wallet.rs
+++ b/packages/runar-rs/src/sdk/token_wallet.rs
@@ -261,6 +261,7 @@ mod tests {
         RunarArtifact {
             version: "0.1.0".to_string(),
             contract_name: "FungibleToken".to_string(),
+            parent_class: None,
             abi: Abi {
                 constructor: AbiConstructor { params: vec![] },
                 methods: vec![

--- a/packages/runar-rs/src/sdk/types.rs
+++ b/packages/runar-rs/src/sdk/types.rs
@@ -135,6 +135,12 @@ pub struct OutputSpec {
 pub struct RunarArtifact {
     pub version: String,
     pub contract_name: String,
+    /// Base class the source contract extends. Authoritative stateful signal
+    /// for the issue-#42/#44 terminal sighash subscript trim: a
+    /// StatefulSmartContract with zero mutable fields still needs the trim
+    /// even though `state_fields` is empty. Older artifacts omit it.
+    #[serde(default)]
+    pub parent_class: Option<String>,
     pub abi: Abi,
     pub script: String,
     #[serde(default)]
@@ -582,6 +588,10 @@ pub struct PreparedCall {
     pub(crate) resolved_args: Vec<SdkValue>,
     pub(crate) method_selector_hex: String,
     pub(crate) is_stateful: bool,
+    /// True when the contract extends StatefulSmartContract (from artifact
+    /// `parent_class`), independent of whether it has mutable state fields.
+    /// Gates the issue-#42/#44 terminal sighash subscript trim.
+    pub(crate) parent_stateful: bool,
     pub(crate) is_terminal: bool,
     pub(crate) needs_op_push_tx: bool,
     pub(crate) method_needs_change: bool,

--- a/packages/runar-rs/tests/intent_witness_values.rs
+++ b/packages/runar-rs/tests/intent_witness_values.rs
@@ -44,6 +44,7 @@ fn make_intent_artifact(prev_out_inputs: &[usize], serialised: bool) -> RunarArt
     RunarArtifact {
         version: "runar-v0.1.0".to_string(),
         contract_name: "IntentWitnessTest".to_string(),
+        parent_class: None,
         abi: Abi {
             constructor: AbiConstructor {
                 params: vec![AbiParam {

--- a/packages/runar-rs/tests/script_size_guard.rs
+++ b/packages/runar-rs/tests/script_size_guard.rs
@@ -23,6 +23,7 @@ fn make_artifact(script: &str, contract_name: &str, methods: Vec<AbiMethod>) -> 
     RunarArtifact {
         version: "runar-v0.1.0".to_string(),
         contract_name: contract_name.to_string(),
+        parent_class: None,
         abi: Abi {
             constructor: AbiConstructor { params: vec![] },
             methods,

--- a/packages/runar-sdk/src/contract.ts
+++ b/packages/runar-sdk/src/contract.ts
@@ -509,16 +509,19 @@ export class RunarContract {
     // getSubscriptForSigning's byte-walker).
     // Stateless contracts: the user controls statement order and may place
     // checkSig BEFORE the codesep (e.g. CovenantVault) — those must use the
-    // FULL script, so the trim stays gated on `_isStateful`.
+    // FULL script, so the trim stays gated on the parent class. A stateful
+    // contract with ZERO mutable fields (empty stateFields) still injects
+    // checkPreimage at entry, so the trim is gated on `_parentStateful`
+    // (artifact.parentClass), NOT `_isStateful` (issue #44).
     let mIdx = 0;
-    if (prepared._isStateful) {
+    if (prepared._parentStateful) {
       const pubMethods = this.artifact.abi.methods.filter((m) => m.isPublic);
       if (pubMethods.length > 1) {
         const idx = pubMethods.findIndex((m) => m.name === methodName);
         if (idx >= 0) mIdx = idx;
       }
     }
-    const sigSubscript = prepared._isStateful
+    const sigSubscript = prepared._parentStateful
       ? this.getSubscriptForSigning(prepared._contractUtxo.script, mIdx)
       : prepared._contractUtxo.script;
 
@@ -564,6 +567,17 @@ export class RunarContract {
     const isStateful =
       this.artifact.stateFields !== undefined &&
       this.artifact.stateFields.length > 0;
+    // `isStateful` (derived from non-empty stateFields) drives continuation
+    // params, op_push_tx, change outputs, etc. But a StatefulSmartContract
+    // with ZERO mutable fields has empty stateFields yet STILL auto-injects
+    // checkPreimage at method entry — so its user checkSig runs AFTER the
+    // OP_CODESEPARATOR and needs the issue-#42 subscript trim. The parentClass
+    // is the authoritative signal for the trim gate (issue #44). Fall back to
+    // `isStateful` for older artifacts that predate the parentClass field.
+    const parentStateful =
+      this.artifact.parentClass !== undefined
+        ? this.artifact.parentClass === 'StatefulSmartContract'
+        : isStateful;
     const methodNeedsChange = method.params.some((p) => p.name === '_changePKH');
     const methodNeedsNewAmount = method.params.some((p) => p.name === '_newAmount');
     // Drop auto-injected continuation params AND intent-intrinsic witness
@@ -786,6 +800,7 @@ export class RunarContract {
         _resolvedArgs: resolvedArgs,
         _methodSelectorHex: methodSelectorHex,
         _isStateful: isStateful,
+        _parentStateful: parentStateful,
         _isTerminal: true,
         _needsOpPushTx: needsOpPushTx,
         _methodNeedsChange: methodNeedsChange,
@@ -1140,6 +1155,7 @@ export class RunarContract {
       _resolvedArgs: resolvedArgs,
       _methodSelectorHex: methodSelectorHex,
       _isStateful: isStateful,
+      _parentStateful: parentStateful,
       _isTerminal: false,
       _needsOpPushTx: needsOpPushTx,
       _methodNeedsChange: methodNeedsChange,

--- a/packages/runar-sdk/src/types.ts
+++ b/packages/runar-sdk/src/types.ts
@@ -71,6 +71,15 @@ export interface PreparedCall {
   /** @internal */ _resolvedArgs: unknown[];
   /** @internal */ _methodSelectorHex: string;
   /** @internal */ _isStateful: boolean;
+  /**
+   * @internal
+   * True when the contract extends StatefulSmartContract (from artifact
+   * `parentClass`), independent of whether it has mutable state fields.
+   * Gates the issue-#42/#44 terminal sighash subscript trim: a stateful
+   * contract with ZERO mutable fields still auto-injects checkPreimage at
+   * method entry, so its user checkSig runs after the OP_CODESEPARATOR.
+   */
+  _parentStateful: boolean;
   /** @internal */ _isTerminal: boolean;
   /** @internal */ _needsOpPushTx: boolean;
   /** @internal */ _methodNeedsChange: boolean;

--- a/packages/runar-zig/src/sdk_contract.zig
+++ b/packages/runar-zig/src/sdk_contract.zig
@@ -330,6 +330,14 @@ pub const RunarContract = struct {
         _ = method;
 
         const is_stateful = self.artifact.state_fields.len > 0;
+        // parent_stateful gates the issue-#42/#44 terminal sighash subscript
+        // trim AND the stateful-vs-stateless code path: a StatefulSmartContract
+        // with zero mutable fields has empty state_fields yet still injects
+        // checkPreimage at method entry (so it needs OP_PUSH_TX and the
+        // subscript trim). It is the authoritative signal; is_stateful still
+        // exclusively drives state-continuation output construction (a
+        // zero-mutable contract has no state to continue).
+        const parent_stateful = self.artifact.parentStateful();
 
         // Determine method index for method selector
         const public_methods = try self.getPublicMethods();
@@ -542,6 +550,14 @@ pub const RunarContract = struct {
         const has_multi_output =
             multi_output_specs != null and multi_output_specs.?.len > 0 and
             !is_terminal_call;
+
+        // A StatefulSmartContract with zero mutable fields (parent_stateful but
+        // !is_stateful) still routes through the OP_PUSH_TX stateful path (it
+        // needs op_push_tx + the issue-#44 subscript trim) but produces NO
+        // state-continuation output — it spends fully, exactly like a terminal
+        // call. Fold it into the terminal-suppression logic below.
+        const no_state_continuation = parent_stateful and !is_stateful;
+        const suppress_continuation = is_terminal_call or no_state_continuation;
 
         if (is_stateful and !is_terminal_call) {
             new_satoshis = contract_utxo.satoshis;
@@ -778,7 +794,11 @@ pub const RunarContract = struct {
         // ---------------------------------------------------------------
         // Stateless path
         // ---------------------------------------------------------------
-        if (!is_stateful) {
+        // Gated on parent_stateful (NOT is_stateful): a StatefulSmartContract
+        // with zero mutable fields routes through the OP_PUSH_TX stateful path
+        // below so its auto-injected checkPreimage gets a preimage AND its user
+        // checkSig is signed over the trimmed subscript (issue #44).
+        if (!parent_stateful) {
             // Build unlocking script: args + method selector
             const unlock = try self.buildUnlockingScript(method_name, resolved_args);
             defer self.allocator.free(unlock);
@@ -939,13 +959,13 @@ pub const RunarContract = struct {
             break :blk &.{};
         };
         const stateful_data_outputs: []const types.ContractOutput =
-            if (is_terminal_call) &.{} else data_outputs_hex.items;
+            if (suppress_continuation) &.{} else data_outputs_hex.items;
         const stateful_change_address: ?[]const u8 =
             if (is_terminal_call) null else change_address;
         const stateful_new_locking_script: []const u8 =
-            if (is_terminal_call or has_multi_output) "" else new_locking_script;
+            if (suppress_continuation or has_multi_output) "" else new_locking_script;
         const stateful_new_satoshis: i64 =
-            if (is_terminal_call or has_multi_output) 0 else new_satoshis;
+            if (suppress_continuation or has_multi_output) 0 else new_satoshis;
 
         const build_opts: call_mod.CallBuildOptions = .{
             .contract_outputs = stateful_contract_outputs,
@@ -1259,7 +1279,9 @@ pub const RunarContract = struct {
             var mu = old.*;
             mu.deinit(self.allocator);
         }
-        if (is_terminal_call) {
+        if (suppress_continuation) {
+            // Terminal call or zero-mutable stateful spend: fully spent, no
+            // continuation UTXO to track.
             self.current_utxo = null;
         } else {
             self.current_utxo = .{

--- a/packages/runar-zig/src/sdk_types.zig
+++ b/packages/runar-zig/src/sdk_types.zig
@@ -164,6 +164,11 @@ pub const RunarArtifact = struct {
     version: []const u8 = &.{},
     compiler_version: []const u8 = &.{},
     contract_name: []const u8 = &.{},
+    // Base class the source contract extends. Authoritative stateful signal
+    // for the issue-#42/#44 terminal sighash subscript trim: a
+    // StatefulSmartContract with zero mutable fields still needs the trim even
+    // though state_fields is empty. Empty for older artifacts.
+    parent_class: []const u8 = &.{},
     abi: ABI = .{},
     script: []const u8 = &.{},
     asm_text: []const u8 = &.{},
@@ -179,11 +184,23 @@ pub const RunarArtifact = struct {
         return self.state_fields.len > 0;
     }
 
+    /// True when the contract extends StatefulSmartContract (from
+    /// `parent_class`), independent of whether it has mutable state fields.
+    /// Gates the issue-#42/#44 terminal sighash subscript trim. Falls back to
+    /// `isStateful()` for older artifacts that predate the parentClass field.
+    pub fn parentStateful(self: *const RunarArtifact) bool {
+        if (self.parent_class.len > 0) {
+            return std.mem.eql(u8, self.parent_class, "StatefulSmartContract");
+        }
+        return self.isStateful();
+    }
+
     pub fn deinit(self: *RunarArtifact) void {
         const a = self.allocator;
         if (self.version.len > 0) a.free(self.version);
         if (self.compiler_version.len > 0) a.free(self.compiler_version);
         if (self.contract_name.len > 0) a.free(self.contract_name);
+        if (self.parent_class.len > 0) a.free(self.parent_class);
         if (self.script.len > 0) a.free(self.script);
         if (self.asm_text.len > 0) a.free(self.asm_text);
         if (self.build_timestamp.len > 0) a.free(self.build_timestamp);
@@ -209,6 +226,9 @@ pub const RunarArtifact = struct {
 
         if (root.get("contractName")) |v| {
             if (v == .string) artifact.contract_name = try allocator.dupe(u8, v.string);
+        }
+        if (root.get("parentClass")) |v| {
+            if (v == .string) artifact.parent_class = try allocator.dupe(u8, v.string);
         }
         if (root.get("version")) |v| {
             if (v == .string) artifact.version = try allocator.dupe(u8, v.string);


### PR DESCRIPTION
## Diagnosis

A `StatefulSmartContract` with **zero mutable fields** (`examples/ts/all-readonly-cleanstack/AllReadonlyCleanstack.runar.ts`, terminal `claim(sig)`) NULLFAILed on spend under strict node policy (`acceptnonstdtxn=0`).

The SDKs derived `is_stateful` from non-empty `state_fields`. With zero mutable fields, `state_fields` is empty, so a stateful contract looked **stateless** and the issue-#42/#44 **terminal sighash subscript trim** (gated on `is_stateful`) was skipped. The user `checkSig` was then signed over the FULL locking script instead of the codesep-trimmed subscript → `mandatory-script-verify-flag-failed (Signature must be zero for failed CHECK(MULTI)SIG operation)`.

**Fix:** emit `parentClass` (`SmartContract` | `StatefulSmartContract` | `UnsafeSmartContract`) into the artifact, and gate the terminal trim on `parentClass == "StatefulSmartContract"` — the authoritative stateful signal — while keeping `state_fields`-based `is_stateful` for its other uses (change params, op_push_tx, continuation, state serialization). `parentClass` is carried in-memory only at the IR layer (never serialized into ANF IR JSON), so cross-tier IR + hex parity is unaffected.

## Per-tier change table

| Tier | Compiler (emit parentClass) | SDK (gate trim on parentClass) | Status |
|------|------------------------------|--------------------------------|--------|
| Schema (runar-ir-schema) | n/a — added `parentClass` field | n/a | pre-existing on branch |
| TypeScript | done (prior) | done (prior) | tests pass (compiler 3332, sdk 518) |
| Rust | done (prior) | done (prior, reference gate) | tests pass (compiler + sdk 390) |
| Go | done (prior, `json:"-"`) | done (prior) | sdk tests pass |
| Python | done (prior, IR-excluded) | done (prior) | compiler 1005, sdk 515 pass |
| Zig | done (prior) | done (prior) | compiler 627, sdk pass |
| **Ruby** | **this PR** — ANFProgram/Artifact carry `parent_class`; emit top-level `parentClass`; excluded from `--emit-ir` + ANF serializer; preserved through constant_fold + anf_optimize | **this PR** — parse `parentClass`; `PreparedCall.parent_stateful`; trim gates on `parent_stateful` | compiler 35-file suite + sdk 927 pass |
| **Java** | n/a — the Java compiler has no artifact-emit path (emits ANF IR / hex only) | **this PR** — `RunarArtifact` parses `parentClass` + `parentStateful()`; `RunarContract` routes zero-mutable-field stateful into the OP_PUSH_TX/codesep path via `parentStateful` | compiler + sdk tests pass |

Also fixed a pre-existing branch breakage: Rust compiler `#[cfg(test)]` `ANFProgram` literals were missing the `parent_class` field that the branch added to the struct.

## Conformance — unaffected

Full multi-format suite: **549 / 549 pass** across all 7 tiers (TS, Go, Rust, Python, Zig, Ruby, Java). `parentClass` changes **neither the ANF IR nor the script hex**:
- Ruby `--emit-ir` contains no `parent_class`/`parentClass`; Ruby IR is byte-equal to the checked-in golden for `all-readonly-cleanstack`.
- Ruby `--hex` (fold-off) is byte-equal to `expected-script.hex`.
- Go `--emit-ir` carries no `parentClass` (struct `json:"-"`).

## On-chain proof (strict regtest, acceptnonstdtxn=0)

Isolated node `cdf` on ports 19777/20777/28777; `grep acceptnonstdtxn integration/regtest-data/cdf/bitcoin.conf` = `0`. Funded via RPC (`generatetoaddress 110`).

New Rust integration test `all_readonly_cleanstack` deploys + spends the terminal `claim()` (`&[SdkValue::Auto, SdkValue::Auto]`):

- **AFTER (fix):** ACCEPTED — deploy 309 B + claim 648 B broadcast OK.
- **BEFORE (gate reverted to `is_stateful`):** REJECTED — `mandatory-script-verify-flag-failed (Signature must be zero for failed CHECK(MULTI)SIG operation)` (the NULLFAIL).
- **No regression:** all 12 `covenant_vault` + `auction` regtest tests pass, including `auction_close` (terminal stateful, 1102 B) and `covenant_vault_deploy` (stateless covenant still signs the FULL script — `parentStateful == false`, `codeSepIdx == -1`).

## Test plan

- [x] Ruby compiler (`rake test`) + SDK (`rspec`, 927) pass
- [x] Java compiler (`gradle test`) + SDK (`gradle test`) pass
- [x] Rust compiler (`cargo test`) + SDK (390) pass; pre-existing test-literal breakage fixed
- [x] Go / Python / Zig / TS suites pass
- [x] Conformance multi-format 549/549 across 7 tiers
- [x] On-chain: all-readonly claim ACCEPTED; before-state NULLFAILs; covenant/auction no regression

## Not verified / caveats

- Pre-existing, unrelated Go compiler failure `TestAliasBindingMultipleMethods_MatchesReference` (alias-binding lowering diverges from the reference). The branch's only Go diff vs `main` is the additive `ParentClass` plumbing — Go codegen is byte-identical to `main`, so this failure pre-dates and is unrelated to this task. Left untouched to stay in scope.
- The non-terminal multi-signer `RunarContract.prepareCall` (Java) still computes its sighash over the full script (`computeContractSighash`), matching pre-existing behaviour and the reference scope (only the terminal/`call` trim was in scope). Not exercised by the all-readonly terminal test.