### PR TITLE
fix(rb): analyzer canonical JSON — version-independent empty-array formatting

### DIFF
--- a/packages/runar-rb/lib/runar/analyzer.rb
+++ b/packages/runar-rb/lib/runar/analyzer.rb
@@ -171,7 +171,32 @@ module Runar
       top['findings'] = result[:findings].map { |f| finding_to_h(f) }
       top['paths'] = result[:paths].map { |p| path_to_h(p) }
       top['summary'] = summary_to_h(result[:summary])
-      JSON.pretty_generate(top) + "\n"
+      pretty_json(top) + "\n"
+    end
+
+    # Pretty-print per spec §3.5: 2-space indent, '": "' key separator,
+    # empty arrays/objects as '[]'/'{}' (no inner newline). We cannot use
+    # JSON.pretty_generate here: json gem < 2.8.0 (bundled with Ruby 3.3)
+    # renders empty containers with an inner newline, which diverges from
+    # the cross-tier golden byte format.
+    def pretty_json(value, depth = 0)
+      case value
+      when Hash
+        return '{}' if value.empty?
+        pad = '  ' * (depth + 1)
+        inner = value.map { |k, v| "#{pad}#{JSON.generate(k.to_s)}: #{pretty_json(v, depth + 1)}" }
+        "{\n#{inner.join(",\n")}\n#{'  ' * depth}}"
+      when Array
+        return '[]' if value.empty?
+        pad = '  ' * (depth + 1)
+        inner = value.map { |v| "#{pad}#{pretty_json(v, depth + 1)}" }
+        "[\n#{inner.join(",\n")}\n#{'  ' * depth}]"
+      else
+        # Scalars: String (RFC 8259 escaping, non-ASCII verbatim),
+        # Integer, true/false. JSON.generate handles all identically
+        # across json gem versions.
+        JSON.generate(value)
+      end
     end
 
     def finding_to_h(f)


### PR DESCRIPTION
## Root cause

The Ruby analyzer (`packages/runar-rb/lib/runar/analyzer.rb`) serialized its report with `JSON.pretty_generate`, whose empty-container formatting is json-gem-version dependent:

- json **< 2.8.0** (bundled with Ruby 3.3, used by the **Ruby SDK** CI job): empty arrays render as `[\n\n  ]`
- json **>= 2.8.0** (newer Rubies): empty arrays render as `[]`

Analyzer spec §3.5 (`spec/script-analyzer-format.md`) mandates *"Empty arrays serialize as `[]` (no newline inside)"*, and the cross-tier goldens in `conformance/analyzer/` encode that (all 6 other tiers match). The 3 fixtures whose reports contain empty `findings` / `branchChoices` arrays — **basic-p2pkh**, **escrow**, **covenant-vault** — therefore failed byte-comparison on CI Ruby 3.3 while passing on newer local Rubies, which is why this slipped through.

## Fix

Replace `JSON.pretty_generate` with a small pretty-printer in `Runar::Analyzer` that implements §3.5 directly (2-space indent, `": "` key separator, compact `[]`/`{}` for empty containers, scalars via `JSON.generate`). Output is now byte-identical regardless of json gem version. The analyzer CLI (`exe/runar_analyzer`) routes through the same `to_canonical_json`, so it is covered too. No goldens or other tiers touched.

## Verification

- Reproduced the exact CI diff locally by pinning json 2.7.2
- All 8 analyzer conformance fixtures byte-match the goldens under **both** json 2.7.2 and json 2.18.0
- Full `packages/runar-rb` suite: **983 examples, 0 failures**
- `scripts/lint-no-silent-skips.sh`: green (109 skip sites, 54 inventory rows)