### PR TITLE
verification: tighten BIP-143 bridge — universal checkSig equality forced auth backend constant

### DIFF
--- a/runar-verification/RunarVerification/Pipeline.lean
+++ b/runar-verification/RunarVerification/Pipeline.lean
@@ -2861,7 +2861,10 @@ integration omnibus — planned split"):
   fragment (decided by `AgreesStateful.statefulConsumeShapeBool`) is
   discharged by the theorem
   `compileSafe_observational_correct_stateful_consume` through the
-  pre-existing BIP-143 bridge axiom (D2.a) + the proved D2.b epilogue;
+  keyed `hStatefulFrag` sig-provenance hypothesis (TIGHTENED
+  2026-06-10 — formerly D2.a's universal bridge axiom, which forced
+  `checkSig` constant; the surviving axiom only asserts witness
+  EXISTENCE per valid context) + the proved D2.b epilogue;
   residual stateful bodies fall through to the sound crypto_call /
   dispatch cascade.
 
@@ -3125,12 +3128,17 @@ axiom compileSafe_observational_correct_modulo_loop_codegen (p : ANFProgram)
 -- `AgreesStateful.statefulConsumeShapeBool`: one param `pre`, body exactly the
 -- auto-injected gated prologue `_cp0 := check_preimage pre ; assert _cp0`),
 -- under the keyed `hStatefulFrag` premise (the valid-BIP-143-context entry
--- bundle).  The discharge composes the constant-lowering reduction
+-- bundle, including — TIGHTENED 2026-06-10 — the per-deployment
+-- sig-provenance fact `authBackend.checkSig sigV G = Crypto.checkPreimage
+-- preimage`).  The discharge composes the constant-lowering reduction
 -- (`AgreesStateful.lowerMethod_ops_statefulPrologue`), the runtime walk
 -- (`runOps_statefulPrologueOps_isSome`), the M3 peephole-identity, the M4
--- concrete parse round-trip, and the pre-existing BIP-143 bridge axiom
--- (`StatefulBridge.checkPreimage_iff_checkSig_under_validTxContext` — D2.a's
--- designed external-crypto assumption, already in the TCB).  Residual stateful
+-- concrete parse round-trip, and that provenance hypothesis (formerly D2.a's
+-- universal bridge axiom `checkPreimage_iff_checkSig_under_validTxContext`,
+-- which forced `checkSig` constant; the surviving TCB entry is the
+-- witness-existence axiom
+-- `StatefulBridge.exists_checkSig_witness_under_validTxContext`, which only
+-- powers the smoke).  Residual stateful
 -- bodies — user logic after the prologue, state-output epilogues
 -- (D2.b's `auto_state_output_at_method_exit_correct` is ALREADY a theorem),
 -- multi-public stateful programs — fall through to the sound crypto_call /
@@ -4998,10 +5006,13 @@ lowers to the CONSTANT `[OP_CODESEPARATOR, .swap, .push G, OP_CHECKSIGVERIFY]`
 (`AgreesStateful.lowerMethod_ops_statefulPrologue`), whose Stack success bit
 is the AUTH backend's verdict (`runOps_statefulPrologueOps_isSome`); the ANF
 success bit is the PREIMAGE backend's verdict
-(`StatefulBridge.gatedStatefulPrologue_isSome_eq`); the two agree under a
-valid BIP-143 context via the pre-existing bridge axiom
-(`checkPreimage_iff_checkSig_under_validTxContext`).  No sub-omnibus axiom
-appears in the discharge. -/
+(`StatefulBridge.gatedStatefulPrologue_isSome_eq`); the two agree via the
+per-deployment sig-provenance hypothesis `hSig` carried by the keyed
+`hStatefulFrag` premise (TIGHTENED 2026-06-10 — previously a universal
+bridge axiom that forced `authBackend.checkSig` constant; the surviving
+axiom `StatefulBridge.exists_checkSig_witness_under_validTxContext` only
+asserts a witness EXISTS per valid context, and powers the smoke).  No
+sub-omnibus axiom appears in the discharge. -/
 
 /-- The 4-pass peephole pipeline is the identity on the constant stateful
 prologue ops (no fusable adjacency: the only push is the 33-byte key `G`
@@ -5043,7 +5054,12 @@ theorem peepholeMethodOps_statefulPrologue :
 The success-bit chain is direct (no runMethod leg needed): the ANF side is
 `Crypto.checkPreimage preimage` (gated prologue), the Stack side is
 `authBackend.checkSig sigV G` (constant prologue ops, M3 peephole-identity,
-M4 concrete parse round-trip), and the BIP-143 bridge equates the two. -/
+M4 concrete parse round-trip), and the per-deployment sig-provenance
+hypothesis `hSig` (the spender's `_opPushTxSig` witness verifies against the
+synthetic key exactly when the preimage backend accepts — discharged per
+fixture by the conformance harness, and for the smoke by the witness
+`StatefulBridge.exists_checkSig_witness_under_validTxContext` provides)
+equates the two. -/
 theorem compileSafe_observational_correct_stateful_consume
     (p : ANFProgram) (anfM : ANFMethod) (bytes : ByteArray)
     (_hMem : anfM ∈ p.methods) (hPublic : anfM.isPublic = true)
@@ -5057,10 +5073,13 @@ theorem compileSafe_observational_correct_stateful_consume
     (hne1 : pre ≠ "_cp0") (hne2 : pre ≠ "_opPushTxSig")
     (ctx : TxContext) (sigV preimage : ByteArray)
     (rest : List RunarVerification.ANF.Eval.Value)
-    (hValid : ValidTxContext ctx)
-    (hPreLink : preimage = TxContext.buildPreimage ctx)
+    (_hValid : ValidTxContext ctx)
+    (_hPreLink : preimage = TxContext.buildPreimage ctx)
     (hAnfPre : initialAnf.resolveRef pre = some (.vBytes preimage))
-    (hStk : initialStack.stack = .vBytes preimage :: .vBytes sigV :: rest) :
+    (hStk : initialStack.stack = .vBytes preimage :: .vBytes sigV :: rest)
+    (hSig : RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sigV
+          AgreesStateful.stG
+        = RunarVerification.ANF.Eval.Crypto.checkPreimage preimage) :
     successAgrees
       (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf anfM.body)
       (runParsedBytes bytes initialStack) := by
@@ -5092,14 +5111,10 @@ theorem compileSafe_observational_correct_stateful_consume
   have hStack : (runOps AgreesStateful.statefulPrologueOps initialStack).toOption.isSome
       = RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sigV AgreesStateful.stG :=
     AgreesStateful.runOps_statefulPrologueOps_isSome initialStack preimage sigV rest hStk
-  have hBridge : RunarVerification.ANF.Eval.Crypto.checkPreimage preimage
-      = RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sigV AgreesStateful.stG :=
-    StatefulBridge.checkPreimage_iff_checkSig_under_validTxContext ctx sigV
-      AgreesStateful.stG preimage hValid hPreLink
   show (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf
       anfM.body).toOption.isSome
       ↔ (runParsedBytes bytes initialStack).toOption.isSome
-  rw [hM4, hANF, hStack, hBridge]
+  rw [hM4, hANF, hStack, hSig]
 
 /-! ### MANDATORY smoke: the stateful consume theorem fires
 
@@ -5119,11 +5134,30 @@ private def stSmokePreimage : ByteArray :=
 
 private def stSmokeAnf : State := { params := [("pre", .vBytes stSmokePreimage)] }
 
-private def stSmokeStk : StackState :=
-  { stack := [.vBytes stSmokePreimage, .vBytes (ByteArray.mk #[0x30])] }
+/-- The sample context's spend witness, from the witness-existence axiom
+(`Classical.choose` — the backends are opaque, so no concrete signature
+bytes are derivable in-model). -/
+private noncomputable def stSmokeSig : ByteArray :=
+  Classical.choose
+    (Stack.StatefulBridge.exists_checkSig_witness_under_validTxContext
+      Stack.TxContext.sampleCtx Stack.ValidTxContext.sampleCtx_valid)
+
+/-- The witness property — discharges the consume theorem's `hSig`
+sig-provenance hypothesis for the smoke. -/
+private theorem stSmokeSig_spec :
+    RunarVerification.ANF.Eval.Crypto.authBackend.checkSig stSmokeSig
+        AgreesStateful.stG
+      = RunarVerification.ANF.Eval.Crypto.checkPreimage stSmokePreimage :=
+  Classical.choose_spec
+    (Stack.StatefulBridge.exists_checkSig_witness_under_validTxContext
+      Stack.TxContext.sampleCtx Stack.ValidTxContext.sampleCtx_valid)
+
+private noncomputable def stSmokeStk : StackState :=
+  { stack := [.vBytes stSmokePreimage, .vBytes stSmokeSig] }
 
 /-- SMOKE — `compileSafe` accepts the canonical stateful contract and the
-consume theorem fires on the sample-context entry. -/
+consume theorem fires on the sample-context entry (with the chosen witness
+signature on the deployed stack). -/
 theorem smoke_stateful_consume_fires :
     ∃ bytes, compileSafe stSmokeProg = .ok bytes ∧
       successAgrees
@@ -5140,8 +5174,9 @@ theorem smoke_stateful_consume_fires :
     stSmokeProg AgreesStateful.smokeMethod bytes
     (by simp [stSmokeProg]) rfl hSafe stSmokeAnf stSmokeStk rfl (by decide)
     "pre" .byteString rfl rfl (by decide) (by decide)
-    Stack.TxContext.sampleCtx (ByteArray.mk #[0x30]) stSmokePreimage []
+    Stack.TxContext.sampleCtx stSmokeSig stSmokePreimage []
     RunarVerification.Stack.ValidTxContext.sampleCtx_valid rfl rfl rfl
+    stSmokeSig_spec
 
 /-! ## Dispatch sub-omnibus retirement — the multi-public passthrough consume
 
@@ -6102,12 +6137,18 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms (p : ANFProgram)
     -- stateful fragment (decided by `AgreesStateful.statefulConsumeShapeBool` —
     -- one param `pre`, body exactly the auto-injected gated prologue) the shape
     -- witnesses plus the valid-BIP-143-context entry bundle are recovered: the
-    -- preimage param resolves to the canonical preimage of a valid context, and
-    -- the runtime stack carries that preimage over the `_opPushTxSig`-derived
-    -- signature.  Keyed on the DECIDABLE classifier, it is VACUOUS for every
+    -- preimage param resolves to the canonical preimage of a valid context, the
+    -- runtime stack carries that preimage over the `_opPushTxSig`-derived
+    -- signature, and (TIGHTENED 2026-06-10) the spender's signature is a
+    -- genuine spend witness — its AUTH-backend verdict against the synthetic
+    -- key `G` equals the PREIMAGE backend's verdict (previously supplied by an
+    -- over-strong universal bridge axiom that forced `checkSig` constant).
+    -- Keyed on the DECIDABLE classifier, it is VACUOUS for every
     -- non-canonical body, so the omnibus stays jointly satisfiable.  Its only
     -- consumer is the conformance harness, which discharges it per fixture from
-    -- the deployment context.
+    -- the deployment context (the witness-existence axiom
+    -- `StatefulBridge.exists_checkSig_witness_under_validTxContext` shows the
+    -- bundle satisfiable for every valid context).
     (hStatefulFrag :
       RunarVerification.Stack.AgreesStateful.statefulConsumeShapeBool anfM = true →
         ∃ (pre : String) (ty : ANFType) (ctx : Stack.TxContext)
@@ -6118,7 +6159,10 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms (p : ANFProgram)
           Stack.ValidTxContext ctx ∧
           preimage = Stack.TxContext.buildPreimage ctx ∧
           initialAnf.resolveRef pre = some (.vBytes preimage) ∧
-          initialStack.stack = .vBytes preimage :: .vBytes sigV :: rest)
+          initialStack.stack = .vBytes preimage :: .vBytes sigV :: rest ∧
+          RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sigV
+              Stack.AgreesStateful.stG
+            = RunarVerification.ANF.Eval.Crypto.checkPreimage preimage)
     -- **Dispatch consume premise (keyed).**  For a multi-public program in the
     -- canonical passthrough fragment (decided by `dispatchConsumeShapeBool`)
     -- the entry bundle is recovered: the unlocking caller pushed the selector
@@ -6177,12 +6221,12 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms (p : ANFProgram)
           RunarVerification.Stack.AgreesStateful.statefulConsumeShapeBool anfM = true
       · by_cases hStName : anfM.name ≠ "constructor"
         · obtain ⟨pre, ty, ctx, sigV, preimage, restV, hStParams, hStBody,
-            hStNe1, hStNe2, hStValid, hStPreLink, hStAnfPre, hStStk⟩ :=
+            hStNe1, hStNe2, hStValid, hStPreLink, hStAnfPre, hStStk, hStSig⟩ :=
             hStatefulFrag hStShape
           exact compileSafe_observational_correct_stateful_consume
             p anfM bytes hMem hPublic hSafe initialAnf initialStack
             hStSingle hStName pre ty hStParams hStBody hStNe1 hStNe2
-            ctx sigV preimage restV hStValid hStPreLink hStAnfPre hStStk
+            ctx sigV preimage restV hStValid hStPreLink hStAnfPre hStStk hStSig
         · exact compileSafe_observational_correct_modulo_crypto_call_codegen
             p hWF anfM bytes hMem hPublic hSafe initialAnf initialStack tsm hAgrees hNoAlias
       · exact compileSafe_observational_correct_modulo_crypto_call_codegen
@@ -6502,12 +6546,14 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms_via_support
     -- stateful fragment (decided by `AgreesStateful.statefulConsumeShapeBool` —
     -- one param `pre`, body exactly the auto-injected gated prologue) the shape
     -- witnesses plus the valid-BIP-143-context entry bundle are recovered: the
-    -- preimage param resolves to the canonical preimage of a valid context, and
-    -- the runtime stack carries that preimage over the `_opPushTxSig`-derived
-    -- signature.  Keyed on the DECIDABLE classifier, it is VACUOUS for every
-    -- non-canonical body, so the omnibus stays jointly satisfiable.  Its only
-    -- consumer is the conformance harness, which discharges it per fixture from
-    -- the deployment context.
+    -- preimage param resolves to the canonical preimage of a valid context, the
+    -- runtime stack carries that preimage over the `_opPushTxSig`-derived
+    -- signature, and (TIGHTENED 2026-06-10) the spender's signature is a
+    -- genuine spend witness — its AUTH-backend verdict against the synthetic
+    -- key `G` equals the PREIMAGE backend's verdict.  Keyed on the DECIDABLE
+    -- classifier, it is VACUOUS for every non-canonical body, so the omnibus
+    -- stays jointly satisfiable.  Its only consumer is the conformance
+    -- harness, which discharges it per fixture from the deployment context.
     (hStatefulFrag :
       RunarVerification.Stack.AgreesStateful.statefulConsumeShapeBool anfM = true →
         ∃ (pre : String) (ty : ANFType) (ctx : Stack.TxContext)
@@ -6518,7 +6564,10 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms_via_support
           Stack.ValidTxContext ctx ∧
           preimage = Stack.TxContext.buildPreimage ctx ∧
           initialAnf.resolveRef pre = some (.vBytes preimage) ∧
-          initialStack.stack = .vBytes preimage :: .vBytes sigV :: rest)
+          initialStack.stack = .vBytes preimage :: .vBytes sigV :: rest ∧
+          RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sigV
+              Stack.AgreesStateful.stG
+            = RunarVerification.ANF.Eval.Crypto.checkPreimage preimage)
     -- **Dispatch consume premise (keyed).**  For a multi-public program in the
     -- canonical passthrough fragment (decided by `dispatchConsumeShapeBool`)
     -- the entry bundle is recovered: the unlocking caller pushed the selector

--- a/runar-verification/RunarVerification/Stack/AgreesStateful.lean
+++ b/runar-verification/RunarVerification/Stack/AgreesStateful.lean
@@ -46,13 +46,11 @@ open RunarVerification.ANF.Eval (Value)
 open RunarVerification.ANF.Eval.Crypto
 
 /-- The compiler's synthetic BIP-143 key: the secp256k1 generator point `G`
-in compressed SEC form (33 bytes).  Byte-identical to the local constant in
+in compressed SEC form (33 bytes).  The byte literal now lives in
+`StatefulBridge.stG` (the witness-existence axiom is stated over it); this
+is a definitional alias, byte-identical to the local constant in
 `Lower.lowerCheckPreimageOpsLive`. -/
-def stG : ByteArray := ByteArray.mk #[
-  0x02, 0x79, 0xBE, 0x66, 0x7E, 0xF9, 0xDC, 0xBB,
-  0xAC, 0x55, 0xA0, 0x62, 0x95, 0xCE, 0x87, 0x0B,
-  0x07, 0x02, 0x9B, 0xFC, 0xDB, 0x2D, 0xCE, 0x28,
-  0xD9, 0x59, 0xF2, 0x81, 0x5B, 0x16, 0xF8, 0x17, 0x98]
+def stG : ByteArray := StatefulBridge.stG
 
 /-- The canonical stateful method's CONSTANT lowered op list. -/
 def statefulPrologueOps : List StackOp :=
@@ -83,7 +81,7 @@ theorem lowerValueP_checkPreimage_statefulPrologue
   simp [Lower.lowerCheckPreimageOpsLive, Lower.loadRefLive, Lower.bringToTop,
     Lower.StackMap.depth?, Lower.StackMap.popN, Lower.isLastUse,
     Lower.lastUsesLookup, Lower.listContains, List.findIdx?, List.findIdx?.go,
-    hne2, Ne.symm hne1, statefulPrologueOps, stG]
+    hne2, Ne.symm hne1, statefulPrologueOps, stG, StatefulBridge.stG]
 
 /-- The auto-injected `assert _cp0` lowers to the bare `OP_VERIFY` (the
 `_cp0` slot is consumed in place at d0 last-use). -/
@@ -237,7 +235,7 @@ open RunarVerification.Script RunarVerification.Script.Parse in
 theorem parseOps_emit_statefulPrologue :
     parseOps (emitOpsL statefulPrologueOps) = .ok statefulPrologueOps := by
   simp +decide [statefulPrologueOps, emitOpsL, emitStackOpL, encodePushValL,
-    encodePushBytesL, encodePushDataL, stG, opcodeByName?,
+    encodePushBytesL, encodePushDataL, stG, StatefulBridge.stG, opcodeByName?,
     ByteArray.toList_eq_data_toList, ByteArray.size]
   rfl
 
@@ -248,7 +246,7 @@ theorem emitOps_toList_statefulPrologue :
   simp +decide [Emit.emitOps, Emit.emitStackOp, Emit.encodePushVal,
     Emit.encodePushBytes, Emit.encodePushData, statefulPrologueOps, emitOpsL,
     emitStackOpL, encodePushValL, encodePushBytesL, encodePushDataL, stG,
-    opcodeByName?, ByteArray.size, ByteArray.toList_append,
+    StatefulBridge.stG, opcodeByName?, ByteArray.size, ByteArray.toList_append,
     ByteArray.toList_mk_singleton, ByteArray.toList_eq_data_toList]
 
 open RunarVerification.Script RunarVerification.Script.Parse in

--- a/runar-verification/RunarVerification/Stack/StatefulBridge.lean
+++ b/runar-verification/RunarVerification/Stack/StatefulBridge.lean
@@ -33,30 +33,48 @@ backends** and have **different abort semantics**:
 So the prologue's success bit on the ANF side (folding in the downstream
 `assert _cp0`) is `Crypto.checkPreimage bytes`, and on the Stack side it is
 `authBackend.checkSig sig pk`.  These agree only under a BIP-143 / ECDSA
-fact about the two external primitives — that is the bridge axiom below.
+fact about the two external primitives — carried below as the
+per-deployment `hSig` provenance hypothesis plus the witness-existence
+axiom.
 
 ## What this file ships
 
-1. `checkPreimage_iff_checkSig_under_validTxContext` — the ONE new
-   (pre-authorized) crypto axiom: under a well-formed BIP-143 context, the
-   PREIMAGE backend's verdict on the preimage equals the AUTH backend's
-   verdict on the synthetic-key signature check the Stack prologue performs.
-   It is a sibling of the existing `hashBackend` / `authBackend` /
-   `preimageBackend` assumptions — an external-primitive agreement, NOT a
-   codegen-soundness axiom (it RETIRES the split-backend blocker, it does
-   not introduce a fresh soundness claim).
-2. `statefulPrologue_successAgrees_under_validTxContext` — the genuine
-   correspondence theorem: composing the bridge with the two `AgreesD2`
-   substrate lemmas (ANF side) and `runOpcode_CHECKSIGVERIFY_ValidTxContext`
-   (Stack side), it proves the GATED ANF stateful-prologue success bit (the
-   `check_preimage` binding followed by its downstream `assert _cp0`) equals
-   the Stack prologue's `OP_CHECKSIGVERIFY` success bit.  This is the
-   cleanest `successAgrees`-shaped statement for the prologue.
-3. In-file smokes firing the correspondence on a concrete VALID context
+1. `stG` — the compiler's synthetic BIP-143 key (the secp256k1 generator
+   `G` in compressed SEC form), the shared constant the Stack prologue
+   pushes (`Lower.lowerCheckPreimageOpsLive`).  `AgreesStateful` re-exports
+   it.
+2. `exists_checkSig_witness_under_validTxContext` — the ONE crypto axiom
+   (TIGHTENED 2026-06-10): for every well-formed BIP-143 context there
+   EXISTS a signature whose AUTH-backend verdict against the synthetic key
+   `G` equals the PREIMAGE backend's verdict on the canonical preimage.
+   The previous shape (`checkPreimage_iff_checkSig_under_validTxContext`)
+   equated the two verdicts for UNIVERSALLY quantified `sig`/`pk` — which
+   forced `authBackend.checkSig` to be a CONSTANT function (one valid
+   context pins the same boolean for all `sig`,`pk`), a cryptographically
+   unfaithful assumption (false for real ECDSA).  The existential shape is
+   TRUE under the real-world reading: when the preimage backend accepts,
+   the deterministic ECDSA signature over the BIP-143 digest with the
+   synthetic key is a verifying witness; when it rejects, any garbage
+   byte-string is a non-verifying one.  It constrains NOTHING about
+   `checkSig` off the witness, so the backend can be non-constant.
+3. `statefulPrologue_successAgrees_under_validTxContext` — the genuine
+   correspondence theorem.  The per-deployment sig-provenance fact is now a
+   HYPOTHESIS (`hSig : authBackend.checkSig sig stG = Crypto.checkPreimage
+   preimage` — "the spender's `_opPushTxSig` witness verifies exactly when
+   the preimage backend accepts"), discharged per fixture by the
+   conformance harness and, for the in-file smokes, by the witness the
+   existence axiom provides (`Classical.choose`).  Composing it with the
+   two `AgreesD2` substrate lemmas (ANF side) and the
+   `OP_CHECKSIGVERIFY` reduction (Stack side) proves the GATED ANF
+   stateful-prologue success bit (the `check_preimage` binding followed by
+   its downstream `assert _cp0`) equals the Stack prologue's
+   `OP_CHECKSIGVERIFY` success bit.
+4. In-file smokes firing the correspondence on a concrete VALID context
    (success on both sides) and exercising the gated-ANF abort path on a
    concrete FALSE preimage verdict.
 
-No `sorry`/`admit`; exactly one new `axiom` (the bridge).
+No `sorry`/`admit`; exactly one `axiom` (the witness existence — count-
+neutral with the shape it replaced).
 -/
 
 namespace RunarVerification
@@ -67,44 +85,59 @@ open RunarVerification.ANF
 open RunarVerification.ANF.Eval
 open RunarVerification.Stack.Eval
 
-/-! ## 1 — The BIP-143 preimage⟷signature bridge axiom -/
+/-! ## 1 — The synthetic key + the BIP-143 witness-existence axiom -/
 
-/-- **BIP-143 preimage⟷signature bridge (crypto assumption).**
+/-- The compiler's synthetic BIP-143 key: the secp256k1 generator point `G`
+in compressed SEC form (33 bytes).  Byte-identical to the local constant in
+`Lower.lowerCheckPreimageOpsLive`; `AgreesStateful.stG` re-exports it. -/
+def stG : ByteArray := ByteArray.mk #[
+  0x02, 0x79, 0xBE, 0x66, 0x7E, 0xF9, 0xDC, 0xBB,
+  0xAC, 0x55, 0xA0, 0x62, 0x95, 0xCE, 0x87, 0x0B,
+  0x07, 0x02, 0x9B, 0xFC, 0xDB, 0x2D, 0xCE, 0x28,
+  0xD9, 0x59, 0xF2, 0x81, 0x5B, 0x16, 0xF8, 0x17, 0x98]
 
-Under a well-formed BIP-143 context (`ValidTxContext ctx`) whose preimage is
-the canonical `TxContext.buildPreimage ctx`, the synthetic-key signature
-check the Stack stateful prologue performs — `OP_CHECKSIGVERIFY` over the
-`_opPushTxSig`-derived signature `sig` against the secp256k1 generator `pk`
-(`G`) — succeeds iff the PREIMAGE backend accepts the preimage.
+/-- **BIP-143 witness existence (crypto assumption — TIGHTENED 2026-06-10).**
 
-Concretely it equates the two external primitives the §11.6 wall keeps
-apart: `Crypto.checkPreimage preimage` (the PREIMAGE backend, used by the
-ANF `check_preimage` binding) and `authBackend.checkSig sig pk` (the AUTH
-backend, used by the Stack `OP_CHECKSIGVERIFY`).  The operand names match
-`runOpcode_CHECKSIGVERIFY_ValidTxContext` exactly: `sig`/`pk` are the two
-byte-values on the prologue stack (pk on top, sig below), `preimage` is the
-`StackState.preimage` field the lowering threads as `buildPreimage ctx`.
+For every well-formed BIP-143 context there exists a signature whose
+AUTH-backend verdict against the compiler's synthetic key `G` (`stG`)
+equals the PREIMAGE backend's verdict on the canonical preimage
+`TxContext.buildPreimage ctx`.
 
-This is the documented external-primitive AGREEMENT between `authBackend`
-and `preimageBackend` under a valid context.  It is a sibling of the
-existing `hashBackend` / `authBackend` / `preimageBackend` crypto
-assumptions — NOT a codegen-soundness axiom.  It REPLACES the split-backend
-blocker (`AgreesD2.lean` documented remaining blocker for the stateful
-sub-omnibus): one external-crypto fact in, one codegen-soundness obligation
-discharged.
+History: the previous shape
+(`checkPreimage_iff_checkSig_under_validTxContext`) asserted
+`Crypto.checkPreimage preimage = authBackend.checkSig sig pk` for
+UNIVERSALLY quantified `sig pk : ByteArray`.  That forced
+`authBackend.checkSig` to be a CONSTANT function — for any one valid
+context, every `(sig, pk)` pair was pinned to the same boolean — an
+assumption whose real-world (ECDSA) reading is FALSE: some signatures
+verify, most don't.  It was tightened to this existential on 2026-06-10.
 
-Cryptographic justification: BIP-143 fixes the exact bytes the stateful
-locking script signs (`buildPreimage ctx`); the compiler's synthetic key is
-`G`, and a valid spending witness for that script is, by the ECDSA
-verification equation over those bytes, exactly a witness the preimage
-backend accepts.  Both backends are opaque in this development, so the
-agreement is assumed, not derived. -/
-axiom checkPreimage_iff_checkSig_under_validTxContext (ctx : TxContext)
-    (sig pk preimage : ByteArray)
-    (_hValid : ValidTxContext ctx)
-    (_hPre : preimage = TxContext.buildPreimage ctx) :
-    RunarVerification.ANF.Eval.Crypto.checkPreimage preimage
-      = RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sig pk
+Real-world reading (TRUE for ECDSA over BIP-143): the synthetic key is the
+generator `G`, whose discrete log (1) is public, so a deterministic ECDSA
+signature over the digest of `buildPreimage ctx` is constructible by every
+spender.  If the preimage backend accepts the canonical preimage, that
+constructed signature is a verifying witness (`true = true`); if it
+rejects, any non-signature byte-string fails verification (`false =
+false`).  Either way a witness exists.  Crucially the existential
+constrains NOTHING about `checkSig` away from the witness — the backend is
+free to be non-constant, as real ECDSA is.
+
+Consumers: the per-deployment AGREEMENT for the specific `_opPushTxSig`
+witness the spender supplies is now a HYPOTHESIS of
+`statefulPrologue_successAgrees_under_validTxContext` (and of the keyed
+`hStatefulFrag` omnibus premise in `Pipeline.lean`), discharged per fixture
+by the conformance harness.  This axiom's role is anti-vacuity: it supplies
+the witness (`Classical.choose`) that lets the in-file smokes and
+`Pipeline.smoke_stateful_consume_fires` fire the correspondence end-to-end
+on concrete contexts.  It is a sibling of the existing `hashBackend` /
+`authBackend` / `preimageBackend` crypto assumptions — NOT a
+codegen-soundness axiom. -/
+axiom exists_checkSig_witness_under_validTxContext (ctx : TxContext)
+    (_hValid : ValidTxContext ctx) :
+    ∃ sig : ByteArray,
+      RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sig stG
+        = RunarVerification.ANF.Eval.Crypto.checkPreimage
+            (TxContext.buildPreimage ctx)
 
 /-! ## 2 — ANF-side gated prologue reduction (the downstream `assert _cp0`)
 
@@ -174,12 +207,19 @@ bit equals the Stack prologue's `OP_CHECKSIGVERIFY` success bit.
 Concretely, with:
 * `ValidTxContext ctx` and `stkSt.preimage = buildPreimage ctx` — the
   well-formed-context facts the Stack `OP_CHECKSIGVERIFY` lemma needs;
-* `stkSt.stack = pk :: sig :: rest` — the prologue's signature-check stack
-  shape (pk = `G` on top, sig = `_opPushTxSig`-derived below), matching
-  `runOpcode_CHECKSIGVERIFY_ValidTxContext`;
+* `stkSt.stack = stG :: sig :: rest` — the prologue's signature-check stack
+  shape (the synthetic key `G` on top, the `_opPushTxSig`-derived witness
+  below), matching `runOpcode_CHECKSIGVERIFY_ValidTxContext`;
 * `s.resolveRef pre = some (.vBytes preimage)` and `preimage = buildPreimage
   ctx` — the ANF-side input readiness, linking the ANF preimage bytes to the
   Stack-threaded preimage;
+* `hSig : authBackend.checkSig sig stG = Crypto.checkPreimage preimage` —
+  the per-deployment sig-provenance fact (TIGHTENED 2026-06-10; previously
+  supplied by the over-strong universal bridge axiom, which forced
+  `checkSig` constant): the spender's witness verifies against the
+  synthetic key exactly when the preimage backend accepts.  Discharged per
+  fixture by the conformance harness; for the smokes, by the witness
+  `exists_checkSig_witness_under_validTxContext` provides;
 
 we have
 
@@ -189,10 +229,9 @@ we have
 Composition:
 * ANF half — `gatedStatefulPrologue_isSome_eq`: the LHS isSome is
   `Crypto.checkPreimage preimage`.
-* bridge — `checkPreimage_iff_checkSig_under_validTxContext`: that equals
-  `authBackend.checkSig sig pk`.
+* provenance — `hSig`: that equals `authBackend.checkSig sig stG`.
 * Stack half — `runOpcode_CHECKSIGVERIFY` definitional shape: the RHS isSome
-  is `authBackend.checkSig sig pk` (success ↦ `.ok`, failure ↦
+  is `authBackend.checkSig sig stG` (success ↦ `.ok`, failure ↦
   `.assertFailed`, both branches case-split through the same bool).
 
 NON-VACUOUS: smokes below fire it on a concrete VALID context where the
@@ -200,29 +239,31 @@ preimage verdict is forced `true` (both sides succeed) and exercise the
 gated-ANF abort on a `false` verdict. -/
 theorem statefulPrologue_successAgrees_under_validTxContext
     (methods : List ANFMethod) (s : State)
-    (ctx : TxContext) (sig pk preimage : ByteArray) (rest : List Value)
+    (ctx : TxContext) (sig preimage : ByteArray) (rest : List Value)
     (stkSt : StackState) (pre : String)
-    (hValid : ValidTxContext ctx)
-    (hStkPre : stkSt.preimage = TxContext.buildPreimage ctx)
-    (hStk : stkSt.stack = .vBytes pk :: .vBytes sig :: rest)
-    (hPreLink : preimage = TxContext.buildPreimage ctx)
-    (hAnfPre : s.resolveRef pre = some (.vBytes preimage)) :
+    (_hValid : ValidTxContext ctx)
+    (_hStkPre : stkSt.preimage = TxContext.buildPreimage ctx)
+    (hStk : stkSt.stack = .vBytes stG :: .vBytes sig :: rest)
+    (_hPreLink : preimage = TxContext.buildPreimage ctx)
+    (hAnfPre : s.resolveRef pre = some (.vBytes preimage))
+    (hSig : RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sig stG
+        = RunarVerification.ANF.Eval.Crypto.checkPreimage preimage) :
     (evalBindingsP methods s (gatedStatefulPrologueBody pre)).toOption.isSome
       ↔ (Eval.runOpcode "OP_CHECKSIGVERIFY" stkSt).toOption.isSome := by
   -- ANF half: LHS isSome = Crypto.checkPreimage preimage.
   rw [gatedStatefulPrologue_isSome_eq methods s pre preimage hAnfPre]
-  -- Bridge: Crypto.checkPreimage preimage = authBackend.checkSig sig pk.
-  rw [checkPreimage_iff_checkSig_under_validTxContext ctx sig pk preimage hValid hPreLink]
+  -- Provenance: Crypto.checkPreimage preimage = authBackend.checkSig sig stG.
+  rw [← hSig]
   -- Stack half: reduce `runOpcode "OP_CHECKSIGVERIFY"` to its bool branch.
-  -- `popN stkSt 2` peels `[pk, sig]` off `hStk`; the arm then branches on
-  -- `checkSig sigB pkB = authBackend.checkSig sig pk`.
+  -- `popN stkSt 2` peels `[stG, sig]` off `hStk`; the arm then branches on
+  -- `checkSig sigB pkB = authBackend.checkSig sig stG`.
   simp only [Eval.runOpcode, Eval.popN, StackState.pop?, hStk, asBytes?,
     RunarVerification.ANF.Eval.Crypto.checkSig]
   -- Both sides are now `<bool> = true ↔ (if <bool> then .ok _ else .error _).isSome`.
   -- The `if` carries a `Decidable (<bool> = true)` instance that depends on the
   -- term, so `simp only [h]` (not `rw`) discharges each branch.
   rcases Bool.eq_false_or_eq_true
-      (RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sig pk) with h | h <;>
+      (RunarVerification.ANF.Eval.Crypto.authBackend.checkSig sig stG) with h | h <;>
     simp only [h] <;> simp [Except.toOption, Option.isSome]
 
 /-! ## 4 — In-file smokes (non-vacuity)
@@ -239,17 +280,35 @@ def smokePreimage : ByteArray := TxContext.buildPreimage TxContext.sampleCtx
 def smokeState : State :=
   { params := [("pre", .vBytes smokePreimage)] }
 
-/-- A concrete Stack state in the prologue's `OP_CHECKSIGVERIFY` shape, with
-the sample context's preimage threaded and `[pk, sig]` on top.  The byte
-values of `pk`/`sig` are irrelevant to the success bit (they are opaque to
-the AUTH backend), so any placeholders do. -/
-def smokeStkSt : StackState :=
-  { stack := [.vBytes (ByteArray.mk #[0x01]), .vBytes (ByteArray.mk #[0x02])],
-    preimage := TxContext.buildPreimage TxContext.sampleCtx }
-
 /-- Smoke: the sample context is a `ValidTxContext` (the bridge precondition). -/
 theorem smoke_sampleCtx_valid : ValidTxContext TxContext.sampleCtx :=
   Stack.ValidTxContext.sampleCtx_valid
+
+/-- The sample context's spend witness, obtained from the witness-existence
+axiom (noncomputable — the backends are opaque, so no concrete signature
+bytes are derivable in-model; `Classical.choose` names the one the axiom
+provides). -/
+noncomputable def smokeSig : ByteArray :=
+  Classical.choose
+    (exists_checkSig_witness_under_validTxContext TxContext.sampleCtx
+      smoke_sampleCtx_valid)
+
+/-- The witness property: `smokeSig`'s AUTH verdict against `stG` equals the
+PREIMAGE backend's verdict on the sample preimage — the `hSig` provenance
+hypothesis of the correspondence, discharged by construction. -/
+theorem smokeSig_spec :
+    RunarVerification.ANF.Eval.Crypto.authBackend.checkSig smokeSig stG
+      = RunarVerification.ANF.Eval.Crypto.checkPreimage smokePreimage :=
+  Classical.choose_spec
+    (exists_checkSig_witness_under_validTxContext TxContext.sampleCtx
+      smoke_sampleCtx_valid)
+
+/-- A concrete Stack state in the prologue's `OP_CHECKSIGVERIFY` shape, with
+the sample context's preimage threaded and `[stG, smokeSig]` on top (the
+synthetic key over the chosen spend witness). -/
+noncomputable def smokeStkSt : StackState :=
+  { stack := [.vBytes stG, .vBytes smokeSig],
+    preimage := TxContext.buildPreimage TxContext.sampleCtx }
 
 /-- Smoke: the ANF entry state resolves `pre` to the canonical preimage.
 (`Value` has no `DecidableEq` — `ByteArray` blocks it — so this is `rfl`, a
@@ -260,16 +319,17 @@ theorem smoke_resolveRef :
 /-- **THE SMOKE.**  The correspondence FIRES on the concrete valid context:
 the gated-ANF prologue success bit ↔ the Stack `OP_CHECKSIGVERIFY` success
 bit.  Exercises `statefulPrologue_successAgrees_under_validTxContext`
-end-to-end through the bridge axiom — non-vacuous (both `isSome` sides are
-the SAME `authBackend.checkSig` bit, not `True`). -/
+end-to-end — the `hSig` provenance hypothesis is discharged by the witness
+the existence axiom provides (`smokeSig_spec`) — non-vacuous (both `isSome`
+sides are the SAME `authBackend.checkSig` bit, not `True`). -/
 theorem smoke_statefulPrologue_successAgrees :
     (evalBindingsP [] smokeState (gatedStatefulPrologueBody "pre")).toOption.isSome
       ↔ (Eval.runOpcode "OP_CHECKSIGVERIFY" smokeStkSt).toOption.isSome :=
   statefulPrologue_successAgrees_under_validTxContext
     [] smokeState TxContext.sampleCtx
-    (ByteArray.mk #[0x02]) (ByteArray.mk #[0x01]) smokePreimage
+    smokeSig smokePreimage
     [] smokeStkSt "pre"
-    smoke_sampleCtx_valid rfl rfl rfl smoke_resolveRef
+    smoke_sampleCtx_valid rfl rfl rfl smoke_resolveRef smokeSig_spec
 
 /-- Smoke (abort-path exercise): the GATED ANF prologue success bit reduces
 to the raw preimage verdict — i.e. it ABORTS exactly when

--- a/runar-verification/TRUST_MANIFEST.md
+++ b/runar-verification/TRUST_MANIFEST.md
@@ -67,6 +67,7 @@ that are preserved by design.
 | **Stateful sub-omnibus retired — canonical gated-prologue consume** | 2026-06-08 | **72** | **−1** | −1 (the stateful O1 sub-omnibus codegen-soundness axiom is GONE) | 0 | `compileSafe_observational_correct_modulo_stateful_codegen` retired (the SIXTH sub-omnibus retirement, 4 → 3 surviving: crypto_call / loop / dispatch). Its omnibus branch is discharged by the theorem `compileSafe_observational_correct_stateful_consume` for the single-public CANONICAL stateful fragment (decided by `AgreesStateful.statefulConsumeShapeBool`: one param `pre`, body exactly the auto-injected gated prologue `_cp0 := check_preimage pre ; assert _cp0`, name-collision exclusions). The whole method lowers to the CONSTANT `[OP_CODESEPARATOR, .swap, .push G, OP_CHECKSIGVERIFY]` (`AgreesStateful.lowerMethod_ops_statefulPrologue` — terminal `OP_VERIFY` elided); the Stack success bit is `authBackend.checkSig sig G` (`runOps_statefulPrologueOps_isSome`), the ANF success bit is `Crypto.checkPreimage preimage` (`StatefulBridge.gatedStatefulPrologue_isSome_eq`), and the pre-existing BIP-143 bridge axiom equates them under a valid context. M3 = peephole identity on the constant list; M4 = concrete `parseScript ∘ emitOpsFast` round-trip (`parseScript_emitOpsFast_statefulPrologue`). The keyed `hStatefulFrag` omnibus premise (vacuous off-fragment) supplies the valid-context entry bundle. Residual stateful bodies (user logic, epilogues, multi-public) fall through to the sound crypto_call cascade. `#print axioms` on the consume theorem: propext / Classical.choice / Quot.sound + the crypto backends + the bridge — NO sub-omnibus axiom, NO sorry. End-to-end smoke `smoke_stateful_consume_fires` (compileSafe accepts the canonical contract; the theorem fires on the sample-context entry). New substrate module `Stack/AgreesStateful.lean` (0 axioms). |
 | **Dispatch sub-omnibus retired — multi-public passthrough consume** | 2026-06-08 | **71** | **−1** | −1 (the dispatch O1 sub-omnibus codegen-soundness axiom is GONE) | 0 | `compileSafe_observational_correct_modulo_dispatch_codegen` retired (the SEVENTH sub-omnibus retirement, 3 → 2 surviving: crypto_call / loop). Its omnibus branch is discharged by the theorem `compileSafe_observational_correct_dispatch_consume` for the CANONICAL multi-public fragment (decided by `dispatchConsumeShapeBool`: 2–17 public methods, each a non-constructor-named single-param passthrough whose body is one `loadParam`). Every fragment method lowers to the EMPTY op list (`lowerMethod_ops_passthrough` — the param is consumed in place at depth-0 last-use), so the deployed script is the bare Merkle dispatch chain; the discharge composes the wave-69 D1 theorem `merkle_dispatch_selection_correct` (parse round-trip + branch-`i` selection) with the NEW multi-public shape lemma `peepholeProgram_multi_public_shape` (`publicMethodsOf (peephole (lower p)) = (filter public).map (peepholedLoweredMethod p)` when no public method is constructor-named). The keyed `hDispatchFrag` omnibus premise (vacuous off-fragment) supplies the selector witness, the index fact, and the param resolution. Residual multi-public programs (non-passthrough bodies, > 17 methods) fall through to the sound crypto_call cascade. `#print axioms` on the consume theorem: propext / Classical.choice / Quot.sound + the crypto backends — NO sub-omnibus axiom, NO bridge, NO sorry. End-to-end smoke `smoke_dispatch_consume_fires` (compileSafe accepts the canonical 2-passthrough contract; selector 0 fires the theorem on a concrete entry). |
 | **Aliased-operand counterexample found — surviving sub-omnibus axioms NARROWED** | 2026-06-08 | **71** | **0** | 0 (no axiom added or removed — 2 axioms narrowed with a decidable guard) | 0 | **The unguarded crypto_call (`hypothesis True`) and loop sub-omnibus axioms were REFUTABLE.** Counterexample: the hand-written ANF binding `t := x + x` (repeated operand, both reads consume-mode last-use). The liveness lowerer double-consumes the single stack copy (`bringToTop` d0-consume emits `[]` twice — the TS reference `05-stack-lower.ts:828` behaves identically), emitting a bare `[OP_ADD]` that UNDERFLOWS at runtime, while the ANF interpreter evaluates the binding fine; `compileSafe` accepts the program, so the unguarded `successAgrees` claim was `true ↔ false` = False. Pinned permanently by `aliasCx_anf_succeeds` / `aliasCx_stack_fails` / `aliasCx_guard_rejects` in `Pipeline.lean`. **Production impact: none from any frontend** — the ANF lowering pass gives every operand a fresh temp (the real TS compiler emits the correct `DUP SWAP ADD` = `767c93009c` for `x + x` source), and zero conformance fixtures contain a repeated-operand value; the pattern is reachable only via hand-written IR through `compileFromANF` / `--ir` (flagged as a compiler-side hardening follow-up). REPAIR: the decidable guard `noAliasedOperandsB` (every binding's value reads pairwise-distinct refs, recursing into branch/loop bodies) is now a REQUIRED hypothesis of both surviving sub-omnibus axioms, and the omnibus theorem threads it (`hNoAlias`). Every frontend-produced program satisfies the guard by construction. This is the second unsoundness repair after D2.b (2026-05-30). |
+| **BIP-143 bridge TIGHTENED — universal `checkSig` equality forced the auth backend constant** | 2026-06-10 | **71** | **0** | 0 (no axiom added or removed — the bridge axiom is REPLACED by a strictly weaker existential, count-neutral) | 0 | **The 2026-05-30 bridge axiom `checkPreimage_iff_checkSig_under_validTxContext` was over-strong.** It asserted `Crypto.checkPreimage preimage = authBackend.checkSig sig pk` for UNIVERSALLY quantified `sig pk : ByteArray` under any one valid context — so `authBackend.checkSig` was pinned to the SAME boolean for ALL `(sig, pk)` pairs, i.e. the axiom forced the auth backend to be a CONSTANT function. Consistent in-model (both backends are opaque), but cryptographically UNFAITHFUL: for real ECDSA some signatures verify and most do not, so the assumption's real-world reading is false. TIGHTENED (in `Stack/StatefulBridge.lean`): (a) the universal equality is GONE; (b) the surviving axiom is `exists_checkSig_witness_under_validTxContext` — for every valid context ∃ sig with `authBackend.checkSig sig stG = Crypto.checkPreimage (buildPreimage ctx)` (`stG` = the compiler's synthetic key `G`, now defined in `StatefulBridge` and aliased by `AgreesStateful.stG`). The existential is TRUE under the real-ECDSA reading (the synthetic key's discrete log is public, so the deterministic signature over the digest is a verifying witness when the preimage backend accepts; any garbage is a non-verifying one when it rejects) and constrains nothing about `checkSig` off the witness — the backend may be non-constant. (c) The per-deployment agreement for the spender's SPECIFIC `_opPushTxSig` witness is now a HYPOTHESIS (`hSig : authBackend.checkSig sig stG = Crypto.checkPreimage preimage`) of `statefulPrologue_successAgrees_under_validTxContext`, of `compileSafe_observational_correct_stateful_consume`, and of the keyed `hStatefulFrag` omnibus premise (one new conjunct) — discharged per fixture by the conformance harness, exactly like the other keyed entry bundles. (d) Anti-vacuity preserved: the smokes (`smoke_statefulPrologue_successAgrees`, `Pipeline.smoke_stateful_consume_fires`) obtain the witness via `Classical.choose` of the existence axiom and fire end-to-end on the sample context. `#print axioms` after: the consume theorem and the correspondence theorem now depend only on propext / Classical.choice / Quot.sound + the crypto backends (the bridge content moved into their hypotheses); the smokes additionally list `exists_checkSig_witness_under_validTxContext`. Net 0, 71 → 71. |
 
 **Net Tier 1 wave 2 (2026-05-17, omnibus-split inflation + Stage C widenings):** 78 → 86,
 Δ = +8 (intentional). The 9 per-family sub-omnibuses replace the single omnibus
@@ -101,7 +102,7 @@ proofs; Path 2 discharges them.
 |---|---:|---:|---:|---|
 | `ANF/Eval.lean` | 6 | 6 | 0 | 3 backend assumptions (`hashBackend`, `authBackend`, `preimageBackend`); 2 partial-SHA-256 ops (`sha256Compress`, `sha256Finalize`); 1 residual (`merkleRootHash256`-style outliers). Tier 1 wave 1 (2026-05-17) converted the 10 secp256k1, 12 P-256/P-384, and 6 SLH-DSA primitive symbols to delegating `def`s into new `Crypto/Secp256k1.lean`, `Crypto/NistEC.lean`, and inline `SlhDsa` namespace (net −28 from this file). `verifyWOTS` was deferred pending the `Crypto/SpecCore.lean` refactor (import-cycle blocker). |
 | `Crypto/Spec.lean` | 41 | 36 | 5 | **Preserved (36):** 10 secp256k1 group laws §1; 10 P-256/P-384 group laws §2.5 (the 2 `pXNegate` function symbols are now concrete `def`s per Tier 1 pXNegate-derivable); 5 auxiliary key functions; 11 EUF-CMA companions. **Target (5):** Phase B4 secp256k1 codegen-to-spec — `emitEcAdd/Mul/MulGen/Negate/OnCurve_runOps_eq`. **(`emitEcModReduce_runOps_eq` + `emitEcEncodeCompressed_runOps_eq` DISCHARGED 2026-05-25; `emitEcPointX_runOps_eq` + `emitEcPointY_runOps_eq` + `emitEcMakePoint_runOps_eq` DISCHARGED 2026-05-25 → theorems in `Stack/AgreesEC.lean`; net −5 from the original 10. `emitEcNegate/OnCurve_runOps_eq` BLOCKED on the Tracker-addressing simulation invariant; `emitEcAdd/Mul/MulGen` M4-walled.)** The 20 group-law axioms in §1 + §2.5 become *derivable* once Tier 2 group-law audit lands against the concrete `Crypto.ecAdd` / `Crypto.p256Add` / etc. defs (now in `Crypto/Secp256k1.lean` and `Crypto/NistEC.lean`). |
-| `Pipeline.lean` | 2 | 0 | 2 | 2 O1 sub-omnibus axioms (crypto_call / loop). **Dispatch sub-omnibus RETIRED (2026-06-08)** — discharged by `compileSafe_observational_correct_dispatch_consume` (canonical multi-public passthrough fragment, via the wave-69 D1 selection theorem + the multi-public shape lemma); residual multi-public programs fall to the sound crypto_call fallback; net −1. **Stateful sub-omnibus RETIRED (2026-06-08)** — `compileSafe_observational_correct_modulo_stateful_codegen` is GONE; its branch is discharged by the theorem `compileSafe_observational_correct_stateful_consume` (canonical gated-prologue fragment, via the pre-existing BIP-143 bridge), residual stateful bodies fall to the sound crypto_call fallback; net −1. The omnibus `compileSafe_observational_correct_modulo_codegen_axioms` is a `theorem`. **D2.b `auto_state_output_at_method_exit_correct` RETIRED (WS0a/T8, 2026-05-30)** — it was UNSOUND as stated (ANF `.addOutput` appends to `State.outputs`; Stack `runOps` leaves `StackState.outputs` empty), now a `theorem` restated via `OutputTrace.applyTrace` and proved from `AgreesD2.statefulEpilogue_outputs_agree`; it had no proof-term consumers. **D1 `merkle_dispatch_selection_correct` RETIRED (Wave 69, 2026-05-24)** — now a `theorem` proved from the wave-69a substrate (`parseScript_emitDispatch_eq_dispatchReconL` + `dispatchReconOps_select_branch`); it had no proof-term consumers. |
+| `Pipeline.lean` | 2 | 0 | 2 | 2 O1 sub-omnibus axioms (crypto_call / loop). **Dispatch sub-omnibus RETIRED (2026-06-08)** — discharged by `compileSafe_observational_correct_dispatch_consume` (canonical multi-public passthrough fragment, via the wave-69 D1 selection theorem + the multi-public shape lemma); residual multi-public programs fall to the sound crypto_call fallback; net −1. **Stateful sub-omnibus RETIRED (2026-06-08)** — `compileSafe_observational_correct_modulo_stateful_codegen` is GONE; its branch is discharged by the theorem `compileSafe_observational_correct_stateful_consume` (canonical gated-prologue fragment, via the keyed `hStatefulFrag` sig-provenance hypothesis — TIGHTENED 2026-06-10, formerly the universal BIP-143 bridge axiom), residual stateful bodies fall to the sound crypto_call fallback; net −1. The omnibus `compileSafe_observational_correct_modulo_codegen_axioms` is a `theorem`. **D2.b `auto_state_output_at_method_exit_correct` RETIRED (WS0a/T8, 2026-05-30)** — it was UNSOUND as stated (ANF `.addOutput` appends to `State.outputs`; Stack `runOps` leaves `StackState.outputs` empty), now a `theorem` restated via `OutputTrace.applyTrace` and proved from `AgreesD2.statefulEpilogue_outputs_agree`; it had no proof-term consumers. **D1 `merkle_dispatch_selection_correct` RETIRED (Wave 69, 2026-05-24)** — now a `theorem` proved from the wave-69a substrate (`parseScript_emitDispatch_eq_dispatchReconL` + `dispatchReconOps_select_branch`); it had no proof-term consumers. |
 | `Stack/Blake3.lean` | 2 | 0 | 2 | `runOps_b3HashOps_eq`, `runOps_b3CompressOps_eq` — codegen-to-spec. |
 | `Stack/P256P384.lean` | 14 | 0 | 14 | Codegen-to-spec for `emitP256/P384*` and `emitVerifyECDSA_P256/P384`. |
 | `Stack/SlhDsa.lean` | 6 | 0 | 6 | One codegen-to-spec link per FIPS 205 SHA-2 parameter set. |
@@ -262,8 +263,11 @@ planned sub-omnibus inventory:
   RETIRED (2026-06-08): the single-public canonical gated-prologue
   fragment (decided by `AgreesStateful.statefulConsumeShapeBool`) is
   discharged by `compileSafe_observational_correct_stateful_consume`
-  through the pre-existing BIP-143 bridge axiom; residual stateful
-  bodies fall through to the sound crypto_call cascade.
+  through the keyed `hStatefulFrag` sig-provenance hypothesis
+  (TIGHTENED 2026-06-10 — formerly the universal BIP-143 bridge
+  axiom, which forced `checkSig` constant; the surviving axiom is the
+  witness-existence form); residual stateful bodies fall through to
+  the sound crypto_call cascade.
 
 The split temporarily inflates the axiom count by ~8 (9 sub-omnibuses
 replace 1 omnibus). Each sub-omnibus retires as the corresponding
@@ -283,8 +287,8 @@ permanent axiom inflation.
 | `RunarVerification/Stack/Wots.lean` | 1 | Phase B8 codegen-to-spec axiom (`runOps_wotsBodyOps_eq`) |
 | `RunarVerification/Stack/Rabin.lean` | 1 | Phase B10 codegen-to-spec axiom (`runOps_rabinBodyOps_eq`) |
 | `RunarVerification/Stack/TxContext.lean` | 0 | Concrete BIP-143 context/preimage model; no companion assumptions |
-| `RunarVerification/Stack/StatefulBridge.lean` | 1 | **WS0a/T8 (2026-05-30):** the BIP-143 preimage⟷signature bridge `checkPreimage_iff_checkSig_under_validTxContext` — a preserved CRYPTO assumption (sibling of `authBackend` / `preimageBackend`), NOT codegen-soundness. Under a valid BIP-143 context it equates the PREIMAGE backend's `checkPreimage preimage` with the AUTH backend's synthetic-key `checkSig sig pk` (the `OP_CHECKSIGVERIFY` against `G` the stateful prologue performs). It RETIRES the §11.6 split-backend wall and powers the genuine theorem `statefulPrologue_successAgrees_under_validTxContext`. See "BIP-143 Preimage⟷Signature Bridge" above |
-| `RunarVerification/Pipeline.lean` | 2 | 2 O1 per-family sub-omnibus axioms (crypto-call, loop). **(2026-06-08) retired the dispatch sub-omnibus** `compileSafe_observational_correct_modulo_dispatch_codegen` (3 → 2 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_dispatch_consume` for the canonical multi-public passthrough fragment (`dispatchConsumeShapeBool`, 2–17 public single-param passthrough methods, each lowering to the EMPTY op list), composing the wave-69 D1 selection theorem `merkle_dispatch_selection_correct` with the new multi-public shape lemma `peepholeProgram_multi_public_shape`; residual multi-public programs fall to the sound crypto_call fallback; net −1. **(2026-06-08) retired the stateful sub-omnibus** `compileSafe_observational_correct_modulo_stateful_codegen` (4 → 3 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_stateful_consume` for the single-public canonical gated-prologue fragment (`AgreesStateful.statefulConsumeShapeBool`), composing the constant-lowering reduction, the runtime walk, the M3 peephole-identity, the M4 concrete parse round-trip, and the pre-existing BIP-143 bridge axiom; residual stateful bodies fall to the sound crypto_call fallback; net −1. The harness omnibus `compileSafe_observational_correct_modulo_codegen_axioms` is a `theorem` (not an axiom) that dispatches into these. **WS0a/T8 (2026-05-30) retired the D2.b state-output axiom** `auto_state_output_at_method_exit_correct` — it was UNSOUND as stated (ANF `.addOutput` appends to `State.outputs`; Stack `runOps` leaves `StackState.outputs` empty), now a `theorem` restated via `OutputTrace.applyTrace` and proved from `AgreesD2.statefulEpilogue_outputs_agree`; it had no proof-term consumers, so net −1. **Wave 69 (2026-05-24) retired the D1 dispatch-selection axiom** `merkle_dispatch_selection_correct` — now a `theorem` proved from the wave-69a substrate (`parseScript_emitDispatch_eq_dispatchReconL` + `dispatchReconOps_select_branch`); it had no proof-term consumers, so net −1. **Wave 39 (2026-05-23) retired the arith sub-omnibus** `compileSafe_observational_correct_modulo_arith_codegen` (9 → 8 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_arith_consume`. **Wave 45 (2026-05-23) retired the if_val sub-omnibus** `compileSafe_observational_correct_modulo_if_val_codegen` (8 → 7 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_ifval_consume`. **Wave 51 (2026-05-23) retired the math_byte sub-omnibus** `compileSafe_observational_correct_modulo_math_byte_call_codegen` (7 → 6 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_mathByte_consume` for the NO-LEN single-arg math_byte fragment; residual `len`/`OP_NIP`, 2-arg, and consume-mode bodies fall to the sound crypto_call fallback; net −1. **Wave 64 (2026-05-23) retired the update_prop sub-omnibus** `compileSafe_observational_correct_modulo_update_prop_codegen` (6 → 5 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_updateProp_consume` for the canonical `prop ± small-const ; update_prop` consume fragment; net −1. **Wave 66 (2026-05-24) retired the method_call sub-omnibus** `compileSafe_observational_correct_modulo_method_call_codegen` (5 → 4 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_methodCall_consume` for the param-passthrough method_call fragment; residual non-passthrough method_call bodies fall to the sound crypto_call fallback; net −1 |
+| `RunarVerification/Stack/StatefulBridge.lean` | 1 | **WS0a/T8 (2026-05-30), TIGHTENED 2026-06-10:** the BIP-143 witness-existence axiom `exists_checkSig_witness_under_validTxContext` — a preserved CRYPTO assumption (sibling of `authBackend` / `preimageBackend`), NOT codegen-soundness. For every valid BIP-143 context it asserts ∃ sig with `authBackend.checkSig sig stG = Crypto.checkPreimage (buildPreimage ctx)` (the synthetic key `G` = `StatefulBridge.stG`). The PREVIOUS shape (`checkPreimage_iff_checkSig_under_validTxContext`) stated that equality for UNIVERSALLY quantified `sig pk`, which forced `authBackend.checkSig` to be a CONSTANT function — false under the real-ECDSA reading; it was tightened 2026-06-10 (count-neutral). The per-deployment agreement for the spender's specific `_opPushTxSig` witness is now the `hSig` HYPOTHESIS of `statefulPrologue_successAgrees_under_validTxContext` and of the keyed `hStatefulFrag` omnibus premise (harness-discharged); the existence axiom's role is anti-vacuity — it supplies the `Classical.choose` witness the smokes fire on. See "BIP-143 Preimage⟷Signature Bridge" above |
+| `RunarVerification/Pipeline.lean` | 2 | 2 O1 per-family sub-omnibus axioms (crypto-call, loop). **(2026-06-08) retired the dispatch sub-omnibus** `compileSafe_observational_correct_modulo_dispatch_codegen` (3 → 2 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_dispatch_consume` for the canonical multi-public passthrough fragment (`dispatchConsumeShapeBool`, 2–17 public single-param passthrough methods, each lowering to the EMPTY op list), composing the wave-69 D1 selection theorem `merkle_dispatch_selection_correct` with the new multi-public shape lemma `peepholeProgram_multi_public_shape`; residual multi-public programs fall to the sound crypto_call fallback; net −1. **(2026-06-08) retired the stateful sub-omnibus** `compileSafe_observational_correct_modulo_stateful_codegen` (4 → 3 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_stateful_consume` for the single-public canonical gated-prologue fragment (`AgreesStateful.statefulConsumeShapeBool`), composing the constant-lowering reduction, the runtime walk, the M3 peephole-identity, the M4 concrete parse round-trip, and the keyed `hStatefulFrag` sig-provenance hypothesis (TIGHTENED 2026-06-10 — formerly the universal BIP-143 bridge axiom, which forced `checkSig` constant; the surviving `StatefulBridge` axiom is the witness-existence form powering the smoke); residual stateful bodies fall to the sound crypto_call fallback; net −1. The harness omnibus `compileSafe_observational_correct_modulo_codegen_axioms` is a `theorem` (not an axiom) that dispatches into these. **WS0a/T8 (2026-05-30) retired the D2.b state-output axiom** `auto_state_output_at_method_exit_correct` — it was UNSOUND as stated (ANF `.addOutput` appends to `State.outputs`; Stack `runOps` leaves `StackState.outputs` empty), now a `theorem` restated via `OutputTrace.applyTrace` and proved from `AgreesD2.statefulEpilogue_outputs_agree`; it had no proof-term consumers, so net −1. **Wave 69 (2026-05-24) retired the D1 dispatch-selection axiom** `merkle_dispatch_selection_correct` — now a `theorem` proved from the wave-69a substrate (`parseScript_emitDispatch_eq_dispatchReconL` + `dispatchReconOps_select_branch`); it had no proof-term consumers, so net −1. **Wave 39 (2026-05-23) retired the arith sub-omnibus** `compileSafe_observational_correct_modulo_arith_codegen` (9 → 8 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_arith_consume`. **Wave 45 (2026-05-23) retired the if_val sub-omnibus** `compileSafe_observational_correct_modulo_if_val_codegen` (8 → 7 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_ifval_consume`. **Wave 51 (2026-05-23) retired the math_byte sub-omnibus** `compileSafe_observational_correct_modulo_math_byte_call_codegen` (7 → 6 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_mathByte_consume` for the NO-LEN single-arg math_byte fragment; residual `len`/`OP_NIP`, 2-arg, and consume-mode bodies fall to the sound crypto_call fallback; net −1. **Wave 64 (2026-05-23) retired the update_prop sub-omnibus** `compileSafe_observational_correct_modulo_update_prop_codegen` (6 → 5 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_updateProp_consume` for the canonical `prop ± small-const ; update_prop` consume fragment; net −1. **Wave 66 (2026-05-24) retired the method_call sub-omnibus** `compileSafe_observational_correct_modulo_method_call_codegen` (5 → 4 sub-omnibuses): its branch is discharged by the theorem `compileSafe_observational_correct_methodCall_consume` for the param-passthrough method_call fragment; residual non-passthrough method_call bodies fall to the sound crypto_call fallback; net −1 |
 
 Tier B11 (2026-05-16) replaced the `buildChangeOutput` and
 `computeStateOutput` axioms with concrete `def`s and exposed them —
@@ -834,23 +838,67 @@ environment-provided. Lean code generation uses a fail-fast backend via
 `implemented_by`, so execution aborts instead of accepting the previous
 unconditional success behavior.
 
-## BIP-143 Preimage⟷Signature Bridge (the single new crypto axiom, WS0a/T8)
+## BIP-143 Preimage⟷Signature Bridge (the single bridge crypto axiom, WS0a/T8 — TIGHTENED 2026-06-10)
 
 `RunarVerification/Stack/StatefulBridge.lean` carries exactly one axiom,
-`checkPreimage_iff_checkSig_under_validTxContext`. It is a **preserved
-CRYPTO assumption** — a sibling of the `AuthBackend` / `PreimageBackend`
-existence assumptions above, NOT a codegen-soundness axiom — and it RETIRES
-the §11.6 split-backend wall for the auto-injected stateful prologue.
+`exists_checkSig_witness_under_validTxContext`. It is a **preserved CRYPTO
+assumption** — a sibling of the `AuthBackend` / `PreimageBackend` existence
+assumptions above, NOT a codegen-soundness axiom — and it (together with the
+per-deployment `hSig` provenance hypothesis described below) RETIRES the
+§11.6 split-backend wall for the auto-injected stateful prologue.
 
-Statement: for any `TxContext ctx` with `ValidTxContext ctx` and any
-`sig pk preimage : ByteArray` with `preimage = TxContext.buildPreimage ctx`,
+Statement: for any `TxContext ctx` with `ValidTxContext ctx`,
 
 ```
-Crypto.checkPreimage preimage = Crypto.authBackend.checkSig sig pk
+∃ sig : ByteArray,
+  Crypto.authBackend.checkSig sig stG
+    = Crypto.checkPreimage (TxContext.buildPreimage ctx)
 ```
 
-Why it is needed. The stateful prologue is checked through two DIFFERENT
-backends with DIFFERENT abort semantics:
+where `stG` (defined in the same file; `AgreesStateful.stG` is a definitional
+alias) is the compiler's synthetic key — the secp256k1 generator `G` in
+compressed SEC form, byte-identical to the constant
+`Lower.lowerCheckPreimageOpsLive` pushes.
+
+**History (the tightening).** The original 2026-05-30 shape,
+`checkPreimage_iff_checkSig_under_validTxContext`, asserted
+`Crypto.checkPreimage preimage = authBackend.checkSig sig pk` for
+UNIVERSALLY quantified `sig pk : ByteArray`. For any one valid context this
+pinned `authBackend.checkSig sig pk` to the SAME boolean for ALL `(sig, pk)`
+pairs — the axiom forced the auth backend to be a CONSTANT function. That is
+consistent in-model (both backends are opaque axioms) but cryptographically
+unfaithful: for real ECDSA some signatures verify and others do not, so the
+assumption's real-world reading is FALSE. The TCB must not contain an
+assumption that is false under its intended reading; it was tightened on
+2026-06-10, count-neutral (one axiom out, one in).
+
+The tightened existential is TRUE under the real-ECDSA reading: the synthetic
+key is `G`, whose discrete log (1) is public, so every spender can construct
+the deterministic ECDSA signature over the BIP-143 digest — a verifying
+witness when the preimage backend accepts the canonical preimage; when it
+rejects, any non-signature byte-string is a non-verifying witness. Either way
+the existential holds, and it constrains NOTHING about `checkSig` away from
+the witness — the backend is free to be non-constant.
+
+**The per-deployment provenance hypothesis.** The agreement for the SPECIFIC
+`_opPushTxSig` witness the spender supplies is no longer an axiom; it is the
+hypothesis
+
+```
+hSig : Crypto.authBackend.checkSig sig stG = Crypto.checkPreimage preimage
+```
+
+of `statefulPrologue_successAgrees_under_validTxContext`, of
+`Pipeline.compileSafe_observational_correct_stateful_consume`, and (as one
+new conjunct) of the keyed `hStatefulFrag` premise in both omnibus
+signatures. Like the other keyed entry bundles it is discharged per fixture
+by the conformance harness from the deployment context — "the spender's
+witness verifies against the synthetic key exactly when the preimage backend
+accepts" — and the existence axiom shows the bundle satisfiable for every
+valid context (the smokes discharge it by `Classical.choose`).
+
+Why a bridge is needed at all. The stateful prologue is checked through two
+DIFFERENT backends with DIFFERENT abort semantics:
 
 * **ANF side** (`ANF/Eval.lean:2186`). The auto-injected
   `_cp0 := check_preimage(pre)` binding runs the PREIMAGE backend and
@@ -865,25 +913,30 @@ backends with DIFFERENT abort semantics:
   ABORTS with `.assertFailed` unless `authBackend.checkSig sig pk = true`.
 
 So the prologue's success bit is `Crypto.checkPreimage bytes` on the ANF
-side (folding in `assert _cp0`) and `authBackend.checkSig sig pk` on the
+side (folding in `assert _cp0`) and `authBackend.checkSig sig stG` on the
 Stack side. These agree only under a BIP-143/ECDSA fact about the two
 external primitives. Both backends are opaque in this development, so the
-agreement is ASSUMED, not derived — exactly as "ECDSA satisfies EUF-CMA" is
-assumed. It is intended and permanent (NOT slated for discharge); it
-REPLACES a codegen-soundness obligation (the stateful sub-omnibus's
-documented split-backend blocker) with one external-crypto assumption.
+agreement cannot be derived: the witness EXISTENCE is assumed (the axiom,
+intended and permanent — exactly as "ECDSA satisfies EUF-CMA" is assumed),
+and the per-witness agreement is a harness-discharged hypothesis. Together
+they REPLACE a codegen-soundness obligation (the stateful sub-omnibus's
+documented split-backend blocker) without forcing the auth backend constant.
 
-The genuine theorem it powers,
-`statefulPrologue_successAgrees_under_validTxContext`, composes this bridge
-with the wave-65 `AgreesD2` ANF substrate
+The genuine theorem this powers,
+`statefulPrologue_successAgrees_under_validTxContext`, composes the `hSig`
+provenance hypothesis with the wave-65 `AgreesD2` ANF substrate
 (`evalBindingsP_statefulPrologue_reduces`) and the Phase-E Stack lemma
 `runOpcode_CHECKSIGVERIFY_ValidTxContext` to prove the gated-ANF
 stateful-prologue success bit ↔ the Stack `OP_CHECKSIGVERIFY` success bit.
-`#print axioms` on that theorem lists only `propext` / `Classical.choice` /
-`Quot.sound` + this bridge + the pre-existing `authBackend` /
-`preimageBackend`; NO `sorryAx`, NO codegen-soundness axiom. In-file smokes
-fire it on the sample valid context (both sides reduce to the SAME
-`authBackend.checkSig` bit — non-vacuous) and exercise the gated-ANF abort.
+`#print axioms` on that theorem (and on the Pipeline consume theorem) lists
+only `propext` / `Classical.choice` / `Quot.sound` + the pre-existing
+`authBackend` / `preimageBackend` (+ `hashBackend` via the pipeline); NO
+`sorryAx`, NO codegen-soundness axiom — the bridge content rides the
+hypothesis. The in-file smokes and `Pipeline.smoke_stateful_consume_fires`
+additionally list `exists_checkSig_witness_under_validTxContext` (they
+obtain the witness by `Classical.choose`), fire on the sample valid context
+(both sides reduce to the SAME `authBackend.checkSig` bit — non-vacuous),
+and exercise the gated-ANF abort.
 
 ## Opaque Executable Defaults
 

--- a/runar-verification/scripts/check-tcb-drift.sh
+++ b/runar-verification/scripts/check-tcb-drift.sh
@@ -20,7 +20,25 @@ cd "$(dirname "$0")/.."
 # |partial def) ` keys on declaration position; in practice the
 # false-positive rate is low because Lean docstrings indent.
 
-TARGET_AXIOMS=71        # −1 (2026-06-08 — dispatch sub-omnibus RETIRED:
+TARGET_AXIOMS=71        # ±0 (2026-06-10 — BIP-143 bridge TIGHTENED, count-neutral:
+                        # `checkPreimage_iff_checkSig_under_validTxContext` in
+                        # Stack/StatefulBridge.lean equated the two backend
+                        # verdicts for UNIVERSALLY quantified sig/pk, which
+                        # forced `authBackend.checkSig` to be a CONSTANT
+                        # function — cryptographically unfaithful. REPLACED by
+                        # the strictly weaker existential
+                        # `exists_checkSig_witness_under_validTxContext`
+                        # (∃ sig, checkSig sig stG = checkPreimage
+                        # (buildPreimage ctx) per valid ctx — true under the
+                        # real-ECDSA reading, constrains nothing off the
+                        # witness). The per-deployment agreement for the
+                        # spender's specific sig is now the `hSig` hypothesis
+                        # of the bridge/consume theorems and a new conjunct of
+                        # the keyed `hStatefulFrag` omnibus premise; the
+                        # existence axiom powers the smokes via
+                        # Classical.choose. See TRUST_MANIFEST.md §3.)
+                        #
+                        # Previous: 71 — −1 (2026-06-08 — dispatch sub-omnibus RETIRED:
                         # `compileSafe_observational_correct_modulo_dispatch_codegen`
                         # is GONE; its branch is discharged by the theorem
                         # `compileSafe_observational_correct_dispatch_consume` for the


### PR DESCRIPTION
## Summary

The stateful-prologue bridge axiom `checkPreimage_iff_checkSig_under_validTxContext` quantified `sig`/`pk` universally with no constraints — formally forcing `authBackend.checkSig` to be a constant function once one valid BIP-143 context exists. Consistent (the backends are opaque), but cryptographically unfaithful: false under a real-ECDSA reading.

## The tightened shape

The bridge content is split:

1. **Per-deployment agreement → hypothesis.** `hSig : authBackend.checkSig sig stG = checkPreimage preimage` (the spender's `_opPushTxSig` witness verifies against the synthetic key `G` exactly when the preimage backend accepts) is now a hypothesis of the prologue correspondence, the stateful consume theorem, and a new conjunct of the keyed `hStatefulFrag` omnibus premise — discharged per fixture like every other keyed entry bundle.
2. **Witness existence → the surviving axiom.** `exists_checkSig_witness_under_validTxContext : ∀ ctx, ValidTxContext ctx → ∃ sig, checkSig sig stG = checkPreimage (buildPreimage ctx)` — strictly weaker, TRUE under the real-ECDSA reading (G's discrete log is public, so the signature over the digest exists when the preimage verifies), and it constrains nothing off the witness: the backend may be non-constant. Its only proof-term role is anti-vacuity (the smokes take `Classical.choose` of it).

`pk` is pinned to `stG` (the 33-byte compressed generator, now defined in `StatefulBridge`; `AgreesStateful.stG` is a definitional alias).

## Result

- `#print axioms` on the stateful consume theorem and the prologue correspondence: standard axioms + crypto backends only — **the bridge axiom no longer appears on the omnibus path at all** (it rides the `hSig` hypothesis).
- The omnibus lists only the 2 surviving sub-omnibus axioms (crypto_call, loop) + backends.
- Gates: lean-verify 59 modules green; check-tcb-drift axioms = 71 (count-neutral), opaques/stubs/partial = 0. TRUST_MANIFEST updated (bridge section rewritten, trajectory row added).