### PR TITLE
fix(compiler/go): refresh stale alias-binding regression golden (post-#48 CLEANSTACK)

### DIFF
--- a/compilers/go/compiler/alias_binding_regression_test.go
+++ b/compilers/go/compiler/alias_binding_regression_test.go
@@ -17,14 +17,22 @@ import "testing"
 //	}
 //
 // The reference compilers emit `OVER ROT NUMEQUAL` for the body (dup b,
-// rotate, compare). The Go compiler instead emits `0 0 0 NOT` — it throws
-// the parameter references away and succeeds unconditionally on three push-0s.
+// rotate, compare). The Go compiler instead emits `0 0 0 NOT` — it threw
+// the parameter references away and succeeded unconditionally on three push-0s.
 //
-// Expected hex (confirmed identical across ts / rust / python / zig / ruby
-// via the IR differential fuzzer):
+// Since issue #44 / PR #48, cleanupExcessStack() runs for *every* public
+// method (not just stateful methods that deserialize mutable fields), so the
+// two unconsumed parameters (`a` and `c`) left below the assertion result in
+// method9 are now balanced off with `OP_NIP OP_NIP` to satisfy CLEANSTACK.
 //
-//	76009c6375787b9c67519d9168
-//	|dispatch|method9|method7|
+// Expected hex (re-confirmed byte-identical across ts / rust / python on the
+// current tree; see PR diagnosis):
+//
+//	76009c6375787b9c777767519d9168
+//	|dispatch|----method9----|method7|
+//
+// where method9 body = OVER ROT NUMEQUAL NIP NIP (compare b===b, then clean
+// the two leftover params), and method7 body = 1 NUMEQUALVERIFY NOT.
 func TestAliasBindingMultipleMethods_MatchesReference(t *testing.T) {
 	source := `import { SmartContract, assert } from 'runar-lang';
 
@@ -48,7 +56,7 @@ class Repro extends SmartContract {
 }
 `
 
-	const expectedHex = "76009c6375787b9c67519d9168"
+	const expectedHex = "76009c6375787b9c777767519d9168"
 
 	result := CompileFromSourceStrWithResult(source, "Repro.runar.ts", CompileOptions{DisableConstantFolding: true})
 	if !result.Success {


### PR DESCRIPTION
## Problem

The main CI **Go Compiler** job fails on one test — `TestAliasBindingMultipleMethods_MatchesReference` (`compilers/go/compiler/alias_binding_regression_test.go`). Its failure cascades to SKIP the Integration Tests + Conformance Tests jobs, blocking all of main CI. Pre-existing, unrelated to recent work, not runar-verification.

```
got:  76009c6375787b9c777767519d9168
want: 76009c6375787b9c67519d9168
```

## Diagnosis — which side was wrong

The **golden was stale**, not the compiler. Decoded, the only difference is the Go output now appends `OP_NIP OP_NIP` inside `method9`'s branch:

```
got:  ... OP_OVER OP_ROT OP_NUMEQUAL OP_NIP OP_NIP OP_ELSE ...
want: ... OP_OVER OP_ROT OP_NUMEQUAL          OP_ELSE ...
```

That is exactly the behavior introduced by **PR #48 / issue #44**, which dropped the `hasDeserializeState` gate so `cleanupExcessStack()` runs for *every* public method (CLEANSTACK fix for all-readonly stateful contracts). `method9(a, b, c)` only consumes `b`; the two unconsumed params (`a`, `c`) left below the assertion result are now balanced off with two `OP_NIP`s. The test golden was written in commit `0f5211fd` (a separate Go *parser* fix) and never refreshed when #48 landed.

## Proof the Go output is correct (all tiers agree)

Compiled the exact test source through the reference compilers on the current tree:

| Tier | hex |
|---|---|
| TypeScript (reference) | `76009c6375787b9c777767519d9168` |
| Rust | `76009c6375787b9c777767519d9168` |
| Python | `76009c6375787b9c777767519d9168` |
| Go | `76009c6375787b9c777767519d9168` |

All byte-identical, with the `OP_NIP OP_NIP`. The stale golden (`...9c67519d9168`) appears nowhere else in the repo — no sibling tier test or conformance fixture carried it.

## Change

Surgical: update the hardcoded `expectedHex` and its explanatory comment in the one Go test. No compiler codegen, IR, or conformance fixture touched.

## Verification

- `cd compilers/go && go test ./...` — all 5 packages PASS.
- Multi-format conformance (fold-OFF, the mode the failing CI step uses): **549 passed, 0 failed, 0 skipped** (60 fixtures × 9 formats × 7 tiers) — no cross-tier regression.

## Notes

- Draft per request; do not merge.
- runar-verification/ untouched.