### PR TITLE
fix(integration): 1-sat data outputs under strict regtest oracle (+ rust module dedup)

### DIFF
--- a/integration/java/src/test/java/runar/integration/DataOutputsIntegrationTest.java
+++ b/integration/java/src/test/java/runar/integration/DataOutputsIntegrationTest.java
@@ -42,7 +42,15 @@ class DataOutputsIntegrationTest extends IntegrationBase {
 
             public emit(payload: ByteString) {
                 this.counter = this.counter + 1n;
-                this.addDataOutput(0n, payload);
+                // 1 satoshi (not 0): the CI regtest node runs with
+                // acceptnonstdtxn=0 (oracle hardening, PR #49), whose dust
+                // policy rejects 0-satoshi OP_RETURN outputs as "dust" at
+                // sendrawtransaction. A 1-sat data output is still a valid
+                // OP_RETURN data carrier and exercises the same
+                // declaration-order continuation-hash layout. The 0-sat form
+                // remains valid on mainnet/ARC and is covered by the
+                // cross-tier conformance suite.
+                this.addDataOutput(1n, payload);
             }
         }
         """;

--- a/integration/java/src/test/java/runar/integration/PrivateHelperOutputsIntegrationTest.java
+++ b/integration/java/src/test/java/runar/integration/PrivateHelperOutputsIntegrationTest.java
@@ -1,6 +1,9 @@
 package runar.integration;
 
+import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +32,36 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * tests for the same contract.
  */
 class PrivateHelperOutputsIntegrationTest extends IntegrationBase {
+
+    // Inline private-helper variant whose record() helper emits a 1-satoshi
+    // (not 0) data output. The CI regtest node runs with acceptnonstdtxn=0
+    // (oracle hardening, PR #49) and rejects 0-satoshi OP_RETURN outputs as
+    // "dust" at sendrawtransaction. The shared conformance contract
+    // (examples/ts/private-helper-outputs/PrivateHelperOutputs.runar.ts) is
+    // deliberately left at 0n so its cross-tier hex goldens stay frozen; this
+    // inline source preserves the exact "data output routed through a private
+    // helper, broadcast to a live node" assertion without that golden churn.
+    private static final String LOG_SOURCE = """
+        import { StatefulSmartContract, ByteString, assert } from 'runar-lang';
+
+        export class PrivateHelperLog extends StatefulSmartContract {
+            counter: bigint;
+
+            constructor(counter: bigint) {
+                super(counter);
+                this.counter = counter;
+            }
+
+            private record(payload: ByteString): void {
+                this.addDataOutput(1n, payload);
+            }
+
+            public log(payload: ByteString): void {
+                this.record(payload);
+                assert(true);
+            }
+        }
+        """;
 
     @Test
     @DisplayName("commit chain: three sequential calls each spend the previous continuation")
@@ -60,9 +93,14 @@ class PrivateHelperOutputsIntegrationTest extends IntegrationBase {
     @Test
     @DisplayName("log() routes a data output through a private helper")
     void logEmitsDataOutput() {
-        RunarArtifact artifact = ContractCompiler.compileRelative(
-            "examples/ts/private-helper-outputs/PrivateHelperOutputs.runar.ts"
-        );
+        Path tmp;
+        try {
+            tmp = Files.createTempFile("runar-private-helper-log-", "PrivateHelperLog.runar.ts");
+            Files.writeString(tmp, LOG_SOURCE);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        RunarArtifact artifact = ContractCompiler.compileAbsolute(tmp);
 
         RpcProvider provider = new RpcProvider(rpc);
         IntegrationWallet wallet = IntegrationWallet.createFunded(rpc, 1.0);

--- a/integration/python/test_data_outputs.py
+++ b/integration/python/test_data_outputs.py
@@ -34,7 +34,14 @@ export class DataEmitter extends StatefulSmartContract {
 
     public emit(payload: ByteString) {
         this.counter = this.counter + 1n;
-        this.addDataOutput(0n, payload);
+        // 1 satoshi (not 0): the CI regtest node runs with
+        // acceptnonstdtxn=0 (oracle hardening, PR #49), whose dust policy
+        // rejects 0-satoshi OP_RETURN outputs as "dust" at
+        // sendrawtransaction. A 1-sat data output is still a valid
+        // OP_RETURN data carrier and exercises the same declaration-order
+        // continuation-hash layout. The 0-sat form remains valid on
+        // mainnet/ARC and is covered by the cross-tier conformance suite.
+        this.addDataOutput(1n, payload);
     }
 }
 """
@@ -126,8 +133,8 @@ class TestDataOutputs:
         outs = _parse_outputs(raw_hex)
         assert len(outs) >= 2, f"expected >=2 outputs, got {len(outs)}"
 
-        # Output[1] is the data output: 0 satoshis, exact payload script.
-        assert outs[1][0] == 0
+        # Output[1] is the data output: 1 satoshi, exact payload script.
+        assert outs[1][0] == 1
         assert outs[1][1] == payload
 
     def test_chain_two_emits_accumulates_state(self):
@@ -159,4 +166,4 @@ class TestDataOutputs:
         raw2 = rpc_call("getrawtransaction", t2)
         outs2 = _parse_outputs(raw2)
         assert outs2[1][1] == payload2
-        assert outs2[1][0] == 0
+        assert outs2[1][0] == 1

--- a/integration/python/test_private_helper_outputs.py
+++ b/integration/python/test_private_helper_outputs.py
@@ -9,10 +9,61 @@ classified as terminal and the deploy + call cycle would fail.
 Mirrors the TS / Go integration tests for the same contract.
 """
 
+import json
+import os
+import tempfile
+
 from conftest import (
     compile_contract, create_provider, create_funded_wallet,
 )
-from runar.sdk import RunarContract, DeployOptions
+from runar_compiler.compiler import compile_from_source, artifact_to_json
+from runar.sdk import RunarArtifact, RunarContract, DeployOptions
+
+
+# Inline private-helper variant whose `record()` helper emits a 1-satoshi
+# (not 0) data output. The CI regtest node runs with acceptnonstdtxn=0
+# (oracle hardening, PR #49) and rejects 0-satoshi OP_RETURN outputs as
+# "dust" at sendrawtransaction. The shared conformance contract
+# (examples/ts/private-helper-outputs/PrivateHelperOutputs.runar.ts) is
+# deliberately left at 0n so its cross-tier hex goldens stay frozen; this
+# inline source preserves the exact "data output routed through a private
+# helper, broadcast to a live node" assertion without that golden churn.
+LOG_SOURCE = """\
+import { StatefulSmartContract, ByteString, assert } from 'runar-lang';
+
+export class PrivateHelperLog extends StatefulSmartContract {
+    counter: bigint;
+
+    constructor(counter: bigint) {
+        super(counter);
+        this.counter = counter;
+    }
+
+    private record(payload: ByteString): void {
+        this.addDataOutput(1n, payload);
+    }
+
+    public log(payload: ByteString): void {
+        this.record(payload);
+        assert(true);
+    }
+}
+"""
+
+
+def _compile_source(source: str, file_name: str) -> RunarArtifact:
+    """Compile inline source to an SDK artifact via a temp file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=file_name, delete=False, dir=tempfile.gettempdir()
+    ) as f:
+        f.write(source)
+        tmp_path = f.name
+    try:
+        compiler_artifact = compile_from_source(tmp_path)
+        artifact_dict = json.loads(artifact_to_json(compiler_artifact))
+        return RunarArtifact.from_dict(artifact_dict)
+    finally:
+        os.unlink(tmp_path)
 
 
 class TestPrivateHelperOutputs:
@@ -45,9 +96,7 @@ class TestPrivateHelperOutputs:
         """log routes a data output through a private helper —
         verifies the F1 fix's recursive scan picks up
         addDataOutput inside a private method."""
-        artifact = compile_contract(
-            "examples/ts/private-helper-outputs/PrivateHelperOutputs.runar.ts"
-        )
+        artifact = _compile_source(LOG_SOURCE, "PrivateHelperLog.runar.ts")
         contract = RunarContract(artifact, [0])
 
         provider = create_provider()

--- a/integration/ruby/spec/data_outputs_spec.rb
+++ b/integration/ruby/spec/data_outputs_spec.rb
@@ -50,7 +50,14 @@ DATA_EMITTER_SOURCE = <<~TS.freeze
 
       public emit(payload: ByteString) {
           this.counter = this.counter + 1n;
-          this.addDataOutput(0n, payload);
+          // 1 satoshi (not 0): the CI regtest node runs with
+          // acceptnonstdtxn=0 (oracle hardening, PR #49), whose dust policy
+          // rejects 0-satoshi OP_RETURN outputs as "dust" at
+          // sendrawtransaction. A 1-sat data output is still a valid
+          // OP_RETURN data carrier and exercises the same declaration-order
+          // continuation-hash layout. The 0-sat form remains valid on
+          // mainnet/ARC and is covered by the cross-tier conformance suite.
+          this.addDataOutput(1n, payload);
       }
   }
 TS

--- a/integration/ruby/spec/private_helper_outputs_spec.rb
+++ b/integration/ruby/spec/private_helper_outputs_spec.rb
@@ -13,6 +13,58 @@
 
 require 'spec_helper'
 
+# Compile an inline TypeScript source string to a RunarArtifact via the
+# reference TS compiler (Node.js). Mirrors data_outputs_spec.rb.
+def compile_source_inline(source, file_name)
+  script = <<~JS
+    (async () => {
+      const { compile } = await import('#{PROJECT_ROOT}/packages/runar-compiler/dist/index.js');
+      const result = compile(#{source.inspect}, { fileName: #{file_name.inspect} });
+      if (!result.success) { console.error(JSON.stringify(result.diagnostics)); process.exit(1); }
+      const json = JSON.stringify(result.artifact, (k, v) => typeof v === 'bigint' ? v.toString() + 'n' : v);
+      process.stdout.write(json);
+    })();
+  JS
+
+  node_bin = ENV['NODE_BIN'] || `which node 2>/dev/null`.strip
+  node_bin = 'node' if node_bin.empty?
+  output = `#{node_bin} -e #{Shellwords.escape(script)} 2>&1`
+  status = Process.last_status
+  raise "Compilation failed for #{file_name}:\n#{output}" unless status&.success?
+
+  Runar::SDK::RunarArtifact.from_json(output)
+end
+
+# Inline private-helper variant whose `record()` helper emits a 1-satoshi
+# (not 0) data output. The CI regtest node runs with acceptnonstdtxn=0
+# (oracle hardening, PR #49) and rejects 0-satoshi OP_RETURN outputs as
+# "dust" at sendrawtransaction. The shared conformance contract
+# (examples/ts/private-helper-outputs/PrivateHelperOutputs.runar.ts) is
+# deliberately left at 0n so its cross-tier hex goldens stay frozen; this
+# inline source preserves the exact "data output routed through a private
+# helper, broadcast to a live node" assertion without that golden churn.
+PRIVATE_HELPER_LOG_SOURCE = <<~TS.freeze
+  import { StatefulSmartContract, ByteString, assert } from 'runar-lang';
+
+  export class PrivateHelperLog extends StatefulSmartContract {
+      counter: bigint;
+
+      constructor(counter: bigint) {
+          super(counter);
+          this.counter = counter;
+      }
+
+      private record(payload: ByteString): void {
+          this.addDataOutput(1n, payload);
+      }
+
+      public log(payload: ByteString): void {
+          this.record(payload);
+          assert(true);
+      }
+  }
+TS
+
 RSpec.describe 'PrivateHelperOutputs' do # rubocop:disable RSpec/DescribeClass
   let(:source_path) { 'examples/ts/private-helper-outputs/PrivateHelperOutputs.runar.ts' }
 
@@ -39,7 +91,7 @@ RSpec.describe 'PrivateHelperOutputs' do # rubocop:disable RSpec/DescribeClass
   end
 
   it 'log() routes a data output through a private helper' do
-    artifact = compile_contract(source_path)
+    artifact = compile_source_inline(PRIVATE_HELPER_LOG_SOURCE, 'PrivateHelperLog.runar.ts')
     contract = Runar::SDK::RunarContract.new(artifact, [0])
 
     provider = create_provider

--- a/integration/rust/tests/integration.rs
+++ b/integration/rust/tests/integration.rs
@@ -6,6 +6,11 @@ mod escrow;
 mod fungible_token;
 mod nft;
 mod auction;
+// Issue #44 / parentClass pipeline (2026-05-24): a StatefulSmartContract with
+// ZERO mutable fields NULLFAILed on spend under strict policy because the SDK
+// derived is_stateful from non-empty state_fields and skipped the terminal
+// sighash subscript trim. The fix carries parentClass in the artifact and gates
+// the trim on it. This test proves the terminal claim() is now ACCEPTED.
 mod all_readonly_cleanstack;
 mod covenant_vault;
 mod oracle_price_feed;
@@ -34,10 +39,3 @@ mod data_outputs;
 mod nullfail_multimethod;
 mod message_board;
 mod ordinals;
-
-// Issue #44 / parentClass pipeline (2026-05-24): a StatefulSmartContract with
-// ZERO mutable fields NULLFAILed on spend under strict policy because the SDK
-// derived is_stateful from non-empty state_fields and skipped the terminal
-// sighash subscript trim. The fix carries parentClass in the artifact and gates
-// the trim on it. This test proves the terminal claim() is now ACCEPTED.
-mod all_readonly_cleanstack;

--- a/integration/ts/data-outputs.test.ts
+++ b/integration/ts/data-outputs.test.ts
@@ -37,7 +37,14 @@ export class DataEmitter extends StatefulSmartContract {
 
     public emit(payload: ByteString) {
         this.counter = this.counter + 1n;
-        this.addDataOutput(0n, payload);
+        // 1 satoshi (not 0): the CI regtest node runs with
+        // acceptnonstdtxn=0 (oracle hardening, PR #49), whose dust policy
+        // rejects 0-satoshi OP_RETURN outputs as "dust" at
+        // sendrawtransaction. A 1-sat data output is still a valid
+        // OP_RETURN data carrier and exercises the same declaration-order
+        // continuation-hash layout. The 0-sat form remains valid on
+        // mainnet/ARC and is covered by the cross-tier conformance suite.
+        this.addDataOutput(1n, payload);
     }
 }
 `;
@@ -64,13 +71,13 @@ describe('DataOutputs (addDataOutput)', () => {
     const rawTxHex = (await rpcCall('getrawtransaction', callTxid)) as string;
     const tx = Transaction.fromHex(rawTxHex);
 
-    // Expected output order: [0]=state, [1]=data (OP_RETURN payload, 0 sats),
+    // Expected output order: [0]=state, [1]=data (OP_RETURN payload, 1 sat),
     // [2]=change (P2PKH). The state-continuation hash must match this exact
     // ordering for the spend to validate on-chain.
     expect(tx.outputs.length).toBeGreaterThanOrEqual(2);
 
     const dataOutput = tx.outputs[1]!;
-    expect(dataOutput.satoshis).toBe(0);
+    expect(dataOutput.satoshis).toBe(1);
     expect(dataOutput.lockingScript.toHex()).toBe(payload);
   });
 
@@ -97,6 +104,6 @@ describe('DataOutputs (addDataOutput)', () => {
     const raw2 = (await rpcCall('getrawtransaction', t2)) as string;
     const tx2 = Transaction.fromHex(raw2);
     expect(tx2.outputs[1]!.lockingScript.toHex()).toBe(payload2);
-    expect(tx2.outputs[1]!.satoshis).toBe(0);
+    expect(tx2.outputs[1]!.satoshis).toBe(1);
   });
 });

--- a/integration/ts/private-helper-outputs.test.ts
+++ b/integration/ts/private-helper-outputs.test.ts
@@ -12,10 +12,40 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { compileContract } from './helpers/compile.js';
+import { compileContract, compileSource } from './helpers/compile.js';
 import { RunarContract } from 'runar-sdk';
 import { createFundedWallet } from './helpers/wallet.js';
 import { createProvider } from './helpers/node.js';
+
+// Inline private-helper variant whose `record()` helper emits a 1-satoshi
+// (not 0) data output. The CI regtest node runs with acceptnonstdtxn=0
+// (oracle hardening, PR #49) and rejects 0-satoshi OP_RETURN outputs as
+// "dust" at sendrawtransaction. The shared conformance contract
+// (examples/ts/private-helper-outputs/PrivateHelperOutputs.runar.ts) is
+// deliberately left at 0n so its cross-tier hex goldens stay frozen; this
+// inline source preserves the exact "data output routed through a private
+// helper, broadcast to a live node" assertion without that golden churn.
+const LOG_SOURCE = `
+import { StatefulSmartContract, ByteString, assert } from 'runar-lang';
+
+export class PrivateHelperLog extends StatefulSmartContract {
+    counter: bigint;
+
+    constructor(counter: bigint) {
+        super(counter);
+        this.counter = counter;
+    }
+
+    private record(payload: ByteString): void {
+        this.addDataOutput(1n, payload);
+    }
+
+    public log(payload: ByteString): void {
+        this.record(payload);
+        assert(true);
+    }
+}
+`;
 
 describe('PrivateHelperOutputs', () => {
   it('commit invokes private state mutation and broadcasts a continuation tx', async () => {
@@ -34,7 +64,7 @@ describe('PrivateHelperOutputs', () => {
   });
 
   it('log routes a data output through a private helper', async () => {
-    const artifact = compileContract('examples/ts/private-helper-outputs/PrivateHelperOutputs.runar.ts');
+    const artifact = compileSource(LOG_SOURCE, 'PrivateHelperLog.runar.ts');
     const contract = new RunarContract(artifact, [0n]);
 
     const provider = createProvider();

--- a/integration/zig/contracts/DataOutputTestLive.runar.zig
+++ b/integration/zig/contracts/DataOutputTestLive.runar.zig
@@ -1,0 +1,24 @@
+const runar = @import("runar");
+
+// Integration-only variant of examples/zig/add-data-output/DataOutputTest
+// whose publish() emits a 1-satoshi (not 0) data output. The CI regtest node
+// runs with acceptnonstdtxn=0 (oracle hardening, PR #49) and rejects
+// 0-satoshi OP_RETURN outputs as "dust" at sendrawtransaction. The shared
+// example contract is conformance-linked (conformance/tests/add-data-output),
+// so it is deliberately left at 0 to keep its cross-tier hex goldens frozen;
+// this dedicated source preserves the live-broadcast assertion without that
+// golden churn. The 0-sat form remains valid on mainnet/ARC.
+pub const DataOutputTest = struct {
+    pub const Contract = runar.StatefulSmartContract;
+
+    count: i64 = 0,
+
+    pub fn init(count: i64) DataOutputTest {
+        return .{ .count = count };
+    }
+
+    pub fn publish(self: *DataOutputTest, payload: runar.ByteString) void {
+        self.count = self.count + 1;
+        self.addDataOutput(1, payload);
+    }
+};

--- a/integration/zig/src/data_outputs_test.zig
+++ b/integration/zig/src/data_outputs_test.zig
@@ -28,9 +28,13 @@ test "DataOutput_Deploy_Publish" {
 
     helpers.requireNodeAvailable(allocator);
 
+    // Integration-only 1-sat data-output variant (see contract file header):
+    // the CI regtest node (acceptnonstdtxn=0, PR #49) rejects 0-sat OP_RETURN
+    // as dust. The conformance-linked example contract stays at 0; the
+    // DataOutput_Compile test above still exercises it for parity coverage.
     var artifact = try compile.compileContract(
         allocator,
-        "examples/zig/add-data-output/DataOutputTest.runar.zig",
+        "integration/zig/contracts/DataOutputTestLive.runar.zig",
     );
     defer artifact.deinit();
 


### PR DESCRIPTION
## Summary

Phase-1 CI repair. After PRs #52/#53/#54 unblocked the Integration job, the **Integration Tests** job (a non-runar-verification job) was failing — but **not** with the anticipated stale-#48-golden pattern. Root cause is a node-policy / oracle mismatch surfaced by **PR #49** (`acceptnonstdtxn=0`).

### Diagnosis (verified locally against a CI-config regtest node)
- PR #49 hardened the integration oracle with `acceptnonstdtxn=0`.
- The BSV v1.2.2 regtest node's **dust policy rejects 0-satoshi `OP_RETURN` data outputs** (`addDataOutput(0n, ...)`) at `sendrawtransaction` (`64: dust`). Confirmed with a hand-crafted P2PKH→[0-sat OP_RETURN, change] tx: **rejected**; the same tx with a **1-sat** OP_RETURN: **accepted**. `acceptnonstdoutputs=true`/`datacarrier=true` are set, so this is specifically the dust check, and BSV v1.2.2 exposes no knob to exempt it. `dontcheckfee` does not bypass it.
- The compiler output is correct and the 0-sat form is valid on mainnet/ARC; this is purely the regtest node's stricter dust relay.

### Latency
The Integration job runs tiers sequentially under `-e -o pipefail`. It aborted at the **TypeScript** step, so the **Rust → Python → Ruby → Zig → Java** steps never ran. Their equivalent failures were therefore *masked*:
- Python / Ruby / Java / Zig integration tests also broadcast 0-sat OP_RETURN data outputs (Go & Rust use `MockProvider`, never broadcast).
- Rust integration **failed to compile** due to a pre-existing duplicate `mod all_readonly_cleanstack;` (PRs #50 and #51 each added the line).

### Fix
- Switch the **live-broadcast** data-output integration tests to a **1-satoshi** data output (TS, Python, Ruby, Java, Zig). Still a valid OP_RETURN data carrier; same declaration-order continuation-hash layout.
- Where the contract was **conformance-linked** (`PrivateHelperOutputs`, Zig `add-data-output`), the shared source is **left at `0n`/`0`** (frozen cross-tier hex goldens) and the test uses an inline/dedicated 1-sat variant instead — **zero conformance churn** (no `examples/` or `conformance/` files touched).
- Remove the pre-existing duplicate Rust module declaration (kept the issue-#44 doc comment on the surviving line).

### Local verification (regtest node with CI config: `acceptnonstdtxn=0`)
- TS integration: **32 files / 203 tests pass** (was 2 files / 3 tests failing).
- Python: 4/4 · Ruby: 4/4 · Java: DataOutputs 1/1 + PrivateHelper 2/2 · Zig: full suite exit 0, no `dust`.
- Go: 3/3 (MockProvider) · Rust: compiles + data-output/private-helper/all-readonly tests pass.
- No changes to compilers, SDKs, `examples/`, or `conformance/` ⇒ cross-tier conformance unaffected.

## Test plan
- [ ] CI "Integration Tests" job runs all tiers (Go/TS/Rust/Python/Ruby/Zig/Java) green
- [ ] CI "Conformance Tests" stays green (549/549)
- [ ] All non-runar-verification CI jobs green