### PR TITLE
GAP-064: cross-tier signing reproduction matrix + Zig RFC 6979 fix

### DIFF
--- a/conformance/sdk-envelope/fixtures.json
+++ b/conformance/sdk-envelope/fixtures.json
@@ -225,5 +225,32 @@
       }
     }
   ],
-  "note_on_pubkey_not_allowed": "pubkey-not-allowed cannot be expressed in a tier-agnostic fixture: it depends on caller-supplied expected_keys. Each tier verifies this reason in its own unit tests by passing a non-matching allowlist; the wire bytes are independent."
+  "note_on_pubkey_not_allowed": "pubkey-not-allowed cannot be expressed in a tier-agnostic fixture: it depends on caller-supplied expected_keys. Each tier verifies this reason in its own unit tests by passing a non-matching allowlist; the wire bytes are independent.",
+  "signing_vectors_notes": "GAP-064 cross-tier signing reproduction. Each tier, signing the SAME payload with the SAME key (alice priv=1) via RFC 6979 deterministic ECDSA whose nonce HMAC uses PLAIN SHA-256, MUST produce the BYTE-IDENTICAL low-S DER signature listed in expected_sig. expected_payload = canonicalJson({...data, nonce, expiresAt}); expected_sig = low-S DER of deterministic ECDSA over sha256(expected_payload) signed directly (the digest is the message representative — do NOT re-hash). Generated via the TS reference (runar-ir-schema canonicalJsonStringify + @bsv/sdk primitives/ECDSA sign with forceLowS=true).",
+  "signing_vectors": [
+    {
+      "_vector_id": "sv1-ascii",
+      "data": {
+        "kind": "order",
+        "qty": 3
+      },
+      "nonce": 1700000000000,
+      "expiresAt": 1700000030000,
+      "expected_payload": "{\"expiresAt\":1700000030000,\"kind\":\"order\",\"nonce\":1700000000000,\"qty\":3}",
+      "expected_sig": "304402205682099f1b0aec291acfbf0ba9b0840d195682074b154edd3711d298a8ca33eb02200c634e5ec29636cda382624e3b15d28a94ac997fbbba830dbbe025bcac76b0b1"
+    },
+    {
+      "_vector_id": "sv2-nonascii-astral-keys",
+      "_notes": "Non-ASCII BMP key (用户), astral-plane emoji key (🔥 = U+1F525), and a Latin-1 value (héllo). Exercises UTF-16 code-unit key ordering AND UTF-8 payload-byte hashing simultaneously: any tier that diverges on either canonicalization or nonce-hash will produce a different signature.",
+      "data": {
+        "用户": "alice",
+        "🔥": "fire",
+        "msg": "héllo"
+      },
+      "nonce": 1700000000000,
+      "expiresAt": 1700000030000,
+      "expected_payload": "{\"expiresAt\":1700000030000,\"msg\":\"héllo\",\"nonce\":1700000000000,\"用户\":\"alice\",\"🔥\":\"fire\"}",
+      "expected_sig": "304402207e137858bb8427abbeb1036b6fda12640edce81eba423181507cd4027ece63ac0220160f849fc4f8cd4c2b352623d4cd6e15d1557a8126d5d085b2dd34333c096f1e"
+    }
+  ]
 }

--- a/conformance/sdk-envelope/validate-fixtures.ts
+++ b/conformance/sdk-envelope/validate-fixtures.ts
@@ -30,7 +30,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { BigNumber, Hash, PrivateKey, PublicKey, Signature, Utils } from '@bsv/sdk';
-import { verify as ecdsaVerifyRaw } from '@bsv/sdk/primitives/ECDSA';
+import { verify as ecdsaVerifyRaw, sign as ecdsaSign } from '@bsv/sdk/primitives/ECDSA';
 // The SDK's wire `canonicalJson` (runar-sdk/src/envelope.ts) is a literal
 // re-export of this `canonicalJsonStringify`, so importing the source here
 // tests the identical function while avoiding a build of runar-ir-schema's
@@ -89,7 +89,41 @@ function main(): void {
     fail('valid_envelope.sig does not verify for its payload under the TS reference (canonicalJson/sha256/ECDSA drift)');
   }
 
-  console.log(`OK: ${vectors.length} canonical-JSON vectors + valid envelope signature validate against the TS reference.`);
+  // 3. GAP-064 signing vectors: re-derive payload + deterministic low-S DER
+  //    signature from the TS reference and assert byte-identity. This is the
+  //    drift guard for the cross-tier signing-reproduction matrix — if TS's
+  //    canonicalJson or its RFC 6979 (plain-SHA-256-nonce) ECDSA path drifts
+  //    from the committed bytes, this fails before any non-TS tier replays
+  //    against a stale expected_sig.
+  const alicePriv = new PrivateKey(1n);
+  const signingVectors = fixture.signing_vectors as Array<{
+    _vector_id?: string;
+    data: Record<string, unknown>;
+    nonce: number;
+    expiresAt: number;
+    expected_payload: string;
+    expected_sig: string;
+  }>;
+  if (!Array.isArray(signingVectors) || signingVectors.length === 0) {
+    fail('signing_vectors missing or empty');
+  }
+  for (const [i, v] of signingVectors.entries()) {
+    const id = v._vector_id ? ` (${v._vector_id})` : '';
+    const payload = canonicalJson({ ...v.data, nonce: v.nonce, expiresAt: v.expiresAt });
+    if (payload !== v.expected_payload) {
+      fail(`signing_vectors[${i}]${id}: expected_payload ${JSON.stringify(v.expected_payload)}, got ${JSON.stringify(payload)}`);
+    }
+    const d = Hash.sha256(Utils.toArray(payload, 'utf8'));
+    // forceLowS=true ⇒ canonical low-S form; the digest IS the message
+    // representative (sign the prehash directly, never re-hash).
+    const sig = ecdsaSign(new BigNumber(d), alicePriv, true);
+    const der = Utils.toHex(sig.toDER() as number[]);
+    if (der !== v.expected_sig) {
+      fail(`signing_vectors[${i}]${id}: expected_sig\n  committed:  ${v.expected_sig}\n  recomputed: ${der}`);
+    }
+  }
+
+  console.log(`OK: ${vectors.length} canonical-JSON vectors + valid envelope signature + ${signingVectors.length} signing vectors validate against the TS reference.`);
 }
 
 main();

--- a/packages/runar-go/sdk_envelope_interop_test.go
+++ b/packages/runar-go/sdk_envelope_interop_test.go
@@ -12,6 +12,8 @@ package runar
 // SDKs Must Stay in Sync" for the rationale.
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -200,4 +202,66 @@ func mustFixturePath(t *testing.T) string {
 	t.Helper()
 	_, thisFile, _, _ := runtime.Caller(0)
 	return filepath.Join(filepath.Dir(thisFile), "..", "..", "conformance", "sdk-envelope", "fixtures.json")
+}
+
+// TestEnvelopeInterop_SigningVectors is the GAP-064 cross-tier signing
+// reproduction: signing the SAME payload with the SAME key (priv=1) via RFC
+// 6979 deterministic ECDSA (plain-SHA-256 nonce, low-S) MUST yield the
+// byte-identical DER signature the TS reference committed. The testSigner's
+// SignHash signs the 32-byte digest directly (go-sdk PrivateKey.Sign) and
+// serializes low-S DER.
+func TestEnvelopeInterop_SigningVectors(t *testing.T) {
+	path := mustFixturePath(t)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var top map[string]any
+	dec := json.NewDecoder(stringReader(string(raw)))
+	dec.UseNumber()
+	if err := dec.Decode(&top); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	svs, _ := top["signing_vectors"].([]any)
+	if len(svs) == 0 {
+		t.Fatal("signing_vectors missing or empty")
+	}
+	alice := newAliceSigner(t)
+	for _, e := range svs {
+		v := e.(map[string]any)
+		id, _ := v["_vector_id"].(string)
+		expectedPayload := v["expected_payload"].(string)
+		expectedSig := v["expected_sig"].(string)
+
+		// Drift guard: re-derive the canonical payload from data + lifetime
+		// fields and confirm it matches the committed expected_payload.
+		data := normalizeJSON(v["data"]).(map[string]any)
+		merged := make(map[string]any, len(data)+2)
+		for k, val := range data {
+			merged[k] = val
+		}
+		merged["nonce"] = normalizeJSON(v["nonce"])
+		merged["expiresAt"] = normalizeJSON(v["expiresAt"])
+		payload, err := CanonicalJSON(merged)
+		if err != nil {
+			t.Errorf("vector %s: CanonicalJSON error: %v", id, err)
+			continue
+		}
+		if payload != expectedPayload {
+			t.Errorf("vector %s: payload\n  got:  %s\n want:  %s", id, payload, expectedPayload)
+			continue
+		}
+
+		// Sign sha256(expected_payload) with priv=1 deterministic ECDSA -> DER.
+		d := sha256.Sum256([]byte(expectedPayload))
+		der, err := alice.SignHash(d[:])
+		if err != nil {
+			t.Errorf("vector %s: sign: %v", id, err)
+			continue
+		}
+		got := hex.EncodeToString(der)
+		if got != expectedSig {
+			t.Errorf("vector %s: signature divergence\n  got:  %s\n want:  %s", id, got, expectedSig)
+		}
+	}
 }

--- a/packages/runar-java/src/test/java/runar/lang/sdk/EnvelopeInteropTest.java
+++ b/packages/runar-java/src/test/java/runar/lang/sdk/EnvelopeInteropTest.java
@@ -1,11 +1,19 @@
 package runar.lang.sdk;
 
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
+import org.bouncycastle.crypto.signers.ECDSASigner;
+import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,6 +91,74 @@ class EnvelopeInteropTest {
             Envelope.VerifyEnvelopeResult r = Envelope.verify(vo);
             assertFalse(r.ok, "rejection " + reasonWire + " should be ok=false");
             assertEquals(reasonWire, r.reason.wire, "rejection " + reasonWire);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // GAP-064 signing vectors
+    // -------------------------------------------------------------------
+
+    private static byte[] sha256(byte[] in) throws Exception {
+        return MessageDigest.getInstance("SHA-256").digest(in);
+    }
+
+    /** RFC 6979 deterministic ECDSA (plain-SHA-256 nonce) -> low-S DER. */
+    private static byte[] signDeterministic(BigInteger priv, byte[] digest) {
+        ECDSASigner signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
+        signer.init(true, new ECPrivateKeyParameters(priv, LocalSigner.DOMAIN));
+        BigInteger[] rs = signer.generateSignature(digest);
+        BigInteger r = rs[0];
+        BigInteger s = rs[1];
+        BigInteger halfN = LocalSigner.DOMAIN.getN().shiftRight(1);
+        if (s.compareTo(halfN) > 0) {
+            s = LocalSigner.DOMAIN.getN().subtract(s);
+        }
+        try {
+            org.bouncycastle.asn1.ASN1EncodableVector v = new org.bouncycastle.asn1.ASN1EncodableVector();
+            v.add(new org.bouncycastle.asn1.ASN1Integer(r));
+            v.add(new org.bouncycastle.asn1.ASN1Integer(s));
+            return new org.bouncycastle.asn1.DERSequence(v).getEncoded();
+        } catch (java.io.IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) sb.append(String.format("%02x", b & 0xff));
+        return sb.toString();
+    }
+
+    /**
+     * GAP-064 cross-tier signing reproduction. Signing the SAME payload with
+     * the SAME key (priv=1) via RFC 6979 deterministic ECDSA (plain-SHA-256
+     * nonce, low-S) MUST yield the byte-identical DER signature the TS
+     * reference committed.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void signingVectors() throws Exception {
+        Map<String, Object> fixture = loadFixture();
+        List<Map<String, Object>> vectors = (List<Map<String, Object>>) fixture.get("signing_vectors");
+        if (vectors == null || vectors.isEmpty()) {
+            throw new AssertionError("signing_vectors missing or empty");
+        }
+        BigInteger alicePriv = BigInteger.ONE;
+        for (Map<String, Object> v : vectors) {
+            String id = (String) v.get("_vector_id");
+            String expectedPayload = (String) v.get("expected_payload");
+            String expectedSig = (String) v.get("expected_sig");
+
+            // Drift guard: re-derive the canonical payload from data + lifetime.
+            Map<String, Object> merged = new LinkedHashMap<>((Map<String, Object>) v.get("data"));
+            merged.put("nonce", v.get("nonce"));
+            merged.put("expiresAt", v.get("expiresAt"));
+            String payload = Envelope.canonicalJson(merged);
+            assertEquals(expectedPayload, payload, "vector " + id + ": payload");
+
+            byte[] digest = sha256(payload.getBytes(StandardCharsets.UTF_8));
+            String der = toHex(signDeterministic(alicePriv, digest));
+            assertEquals(expectedSig, der, "vector " + id + ": signature divergence");
         }
     }
 

--- a/packages/runar-py/tests/test_envelope_interop.py
+++ b/packages/runar-py/tests/test_envelope_interop.py
@@ -12,10 +12,12 @@ SDKs Must Stay in Sync".
 """
 
 import json
+import hashlib
 import pathlib
 
 import pytest
 
+from runar.ecdsa import ecdsa_sign
 from runar.sdk.envelope import (
     canonical_json,
     verify_envelope,
@@ -51,6 +53,27 @@ def test_verify_rejection_vectors(fixture: dict) -> None:
         assert r.reason == VerifyEnvelopeReason(v["reason"]), (
             f"rejection {v['reason']!r}: got reason={r.reason}"
         )
+
+
+def test_signing_vectors(fixture: dict) -> None:
+    """GAP-064 cross-tier signing reproduction. Signing the SAME payload with
+    the SAME key (priv=1) via RFC 6979 deterministic ECDSA (plain-SHA-256
+    nonce, low-S) MUST yield the byte-identical DER signature the TS reference
+    committed. ecdsa_sign signs the 32-byte digest directly.
+    """
+    alice_priv = 1
+    vectors = fixture["signing_vectors"]
+    assert vectors, "signing_vectors missing or empty"
+    for v in vectors:
+        vid = v.get("_vector_id", "?")
+        # Drift guard: re-derive the canonical payload from data + lifetime.
+        merged = {**v["data"], "nonce": v["nonce"], "expiresAt": v["expiresAt"]}
+        payload = canonical_json(merged)
+        assert payload == v["expected_payload"], f"vector {vid}: payload"
+
+        digest = hashlib.sha256(payload.encode("utf-8")).digest()
+        der = ecdsa_sign(alice_priv, digest).hex()
+        assert der == v["expected_sig"], f"vector {vid}: signature divergence"
 
 
 def test_canonical_json_rejection_vectors(fixture: dict) -> None:

--- a/packages/runar-rb/spec/runar/sdk/envelope_interop_spec.rb
+++ b/packages/runar-rb/spec/runar/sdk/envelope_interop_spec.rb
@@ -7,8 +7,10 @@
 # See CLAUDE.md §"Seven SDKs Must Stay in Sync".
 
 require 'spec_helper'
+require 'digest'
 require 'json'
 require 'runar/sdk'
+require 'runar/ecdsa'
 
 FIXTURE_PATH = File.expand_path('../../../../../../conformance/sdk-envelope/fixtures.json', __FILE__)
 
@@ -34,6 +36,25 @@ RSpec.describe 'Runar::SDK::Envelope cross-tier interop' do
       r = Runar::SDK::Envelope.verify_envelope(envelope: env, now_ms: fixture['verify_now_ms'])
       expect(r[:ok]).to be(false), "rejection #{v['reason']} should be ok=false"
       expect(r[:reason]).to eq(v['reason']), "rejection #{v['reason']}: got #{r[:reason]}"
+    end
+  end
+
+  # GAP-064 cross-tier signing reproduction. Signing the SAME payload with the
+  # SAME key (priv=1) via RFC 6979 deterministic ECDSA (plain-SHA-256 nonce,
+  # low-S) MUST yield the byte-identical DER signature the TS reference
+  # committed. ecdsa_sign signs the 32-byte digest directly.
+  it 'reproduces every signing vector byte-identically' do
+    alice_priv = 1
+    fixture['signing_vectors'].each do |v|
+      vid = v['_vector_id'] || '?'
+      # Drift guard: re-derive the canonical payload from data + lifetime.
+      merged = v['data'].merge('nonce' => v['nonce'], 'expiresAt' => v['expiresAt'])
+      payload = Runar::SDK::Envelope.canonical_json(merged)
+      expect(payload).to eq(v['expected_payload']), "vector #{vid}: payload"
+
+      digest = Digest::SHA256.digest(payload)
+      der = Runar::ECDSA.ecdsa_sign(alice_priv, digest).unpack1('H*')
+      expect(der).to eq(v['expected_sig']), "vector #{vid}: signature divergence"
     end
   end
 

--- a/packages/runar-rs/tests/envelope_interop.rs
+++ b/packages/runar-rs/tests/envelope_interop.rs
@@ -6,10 +6,12 @@
 
 use std::path::PathBuf;
 
+use k256::ecdsa::{signature::hazmat::PrehashSigner, Signature, SigningKey};
 use runar_lang::sdk::{
     canonical_json, verify_envelope, SignedEnvelope, VerifyEnvelopeOpts, VerifyEnvelopeReason,
 };
-use serde_json::Value;
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
 
 fn fixture_path() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -20,6 +22,14 @@ fn fixture_path() -> PathBuf {
 fn load_fixture() -> Value {
     let bytes = std::fs::read(fixture_path()).expect("read fixture");
     serde_json::from_slice(&bytes).expect("parse fixture")
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
 }
 
 #[test]
@@ -81,6 +91,47 @@ fn rejection_vectors() {
             other => panic!("unknown reason {other}"),
         };
         assert_eq!(r.reason, Some(expected), "rejection {}", rv["reason"]);
+    }
+}
+
+/// GAP-064 cross-tier signing reproduction. Signing the SAME payload with the
+/// SAME key (priv=1) via RFC 6979 deterministic ECDSA (plain-SHA-256 nonce,
+/// low-S) MUST yield the byte-identical DER signature the TS reference
+/// committed. k256's `sign_prehash` signs the 32-byte digest directly and is
+/// deterministic + low-S, matching @bsv/sdk's `primitives/ECDSA` sign.
+#[test]
+fn signing_vectors() {
+    let fixture = load_fixture();
+    let alice = SigningKey::from_bytes(
+        &[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]
+        .into(),
+    )
+    .unwrap();
+
+    let svs = fixture["signing_vectors"]
+        .as_array()
+        .expect("signing_vectors missing");
+    assert!(!svs.is_empty(), "signing_vectors empty");
+    for v in svs {
+        let id = v["_vector_id"].as_str().unwrap_or("?");
+        let expected_payload = v["expected_payload"].as_str().unwrap();
+        let expected_sig = v["expected_sig"].as_str().unwrap();
+
+        // Drift guard: re-derive the canonical payload from data + lifetime.
+        let mut merged: Map<String, Value> = v["data"].as_object().unwrap().clone();
+        merged.insert("nonce".into(), v["nonce"].clone());
+        merged.insert("expiresAt".into(), v["expiresAt"].clone());
+        let payload = canonical_json(&Value::Object(merged)).expect("canonical_json");
+        assert_eq!(payload, expected_payload, "vector {id}: payload");
+
+        // Sign sha256(expected_payload) with priv=1 deterministic ECDSA -> DER.
+        let digest = Sha256::digest(expected_payload.as_bytes());
+        let (sig, _): (Signature, _) = alice.sign_prehash(&digest).expect("sign_prehash");
+        let der = to_hex(sig.to_der().as_bytes());
+        assert_eq!(der, expected_sig, "vector {id}: signature divergence");
     }
 }
 

--- a/packages/runar-zig/src/root.zig
+++ b/packages/runar-zig/src/root.zig
@@ -27,6 +27,7 @@ pub const sdk_ordinals = @import("sdk_ordinals.zig");
 pub const sdk_script_utils = @import("sdk_script_utils.zig");
 pub const sdk_anf_interpreter = @import("sdk_anf_interpreter.zig");
 pub const sdk_envelope = @import("sdk_envelope.zig");
+pub const sdk_envelope_sign = @import("sdk_envelope_sign.zig");
 pub const sdk_wallet = @import("sdk_wallet.zig");
 pub const sdk_http_client = @import("sdk_http_client.zig");
 pub const analyzer = @import("analyzer.zig");

--- a/packages/runar-zig/src/root.zig
+++ b/packages/runar-zig/src/root.zig
@@ -244,6 +244,7 @@ test {
     _ = @import("sdk_anf_interpreter.zig");
     _ = @import("sdk_anf_interpreter_intent_test.zig");
     _ = @import("sdk_envelope.zig");
+    _ = @import("sdk_envelope_sign.zig");
     _ = @import("sdk_envelope_interop_test.zig");
     _ = @import("sdk_rpc_provider.zig");
     _ = @import("sdk_token_wallet.zig");

--- a/packages/runar-zig/src/sdk_envelope.zig
+++ b/packages/runar-zig/src/sdk_envelope.zig
@@ -9,6 +9,7 @@
 const std = @import("std");
 const Sha256 = std.crypto.hash.sha2.Sha256;
 const Ecdsa = std.crypto.sign.ecdsa.EcdsaSecp256k1Sha256;
+const envelope_sign = @import("sdk_envelope_sign.zig");
 
 // ---------------------------------------------------------------------------
 // Value tree — minimal JSON-shaped value used by the canonical serializer.
@@ -343,6 +344,59 @@ pub fn signEnvelope(allocator: std.mem.Allocator, opts: SignEnvelopeOpts) !Signe
     errdefer allocator.free(sig_hex);
 
     const pubkey_copy = try allocator.dupe(u8, opts.pubkey_hex);
+
+    return SignedEnvelope{
+        .payload = payload,
+        .sig = sig_hex,
+        .pubkey = pubkey_copy,
+        .nonce = nonce,
+        .expiresAt = expires_at,
+    };
+}
+
+pub const SignEnvelopeWithKeyOpts = struct {
+    data: []const Value.KeyValue,
+    /// 32-byte big-endian secp256k1 private key.
+    private_key: [32]u8,
+    ttl_ms: i64 = 30_000,
+    /// Wall-clock ms used as the nonce (see SignEnvelopeOpts.now_ms).
+    now_ms: i64,
+};
+
+/// Convenience: sign an envelope directly from a private key using canonical
+/// RFC 6979 deterministic ECDSA whose nonce HMAC uses PLAIN SHA-256 (GAP-064).
+/// This is the cross-tier-correct signing path for overlay apps — it produces
+/// byte-identical signatures to the other six Rúnar SDKs, unlike a `sign_fn`
+/// routed through bsvz (SHA-256d nonce) or Zig stdlib's additional-randomness
+/// ECDSA. The compressed pubkey is derived from the key.
+pub fn signEnvelopeWithKey(allocator: std.mem.Allocator, opts: SignEnvelopeWithKeyOpts) !SignedEnvelope {
+    const nonce: i64 = opts.now_ms;
+    const expires_at = nonce + opts.ttl_ms;
+
+    var merged: std.ArrayListUnmanaged(Value.KeyValue) = .empty;
+    defer merged.deinit(allocator);
+    try merged.appendSlice(allocator, opts.data);
+    try merged.append(allocator, .{ .key = "nonce", .value = .{ .Int = nonce } });
+    try merged.append(allocator, .{ .key = "expiresAt", .value = .{ .Int = expires_at } });
+
+    const payload = try canonicalJson(allocator, .{ .Object = merged.items });
+    errdefer allocator.free(payload);
+
+    var digest: [32]u8 = undefined;
+    Sha256.hash(payload, &digest, .{});
+
+    var der_buf: [72]u8 = undefined;
+    const der = try envelope_sign.signDigestLowSDer(opts.private_key, digest, &der_buf);
+    const sig_hex = try bytesToHex(allocator, der);
+    errdefer allocator.free(sig_hex);
+
+    // Derive compressed pubkey hex from the private key. Note:
+    // KeyPair.generateDeterministic derives a key FROM a seed (it is NOT the
+    // private key), so we build the key pair directly from the secret scalar.
+    const secret = try Ecdsa.SecretKey.fromBytes(opts.private_key);
+    const kp = try Ecdsa.KeyPair.fromSecretKey(secret);
+    const compressed = kp.public_key.toCompressedSec1();
+    const pubkey_copy = try bytesToHex(allocator, &compressed);
 
     return SignedEnvelope{
         .payload = payload,

--- a/packages/runar-zig/src/sdk_envelope_interop_test.zig
+++ b/packages/runar-zig/src/sdk_envelope_interop_test.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 const envelope = @import("sdk_envelope.zig");
+const envelope_sign = @import("sdk_envelope_sign.zig");
 
 const FIXTURE_REL_PATH = "../../conformance/sdk-envelope/fixtures.json";
 
@@ -130,6 +131,114 @@ test "interop: every rejection vector returns the listed reason" {
         try std.testing.expect(!r.ok);
         try std.testing.expectEqualStrings(reason_wire, r.reason.?.wire());
     }
+}
+
+// GAP-064 cross-tier signing reproduction. Signing the SAME payload with the
+// SAME key (priv=1) via RFC 6979 deterministic ECDSA whose nonce uses PLAIN
+// SHA-256 (sdk_envelope_sign.signDigestLowSDer) MUST yield the byte-identical
+// low-S DER signature the TS reference committed. This is the Zig fix: the
+// envelope signing path no longer routes through bsvz's SHA-256d-nonce
+// signDigest256 (which diverges), but through Zig stdlib's plain-SHA-256-nonce
+// EcdsaSecp256k1Sha256.
+test "interop: signing vectors reproduce the reference DER byte-for-byte" {
+    const allocator = std.testing.allocator;
+    const bytes = try loadFixtureBytes(allocator);
+    defer allocator.free(bytes);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
+    defer parsed.deinit();
+
+    // Alice private key = 1 (32-byte big-endian).
+    var priv: [32]u8 = [_]u8{0} ** 32;
+    priv[31] = 1;
+
+    const svs = parsed.value.object.get("signing_vectors").?.array;
+    try std.testing.expect(svs.items.len > 0);
+    for (svs.items) |sv| {
+        const data_obj = sv.object.get("data").?.object;
+        const nonce = sv.object.get("nonce").?.integer;
+        const expires_at = sv.object.get("expiresAt").?.integer;
+        const expected_payload = sv.object.get("expected_payload").?.string;
+        const expected_sig = sv.object.get("expected_sig").?.string;
+
+        // Build merged object: { ...data, nonce, expiresAt } as our Value tree.
+        const merged = try allocator.alloc(envelope.Value.KeyValue, data_obj.count() + 2);
+        defer {
+            for (merged) |kv| {
+                allocator.free(kv.key);
+                freeValue(allocator, kv.value);
+            }
+            allocator.free(merged);
+        }
+        var it = data_obj.iterator();
+        var i: usize = 0;
+        while (it.next()) |entry| : (i += 1) {
+            merged[i] = .{
+                .key = try allocator.dupe(u8, entry.key_ptr.*),
+                .value = try jsonToValue(allocator, entry.value_ptr.*),
+            };
+        }
+        merged[i] = .{ .key = try allocator.dupe(u8, "nonce"), .value = .{ .Int = nonce } };
+        merged[i + 1] = .{ .key = try allocator.dupe(u8, "expiresAt"), .value = .{ .Int = expires_at } };
+
+        const payload = try envelope.canonicalJson(allocator, .{ .Object = merged });
+        defer allocator.free(payload);
+        try std.testing.expectEqualStrings(expected_payload, payload);
+
+        // Sign sha256(payload) with priv=1 deterministic ECDSA (plain SHA-256
+        // nonce) -> low-S DER, hex-encode, compare byte-for-byte.
+        var digest: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(payload, &digest, .{});
+        var der_buf: [72]u8 = undefined;
+        const der = try envelope_sign.signDigestLowSDer(priv, digest, &der_buf);
+
+        const der_hex = try envelope.bytesToHex(allocator, der);
+        defer allocator.free(der_hex);
+        try std.testing.expectEqualStrings(expected_sig, der_hex);
+    }
+}
+
+// The SDK convenience path `signEnvelopeWithKey` must produce the same
+// cross-tier sv1 signature AND self-verify — proving overlay apps get
+// byte-identical, verifiable envelopes without hand-rolling a sign_fn.
+test "interop: signEnvelopeWithKey reproduces sv1 + self-verifies" {
+    const allocator = std.testing.allocator;
+    const bytes = try loadFixtureBytes(allocator);
+    defer allocator.free(bytes);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
+    defer parsed.deinit();
+
+    // Locate sv1 in the fixture.
+    const svs = parsed.value.object.get("signing_vectors").?.array;
+    var sv1: ?std.json.ObjectMap = null;
+    for (svs.items) |sv| {
+        if (std.mem.eql(u8, sv.object.get("_vector_id").?.string, "sv1-ascii")) sv1 = sv.object;
+    }
+    const v = sv1.?;
+    const nonce = v.get("nonce").?.integer;
+    const expires_at = v.get("expiresAt").?.integer;
+    const expected_sig = v.get("expected_sig").?.string;
+
+    var priv: [32]u8 = [_]u8{0} ** 32;
+    priv[31] = 1;
+
+    // sv1 data = { kind: "order", qty: 3 }.
+    const data = [_]envelope.Value.KeyValue{
+        .{ .key = "kind", .value = .{ .String = "order" } },
+        .{ .key = "qty", .value = .{ .Int = 3 } },
+    };
+    const env = try envelope.signEnvelopeWithKey(allocator, .{
+        .data = &data,
+        .private_key = priv,
+        .ttl_ms = expires_at - nonce,
+        .now_ms = nonce,
+    });
+    defer env.deinit(allocator);
+
+    try std.testing.expectEqualStrings(expected_sig, env.sig);
+
+    var r = try envelope.verifyEnvelope(allocator, .{ .envelope = &env, .now_ms = nonce + 500 });
+    defer r.deinit();
+    try std.testing.expect(r.ok);
 }
 
 // RFC 8785 §3.2.2.2 — canonical_json MUST reject malformed Unicode (lone

--- a/packages/runar-zig/src/sdk_envelope_sign.zig
+++ b/packages/runar-zig/src/sdk_envelope_sign.zig
@@ -60,30 +60,44 @@ fn hmac(key: []const u8, msgs: []const []const u8) [32]u8 {
     return out;
 }
 
-/// Derive the canonical RFC 6979 nonce `k` (as a valid scalar in [1, N-1]).
-/// `x_oct` = int2octets(privkey), `h1_oct` = bits2octets(digest).
-fn rfc6979Nonce(x_oct: [32]u8, h1_oct: [32]u8) Scalar {
-    var v: [32]u8 = [_]u8{0x01} ** 32;
-    var k: [32]u8 = [_]u8{0x00} ** 32;
+/// RFC 6979 §3.2 HMAC-DRBG nonce generator. Stateful so that a caller which
+/// rejects a candidate's *signature* (r == 0 or s == 0, §3.2 final paragraph)
+/// draws a NEW `k` on the next call instead of re-deriving the same one.
+const Rfc6979Drbg = struct {
+    k: [32]u8,
+    v: [32]u8,
 
-    // K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1)); V = HMAC_K(V)
-    k = hmac(&k, &.{ &v, &[_]u8{0x00}, &x_oct, &h1_oct });
-    v = hmac(&k, &.{&v});
-    // K = HMAC_K(V || 0x01 || int2octets(x) || bits2octets(h1)); V = HMAC_K(V)
-    k = hmac(&k, &.{ &v, &[_]u8{0x01}, &x_oct, &h1_oct });
-    v = hmac(&k, &.{&v});
-
-    while (true) {
-        // T = V (single block, since hlen == qlen == 256).
-        v = hmac(&k, &.{&v});
-        if (Scalar.fromBytes(v, .big)) |s| {
-            if (!s.isZero()) return s;
-        } else |_| {}
-        // Retry: K = HMAC_K(V || 0x00); V = HMAC_K(V).
-        k = hmac(&k, &.{ &v, &[_]u8{0x00} });
-        v = hmac(&k, &.{&v});
+    /// Steps b–g: `x_oct` = int2octets(privkey), `h1_oct` = bits2octets(digest).
+    fn init(x_oct: [32]u8, h1_oct: [32]u8) Rfc6979Drbg {
+        var st: Rfc6979Drbg = .{ .v = [_]u8{0x01} ** 32, .k = [_]u8{0x00} ** 32 };
+        // K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1)); V = HMAC_K(V)
+        st.k = hmac(&st.k, &.{ &st.v, &[_]u8{0x00}, &x_oct, &h1_oct });
+        st.v = hmac(&st.k, &.{&st.v});
+        // K = HMAC_K(V || 0x01 || int2octets(x) || bits2octets(h1)); V = HMAC_K(V)
+        st.k = hmac(&st.k, &.{ &st.v, &[_]u8{0x01}, &x_oct, &h1_oct });
+        st.v = hmac(&st.k, &.{&st.v});
+        return st;
     }
-}
+
+    /// Step h: next candidate `k` in [1, N-1]. The retry update
+    /// (K = HMAC_K(V || 0x00); V = HMAC_K(V)) is applied eagerly after every
+    /// emitted candidate — the update is deterministic in (K, V), so this
+    /// yields the exact same candidate sequence as the lazy on-reject update
+    /// the RFC describes, while leaving the state ready for a re-draw.
+    fn next(self: *Rfc6979Drbg) Scalar {
+        while (true) {
+            // T = V (single block, since hlen == qlen == 256).
+            self.v = hmac(&self.k, &.{&self.v});
+            const t = self.v;
+            // K = HMAC_K(V || 0x00); V = HMAC_K(V).
+            self.k = hmac(&self.k, &.{ &self.v, &[_]u8{0x00} });
+            self.v = hmac(&self.k, &.{&self.v});
+            if (Scalar.fromBytes(t, .big)) |s| {
+                if (!s.isZero()) return s;
+            } else |_| {}
+        }
+    }
+};
 
 /// Sign `digest` (a 32-byte hash, e.g. sha256(payload)) with `priv_key_be`
 /// (32-byte big-endian secp256k1 scalar) using canonical RFC 6979 deterministic
@@ -101,8 +115,9 @@ pub fn signDigestLowSDer(
     const z = bits2octets(digest); // message representative, reduced mod N
     const z_scalar = Scalar.fromBytes(z, .big) catch return error.SigningFailed;
 
+    var drbg = Rfc6979Drbg.init(priv_key_be, z);
     while_k: while (true) {
-        const k = rfc6979Nonce(priv_key_be, z);
+        const k = drbg.next();
 
         // R = k*G; r = R.x mod N.
         const rp = Secp256k1.basePoint.mul(k.toBytes(.big), .big) catch continue :while_k;
@@ -171,4 +186,36 @@ fn minimalInt(be: []const u8, out: *[33]u8) []u8 {
     }
     @memcpy(out[0..body.len], body);
     return out[0..body.len];
+}
+
+// ---------------------------------------------------------------------------
+// Tests — canonical public RFC 6979 secp256k1 vector.
+// ---------------------------------------------------------------------------
+
+test "RFC 6979 canonical vector: priv=1, msg=\"Satoshi Nakamoto\" — nonce k and low-S DER signature" {
+    // The widely published secp256k1 RFC 6979 (plain-SHA-256 nonce) vector:
+    //   priv = 0x...01, h1 = sha256("Satoshi Nakamoto")
+    //   k = 8F8A276C19F4149656B280621E358CCE24F5F52542772691EE69063B74F15D15
+    //   r = 934b1ea10a4b3c1757e2b0c017d0b6143ce3c9a7e6a4a49860d7a6ab210ee3d8
+    //   s = 2442ce9d2b916064108014783e923ec36b49743e2ffa1c4496f01a512aafd9e5 (low-S)
+    var priv: [32]u8 = [_]u8{0} ** 32;
+    priv[31] = 0x01;
+
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash("Satoshi Nakamoto", &digest, .{});
+
+    // Nonce check (private path: k must match the published vector exactly).
+    var drbg = Rfc6979Drbg.init(priv, bits2octets(digest));
+    const k = drbg.next();
+    var expected_k: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&expected_k, "8F8A276C19F4149656B280621E358CCE24F5F52542772691EE69063B74F15D15");
+    try std.testing.expectEqualSlices(u8, &expected_k, &k.toBytes(.big));
+
+    // Full signature check (r and s in minimal low-S DER). r's high bit is
+    // set (0x93...), so DER prefixes its INTEGER body with 0x00 (33 bytes).
+    var der_buf: [72]u8 = undefined;
+    const der = try signDigestLowSDer(priv, digest, &der_buf);
+    var expected_der: [71]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&expected_der, "3045022100934b1ea10a4b3c1757e2b0c017d0b6143ce3c9a7e6a4a49860d7a6ab210ee3d802202442ce9d2b916064108014783e923ec36b49743e2ffa1c4496f01a512aafd9e5");
+    try std.testing.expectEqualSlices(u8, &expected_der, der);
 }

--- a/packages/runar-zig/src/sdk_envelope_sign.zig
+++ b/packages/runar-zig/src/sdk_envelope_sign.zig
@@ -1,0 +1,174 @@
+//! GAP-064: canonical RFC 6979 deterministic ECDSA over secp256k1 (nonce HMAC
+//! uses PLAIN SHA-256) — the wire-protocol signing path for the signed-envelope
+//! cross-tier interop matrix.
+//!
+//! Why this exists separately from `sdk_signer.zig`, and why it does NOT use
+//! Zig's stdlib ECDSA signer:
+//!
+//!   * `sdk_signer.LocalSigner` signs BIP-143 sighashes via
+//!     `bsvz.crypto.PrivateKey.signDigest256`, which routes through bsvz's
+//!     `EcdsaSha256d` (double-SHA256). Its RFC 6979 nonce hashes the message
+//!     with SHA-256d, so for an arbitrary 32-byte digest it derives a DIFFERENT
+//!     deterministic `k` than the other six Rúnar tiers (all plain-SHA-256
+//!     nonce). bsvz is a gitignored fetch cache and cannot be patched here.
+//!
+//!   * Zig's stdlib `EcdsaSecp256k1Sha256` derives its nonce from the
+//!     "Deterministic ECDSA with Additional Randomness" draft, NOT canonical
+//!     RFC 6979: it folds a `noise` block (32 zero bytes when null) into the
+//!     HMAC-DRBG seed and uses the raw digest rather than `bits2octets(h)`.
+//!     That yields a different `k` than @bsv/sdk / go-sdk / k256 / the
+//!     Python+Ruby implementations, so it also diverges.
+//!
+//! This module therefore implements canonical RFC 6979 §3.2 directly on top of
+//! Zig's secp256k1 scalar/point primitives (HMAC-SHA256 DRBG, no noise,
+//! `bits2octets` reduction), then applies BIP-62 low-S normalization and DER
+//! encoding. The output is byte-identical to @bsv/sdk `primitives/ECDSA` sign
+//! and the five other tiers.
+
+const std = @import("std");
+
+const Secp256k1 = std.crypto.ecc.Secp256k1;
+const Scalar = Secp256k1.scalar.Scalar;
+const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+
+/// N/2 (big-endian, 32 bytes). s is "high" (must be flipped) iff s > N/2.
+const HALF_N_BE: [32]u8 = .{
+    0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0x5d, 0x57, 0x6e, 0x73, 0x57, 0xa4, 0x50, 0x1d,
+    0xdf, 0xe9, 0x2f, 0x46, 0x68, 0x1b, 0x20, 0xa0,
+};
+
+pub const SignError = error{ InvalidPrivateKey, SigningFailed };
+
+/// `bits2octets(h)` per RFC 6979 §2.3.4 for a 256-bit hash on a 256-bit curve:
+/// reduce the hash modulo N and return the 32-byte big-endian encoding. With
+/// qlen == hlen == 256 the bits2int step is the identity, so this is `h mod N`.
+fn bits2octets(digest: [32]u8) [32]u8 {
+    // Scalar.fromBytes64 reduces a wide input mod N; we left-pad the 32-byte
+    // digest into a 64-byte buffer to get an unconditional reduction.
+    var wide: [64]u8 = [_]u8{0} ** 64;
+    @memcpy(wide[32..], &digest);
+    return Scalar.fromBytes64(wide, .big).toBytes(.big);
+}
+
+fn hmac(key: []const u8, msgs: []const []const u8) [32]u8 {
+    var mac = HmacSha256.init(key);
+    for (msgs) |m| mac.update(m);
+    var out: [32]u8 = undefined;
+    mac.final(&out);
+    return out;
+}
+
+/// Derive the canonical RFC 6979 nonce `k` (as a valid scalar in [1, N-1]).
+/// `x_oct` = int2octets(privkey), `h1_oct` = bits2octets(digest).
+fn rfc6979Nonce(x_oct: [32]u8, h1_oct: [32]u8) Scalar {
+    var v: [32]u8 = [_]u8{0x01} ** 32;
+    var k: [32]u8 = [_]u8{0x00} ** 32;
+
+    // K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1)); V = HMAC_K(V)
+    k = hmac(&k, &.{ &v, &[_]u8{0x00}, &x_oct, &h1_oct });
+    v = hmac(&k, &.{&v});
+    // K = HMAC_K(V || 0x01 || int2octets(x) || bits2octets(h1)); V = HMAC_K(V)
+    k = hmac(&k, &.{ &v, &[_]u8{0x01}, &x_oct, &h1_oct });
+    v = hmac(&k, &.{&v});
+
+    while (true) {
+        // T = V (single block, since hlen == qlen == 256).
+        v = hmac(&k, &.{&v});
+        if (Scalar.fromBytes(v, .big)) |s| {
+            if (!s.isZero()) return s;
+        } else |_| {}
+        // Retry: K = HMAC_K(V || 0x00); V = HMAC_K(V).
+        k = hmac(&k, &.{ &v, &[_]u8{0x00} });
+        v = hmac(&k, &.{&v});
+    }
+}
+
+/// Sign `digest` (a 32-byte hash, e.g. sha256(payload)) with `priv_key_be`
+/// (32-byte big-endian secp256k1 scalar) using canonical RFC 6979 deterministic
+/// ECDSA (plain-SHA-256 nonce). Writes the low-S DER signature into `der_buf`
+/// and returns the populated slice. The digest is the message representative —
+/// it is signed directly and never re-hashed.
+pub fn signDigestLowSDer(
+    priv_key_be: [32]u8,
+    digest: [32]u8,
+    der_buf: *[72]u8,
+) SignError![]u8 {
+    const x = Scalar.fromBytes(priv_key_be, .big) catch return error.InvalidPrivateKey;
+    if (x.isZero()) return error.InvalidPrivateKey;
+
+    const z = bits2octets(digest); // message representative, reduced mod N
+    const z_scalar = Scalar.fromBytes(z, .big) catch return error.SigningFailed;
+
+    while_k: while (true) {
+        const k = rfc6979Nonce(priv_key_be, z);
+
+        // R = k*G; r = R.x mod N.
+        const rp = Secp256k1.basePoint.mul(k.toBytes(.big), .big) catch continue :while_k;
+        const rx = rp.affineCoordinates().x.toBytes(.big);
+        const r = Scalar.fromBytes64(blk: {
+            var wide: [64]u8 = [_]u8{0} ** 64;
+            @memcpy(wide[32..], &rx);
+            break :blk wide;
+        }, .big);
+        if (r.isZero()) continue :while_k;
+
+        // s = k^-1 * (z + r*x) mod N.
+        const s = k.invert().mul(z_scalar.add(r.mul(x)));
+        if (s.isZero()) continue :while_k;
+
+        // BIP-62 low-S normalization.
+        var s_bytes = s.toBytes(.big);
+        if (std.mem.order(u8, &s_bytes, &HALF_N_BE) == .gt) {
+            s_bytes = s.neg().toBytes(.big); // N - s
+        }
+
+        return encodeDer(r.toBytes(.big), s_bytes, der_buf);
+    }
+}
+
+/// DER-encode (r, s) as 0x30 len 0x02 rlen r 0x02 slen s, with minimal
+/// big-endian integers (strip leading zeros; prepend 0x00 if high bit set).
+fn encodeDer(r_be: [32]u8, s_be: [32]u8, der_buf: *[72]u8) []u8 {
+    var r_int: [33]u8 = undefined;
+    const r_slice = minimalInt(&r_be, &r_int);
+    var s_int: [33]u8 = undefined;
+    const s_slice = minimalInt(&s_be, &s_int);
+
+    var i: usize = 0;
+    der_buf[i] = 0x30;
+    i += 1;
+    der_buf[i] = @intCast(2 + r_slice.len + 2 + s_slice.len);
+    i += 1;
+    der_buf[i] = 0x02;
+    i += 1;
+    der_buf[i] = @intCast(r_slice.len);
+    i += 1;
+    @memcpy(der_buf[i .. i + r_slice.len], r_slice);
+    i += r_slice.len;
+    der_buf[i] = 0x02;
+    i += 1;
+    der_buf[i] = @intCast(s_slice.len);
+    i += 1;
+    @memcpy(der_buf[i .. i + s_slice.len], s_slice);
+    i += s_slice.len;
+    return der_buf[0..i];
+}
+
+/// Render a 32-byte big-endian integer as a minimal DER INTEGER body: strip
+/// leading zero bytes, then prepend a single 0x00 if the high bit is set (so
+/// the value stays non-negative). Writes into `out` (>= 33 bytes) and returns
+/// the populated slice.
+fn minimalInt(be: []const u8, out: *[33]u8) []u8 {
+    var start: usize = 0;
+    while (start < be.len - 1 and be[start] == 0x00) start += 1;
+    const body = be[start..];
+    if (body[0] & 0x80 != 0) {
+        out[0] = 0x00;
+        @memcpy(out[1 .. 1 + body.len], body);
+        return out[0 .. 1 + body.len];
+    }
+    @memcpy(out[0..body.len], body);
+    return out[0..body.len];
+}


### PR DESCRIPTION
## Summary

GAP-064 (premortems/remediation-plan.md): each of the 7 SDK tiers, signing the **same payload** with the **same key** (alice priv=1) via RFC 6979 deterministic ECDSA, must produce a **byte-identical DER signature**. This was built earlier then reverted because Zig diverged. This PR re-creates it **and fixes Zig**.

### Fixture + drift guard
- `conformance/sdk-envelope/fixtures.json` gains a `signing_vectors` block: `sv1-ascii` (`{kind:"order",qty:3}`) and `sv2-nonascii-astral-keys` (`{用户,🔥,msg:"héllo"}`), each with `expected_payload = canonicalJson({...data,nonce,expiresAt})` and `expected_sig` = low-S DER of deterministic ECDSA over `sha256(expected_payload)` with priv=1. Values generated + confirmed against the TS reference (`runar-ir-schema canonicalJsonStringify` + `@bsv/sdk primitives/ECDSA` sign, `forceLowS=true`).
- `validate-fixtures.ts`: per vector, re-derives the payload **and** re-signs the digest, asserting byte-identity — the committed `expected_sig` can never silently drift from the TS path.

### Per-tier interop tests (all load `signing_vectors`, drift-guard the payload, sign, assert == `expected_sig`)
- **Go** `sdk_envelope_interop_test.go` — reuses `newAliceSigner`/`testSigner.SignHash` (go-sdk `PrivateKey.Sign`, signs the digest raw, low-S DER).
- **Rust** `tests/envelope_interop.rs` — `k256` `sign_prehash` (deterministic, low-S) + `to_der`.
- **Python** `tests/test_envelope_interop.py` — `runar.ecdsa.ecdsa_sign(1, digest)`.
- **Ruby** `spec/.../envelope_interop_spec.rb` — `Runar::ECDSA.ecdsa_sign(1, digest)`.
- **Java** `EnvelopeInteropTest.java` — BouncyCastle `ECDSASigner(HMacDSAKCalculator(SHA256Digest))` + low-S DER.
- **Zig** `sdk_envelope_interop_test.zig` — the **fixed** signing path (below).

### Zig fix (the held divergence — root cause + remedy)
The Zig envelope signing path routed through `bsvz.crypto.PrivateKey.signDigest256`, whose RFC 6979 nonce hashes with **SHA-256d** ⇒ a different `k` ⇒ a different (valid) signature. `bsvz` is a gitignored fetch cache and cannot be patched. Zig **stdlib** `EcdsaSecp256k1Sha256` also diverges — it implements the *"Deterministic ECDSA with Additional Randomness"* draft (folds a noise block into the DRBG seed; uses the raw digest, not `bits2octets`).

New module **`packages/runar-zig/src/sdk_envelope_sign.zig`** implements **canonical RFC 6979** (HMAC-SHA256 DRBG, no noise, `bits2octets` reduction) on Zig's secp256k1 scalar/point primitives, then applies BIP-62 low-S + minimal DER. `Envelope.signEnvelopeWithKey` is a convenience entry point so overlay apps sign cross-tier-compatible envelopes directly from a key (and a test proves it reproduces sv1 **and** self-verifies). bsvz is untouched.

### Per-tier reproduction (verified locally — all byte-identical)
| Tier | sv1 + sv2 == reference DER |
|------|----------------------------|
| TS (reference) | ✅ drift guard: 21 cjson + valid env + 2 signing vectors |
| Go | ✅ `TestEnvelopeInterop_SigningVectors` |
| Rust | ✅ `signing_vectors` (5/5) |
| Python | ✅ `test_signing_vectors` (5/5) |
| Ruby | ✅ `reproduces every signing vector` (5/5) |
| Java | ✅ `signingVectors` (5/5) |
| Zig | ✅ signing vectors + `signEnvelopeWithKey` (212/214, 2 pre-existing skips) |

No compiler / contract / non-envelope SDK surface touched ⇒ conformance unaffected (this only adds a fixture block + tests + one Zig signer module).

## Test plan
- [ ] CI "Lint — SDK envelope fixture drift + interop coverage" green (drift guard + coverage)
- [ ] Each tier's SDK job runs its envelope interop test green