### PR TITLE
fix(compiler): copy repeated operand refs in stack lowering (Go + Rust tiers)

### DIFF
--- a/compilers/go/codegen/stack.go
+++ b/compilers/go/codegen/stack.go
@@ -855,6 +855,37 @@ func (ctx *loweringContext) isLastUse(ref string, currentIndex int, lastUses map
 	return !ok || last <= currentIndex
 }
 
+// operandConsume is the consume-vs-copy decision for one operand of a
+// multi-operand ANF value.
+//
+// operands is the FULL operand-ref list of the value (including ref itself).
+// The load may consume (ROLL / move) the ref only when this binding is the
+// ref's last use AND the ref occurs exactly once in the operand list. A ref
+// that is read at more than one operand position of the same value must be
+// copied (PICK / DUP) at EVERY position: each operand position needs its own
+// stack slot, and a consume-mode load of a ref that is already on top of the
+// stack is a no-op (see bringToTop), so two consume-mode loads of the same
+// ref would leave a single slot for an opcode that pops one item per operand
+// (e.g. `t := x + x` underflowing OP_ADD), or — when the ref sits below
+// other live slots — silently pair the opcode with the wrong slot. The
+// original value then simply stays on the stack, exactly like any ref whose
+// last use is a later binding.
+//
+// Unreachable from the frontend (ANF lowering gives every operand a fresh
+// temp); reachable via CompileFromIR / CLI --ir hand-written ANF.
+func (ctx *loweringContext) operandConsume(ref string, operands []string, currentIndex int, lastUses map[string]int) bool {
+	if !ctx.isLastUse(ref, currentIndex, lastUses) {
+		return false
+	}
+	occurrences := 0
+	for _, o := range operands {
+		if o == ref {
+			occurrences++
+		}
+	}
+	return occurrences <= 1
+}
+
 // ---------------------------------------------------------------------------
 // Lower bindings
 // ---------------------------------------------------------------------------
@@ -1110,11 +1141,11 @@ func (ctx *loweringContext) lowerLoadConst(bindingName string, value *ir.ANFValu
 }
 
 func (ctx *loweringContext) lowerBinOp(bindingName, op, left, right string, bindingIndex int, lastUses map[string]int, resultType string) {
-	leftIsLast := ctx.isLastUse(left, bindingIndex, lastUses)
-	ctx.bringToTop(left, leftIsLast)
+	leftConsume := ctx.operandConsume(left, []string{left, right}, bindingIndex, lastUses)
+	ctx.bringToTop(left, leftConsume)
 
-	rightIsLast := ctx.isLastUse(right, bindingIndex, lastUses)
-	ctx.bringToTop(right, rightIsLast)
+	rightConsume := ctx.operandConsume(right, []string{left, right}, bindingIndex, lastUses)
+	ctx.bringToTop(right, rightConsume)
 
 	ctx.sm.pop()
 	ctx.sm.pop()
@@ -1466,8 +1497,8 @@ func (ctx *loweringContext) lowerCall(bindingName, funcName string, args []strin
 
 	// General builtin: push args in order, then emit opcodes
 	for _, arg := range args {
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 
 	// Pop all args
@@ -1539,8 +1570,8 @@ func (ctx *loweringContext) inlineMethodCall(bindingName string, method *ir.ANFM
 	// Bind call arguments to private method params.
 	for i, arg := range args {
 		if i < len(method.Params) {
-			isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-			ctx.bringToTop(arg, isLast)
+			consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+			ctx.bringToTop(arg, consume)
 			ctx.sm.pop()
 
 			paramName := method.Params[i].Name
@@ -2030,12 +2061,12 @@ func (ctx *loweringContext) lowerComputeStateOutputHash(bindingName string, args
 	stateBytesRef := args[1]
 
 	// Bring stateBytes to stack first.
-	stateLast := ctx.isLastUse(stateBytesRef, bindingIndex, lastUses)
-	ctx.bringToTop(stateBytesRef, stateLast)
+	stateConsume := ctx.operandConsume(stateBytesRef, []string{preimageRef, stateBytesRef}, bindingIndex, lastUses)
+	ctx.bringToTop(stateBytesRef, stateConsume)
 
 	// Extract amount from preimage for the continuation output.
-	preLast := ctx.isLastUse(preimageRef, bindingIndex, lastUses)
-	ctx.bringToTop(preimageRef, preLast)
+	preConsume := ctx.operandConsume(preimageRef, []string{preimageRef, stateBytesRef}, bindingIndex, lastUses)
+	ctx.bringToTop(preimageRef, preConsume)
 
 	// Extract amount: last 52 bytes from end, take 8 bytes at offset 0.
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_SIZE"})
@@ -2137,15 +2168,17 @@ func (ctx *loweringContext) lowerComputeStateOutput(bindingName string, args []s
 	stateBytesRef := args[1]
 	newAmountRef := args[2]
 
+	csoOperands := []string{preimageRef, stateBytesRef, newAmountRef}
+
 	// Consume preimage ref (no longer needed — we use _codePart and _newAmount).
-	preLast := ctx.isLastUse(preimageRef, bindingIndex, lastUses)
-	ctx.bringToTop(preimageRef, preLast)
+	preConsume := ctx.operandConsume(preimageRef, csoOperands, bindingIndex, lastUses)
+	ctx.bringToTop(preimageRef, preConsume)
 	ctx.emitOp(StackOp{Op: "drop"})
 	ctx.sm.pop()
 
 	// Step 1: Convert _newAmount to 8-byte LE and save to altstack.
-	amountLast := ctx.isLastUse(newAmountRef, bindingIndex, lastUses)
-	ctx.bringToTop(newAmountRef, amountLast)
+	amountConsume := ctx.operandConsume(newAmountRef, csoOperands, bindingIndex, lastUses)
+	ctx.bringToTop(newAmountRef, amountConsume)
 	ctx.emitOp(StackOp{Op: "push", Value: bigIntPush(8)})
 	ctx.sm.push("")
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_NUM2BIN"})
@@ -2156,8 +2189,8 @@ func (ctx *loweringContext) lowerComputeStateOutput(bindingName string, args []s
 	ctx.sm.pop()
 
 	// Step 2: Bring stateBytes to stack.
-	stateLast := ctx.isLastUse(stateBytesRef, bindingIndex, lastUses)
-	ctx.bringToTop(stateBytesRef, stateLast)
+	stateConsume := ctx.operandConsume(stateBytesRef, csoOperands, bindingIndex, lastUses)
+	ctx.bringToTop(stateBytesRef, stateConsume)
 
 	// Step 3: Bring _codePart to top (PICK — never consume, reused across outputs)
 	ctx.bringToTop("_codePart", false)
@@ -2225,7 +2258,7 @@ func (ctx *loweringContext) lowerBuildChangeOutput(bindingName string, args []st
 	ctx.sm.push("")
 
 	// Push the 20-byte PKH
-	ctx.bringToTop(pkhRef, ctx.isLastUse(pkhRef, bindingIndex, lastUses))
+	ctx.bringToTop(pkhRef, ctx.operandConsume(pkhRef, []string{pkhRef, amountRef}, bindingIndex, lastUses))
 	// CAT: prefix || pkh
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_CAT"})
 	ctx.sm.pop()
@@ -2243,7 +2276,7 @@ func (ctx *loweringContext) lowerBuildChangeOutput(bindingName string, args []st
 	// --- Stack: [..., 0x1976a914{pkh}88ac] ---
 
 	// Step 2: Prepend amount as 8-byte LE.
-	ctx.bringToTop(amountRef, ctx.isLastUse(amountRef, bindingIndex, lastUses))
+	ctx.bringToTop(amountRef, ctx.operandConsume(amountRef, []string{pkhRef, amountRef}, bindingIndex, lastUses))
 	ctx.emitOp(StackOp{Op: "push", Value: bigIntPush(8)})
 	ctx.sm.push("")
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_NUM2BIN"})
@@ -2665,6 +2698,7 @@ func (ctx *loweringContext) lowerAddOutput(bindingName, satoshis string, stateVa
 			stateProps = append(stateProps, p)
 		}
 	}
+	outputOperands := append([]string{satoshis}, stateValues...)
 
 	// Step 1: Bring _codePart to top (PICK — never consume, reused across outputs)
 	ctx.bringToTop("_codePart", false)
@@ -2684,8 +2718,8 @@ func (ctx *loweringContext) lowerAddOutput(bindingName, satoshis string, stateVa
 		valueRef := stateValues[i]
 		prop := stateProps[i]
 
-		isLast := ctx.isLastUse(valueRef, bindingIndex, lastUses)
-		ctx.bringToTop(valueRef, isLast)
+		consume := ctx.operandConsume(valueRef, outputOperands, bindingIndex, lastUses)
+		ctx.bringToTop(valueRef, consume)
 
 		// Convert numeric/boolean values to fixed-width bytes
 		if prop.Type == "bigint" {
@@ -2728,8 +2762,8 @@ func (ctx *loweringContext) lowerAddOutput(bindingName, satoshis string, stateVa
 	// --- Stack: [..., varint+script] ---
 
 	// Step 6: Prepend satoshis as 8-byte LE.
-	isLastSatoshis := ctx.isLastUse(satoshis, bindingIndex, lastUses)
-	ctx.bringToTop(satoshis, isLastSatoshis)
+	satoshisConsume := ctx.operandConsume(satoshis, outputOperands, bindingIndex, lastUses)
+	ctx.bringToTop(satoshis, satoshisConsume)
 	ctx.emitOp(StackOp{Op: "push", Value: bigIntPush(8)})
 	ctx.sm.push("")
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_NUM2BIN"})
@@ -2756,8 +2790,8 @@ func (ctx *loweringContext) lowerAddOutput(bindingName, satoshis string, stateVa
 // The scriptBytes are used as-is (no codePart/state insertion).
 func (ctx *loweringContext) lowerAddRawOutput(bindingName, satoshis, scriptBytes string, bindingIndex int, lastUses map[string]int) {
 	// Step 1: Bring scriptBytes to top
-	scriptIsLast := ctx.isLastUse(scriptBytes, bindingIndex, lastUses)
-	ctx.bringToTop(scriptBytes, scriptIsLast)
+	scriptConsume := ctx.operandConsume(scriptBytes, []string{satoshis, scriptBytes}, bindingIndex, lastUses)
+	ctx.bringToTop(scriptBytes, scriptConsume)
 
 	// Step 2: Compute varint prefix for script length
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_SIZE"}) // [script, len]
@@ -2774,8 +2808,8 @@ func (ctx *loweringContext) lowerAddRawOutput(bindingName, satoshis, scriptBytes
 	ctx.sm.push("")
 
 	// Step 4: Prepend satoshis as 8-byte LE
-	satIsLast := ctx.isLastUse(satoshis, bindingIndex, lastUses)
-	ctx.bringToTop(satoshis, satIsLast)
+	satConsume := ctx.operandConsume(satoshis, []string{satoshis, scriptBytes}, bindingIndex, lastUses)
+	ctx.bringToTop(satoshis, satConsume)
 	ctx.emitOp(StackOp{Op: "push", Value: bigIntPush(8)})
 	ctx.sm.push("")
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_NUM2BIN"})
@@ -2864,10 +2898,16 @@ func (ctx *loweringContext) lowerCheckMultiSig(bindingName string, args []string
 	ctx.emitOp(StackOp{Op: "push", Value: bigIntPush(0)})
 	ctx.sm.push("")
 
+	// A ref repeated across the combined element list (e.g. the same pubkey
+	// twice) must be copied at every position — see operandConsume.
+	msigOperands := make([]string, 0, len(sigElems)+len(pkElems))
+	msigOperands = append(msigOperands, sigElems...)
+	msigOperands = append(msigOperands, pkElems...)
+
 	// Bring each sig element to TOS in declaration order.
 	for _, sig := range sigElems {
-		isLast := ctx.isLastUse(sig, bindingIndex, lastUses)
-		ctx.bringToTop(sig, isLast)
+		consume := ctx.operandConsume(sig, msigOperands, bindingIndex, lastUses)
+		ctx.bringToTop(sig, consume)
 	}
 
 	// Push nSigs.
@@ -2876,8 +2916,8 @@ func (ctx *loweringContext) lowerCheckMultiSig(bindingName string, args []string
 
 	// Bring each pubkey element to TOS in declaration order.
 	for _, pk := range pkElems {
-		isLast := ctx.isLastUse(pk, bindingIndex, lastUses)
-		ctx.bringToTop(pk, isLast)
+		consume := ctx.operandConsume(pk, msigOperands, bindingIndex, lastUses)
+		ctx.bringToTop(pk, consume)
 	}
 
 	// Push nPKs.
@@ -3333,12 +3373,12 @@ func (ctx *loweringContext) lowerArrayAccess(bindingName string, args []string, 
 	obj, index := args[0], args[1]
 
 	// Push the data (ByteString) onto the stack
-	objIsLast := ctx.isLastUse(obj, bindingIndex, lastUses)
-	ctx.bringToTop(obj, objIsLast)
+	objConsume := ctx.operandConsume(obj, args, bindingIndex, lastUses)
+	ctx.bringToTop(obj, objConsume)
 
 	// Push the index onto the stack
-	indexIsLast := ctx.isLastUse(index, bindingIndex, lastUses)
-	ctx.bringToTop(index, indexIsLast)
+	indexConsume := ctx.operandConsume(index, args, bindingIndex, lastUses)
+	ctx.bringToTop(index, indexConsume)
 
 	// OP_SPLIT at index: stack = [..., left, right]
 	ctx.sm.pop()  // index consumed
@@ -3385,11 +3425,11 @@ func (ctx *loweringContext) lowerSubstr(bindingName string, args []string, bindi
 
 	data, start, length := args[0], args[1], args[2]
 
-	dataIsLast := ctx.isLastUse(data, bindingIndex, lastUses)
-	ctx.bringToTop(data, dataIsLast)
+	dataConsume := ctx.operandConsume(data, args, bindingIndex, lastUses)
+	ctx.bringToTop(data, dataConsume)
 
-	startIsLast := ctx.isLastUse(start, bindingIndex, lastUses)
-	ctx.bringToTop(start, startIsLast)
+	startConsume := ctx.operandConsume(start, args, bindingIndex, lastUses)
+	ctx.bringToTop(start, startConsume)
 
 	// Split at start position.
 	// Before: stack map has [..., data, start]. Pop both because OP_SPLIT
@@ -3413,8 +3453,8 @@ func (ctx *loweringContext) lowerSubstr(bindingName string, args []string, bindi
 	ctx.sm.push(rightPart)
 
 	// Push length
-	lenIsLast := ctx.isLastUse(length, bindingIndex, lastUses)
-	ctx.bringToTop(length, lenIsLast)
+	lenConsume := ctx.operandConsume(length, args, bindingIndex, lastUses)
+	ctx.bringToTop(length, lenConsume)
 
 	// Split at length to extract the substring.
 	// Before: stack map has [..., rightPart, length]. Pop both for OP_SPLIT.
@@ -3448,7 +3488,7 @@ func (ctx *loweringContext) lowerVerifyRabinSig(bindingName string, args []strin
 
 	// Bring all 4 args to the top in argument order: msg sig padding pubKey
 	for _, arg := range args {
-		ctx.bringToTop(arg, ctx.isLastUse(arg, bindingIndex, lastUses))
+		ctx.bringToTop(arg, ctx.operandConsume(arg, args, bindingIndex, lastUses))
 	}
 
 	// Pop all 4 args from stack map
@@ -3502,11 +3542,11 @@ func (ctx *loweringContext) lowerRight(bindingName string, args []string, bindin
 	}
 	data, length := args[0], args[1]
 
-	dataIsLast := ctx.isLastUse(data, bindingIndex, lastUses)
-	ctx.bringToTop(data, dataIsLast)
+	dataConsume := ctx.operandConsume(data, args, bindingIndex, lastUses)
+	ctx.bringToTop(data, dataConsume)
 
-	lengthIsLast := ctx.isLastUse(length, bindingIndex, lastUses)
-	ctx.bringToTop(length, lengthIsLast)
+	lengthConsume := ctx.operandConsume(length, args, bindingIndex, lastUses)
+	ctx.bringToTop(length, lengthConsume)
 
 	ctx.sm.pop() // len
 	ctx.sm.pop() // data
@@ -3535,11 +3575,11 @@ func (ctx *loweringContext) lowerSafeDivMod(bindingName, funcName string, args [
 	}
 	a, b := args[0], args[1]
 
-	aIsLast := ctx.isLastUse(a, bindingIndex, lastUses)
-	ctx.bringToTop(a, aIsLast)
+	aConsume := ctx.operandConsume(a, args, bindingIndex, lastUses)
+	ctx.bringToTop(a, aConsume)
 
-	bIsLast := ctx.isLastUse(b, bindingIndex, lastUses)
-	ctx.bringToTop(b, bIsLast)
+	bConsume := ctx.operandConsume(b, args, bindingIndex, lastUses)
+	ctx.bringToTop(b, bConsume)
 
 	// Stack: ... a b
 	// DUP b, check non-zero, then divide/mod
@@ -3570,11 +3610,11 @@ func (ctx *loweringContext) lowerClamp(bindingName string, args []string, bindin
 	}
 	val, lo, hi := args[0], args[1], args[2]
 
-	valIsLast := ctx.isLastUse(val, bindingIndex, lastUses)
-	ctx.bringToTop(val, valIsLast)
+	valConsume := ctx.operandConsume(val, args, bindingIndex, lastUses)
+	ctx.bringToTop(val, valConsume)
 
-	loIsLast := ctx.isLastUse(lo, bindingIndex, lastUses)
-	ctx.bringToTop(lo, loIsLast)
+	loConsume := ctx.operandConsume(lo, args, bindingIndex, lastUses)
+	ctx.bringToTop(lo, loConsume)
 
 	// Stack: ... val lo -> OP_MAX -> max(val, lo)
 	ctx.sm.pop()
@@ -3582,8 +3622,8 @@ func (ctx *loweringContext) lowerClamp(bindingName string, args []string, bindin
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_MAX"})
 	ctx.sm.push("") // intermediate
 
-	hiIsLast := ctx.isLastUse(hi, bindingIndex, lastUses)
-	ctx.bringToTop(hi, hiIsLast)
+	hiConsume := ctx.operandConsume(hi, args, bindingIndex, lastUses)
+	ctx.bringToTop(hi, hiConsume)
 
 	// Stack: ... max(val,lo) hi -> OP_MIN -> min(max(val,lo), hi)
 	ctx.sm.pop()
@@ -3607,11 +3647,11 @@ func (ctx *loweringContext) lowerPow(bindingName string, args []string, bindingI
 	}
 	base, exp := args[0], args[1]
 
-	baseIsLast := ctx.isLastUse(base, bindingIndex, lastUses)
-	ctx.bringToTop(base, baseIsLast)
+	baseConsume := ctx.operandConsume(base, args, bindingIndex, lastUses)
+	ctx.bringToTop(base, baseConsume)
 
-	expIsLast := ctx.isLastUse(exp, bindingIndex, lastUses)
-	ctx.bringToTop(exp, expIsLast)
+	expConsume := ctx.operandConsume(exp, args, bindingIndex, lastUses)
+	ctx.bringToTop(exp, expConsume)
 
 	// Pop both args from stack map
 	ctx.sm.pop() // exp
@@ -3652,18 +3692,18 @@ func (ctx *loweringContext) lowerMulDiv(bindingName string, args []string, bindi
 	}
 	a, b, c := args[0], args[1], args[2]
 
-	aIsLast := ctx.isLastUse(a, bindingIndex, lastUses)
-	ctx.bringToTop(a, aIsLast)
-	bIsLast := ctx.isLastUse(b, bindingIndex, lastUses)
-	ctx.bringToTop(b, bIsLast)
+	aConsume := ctx.operandConsume(a, args, bindingIndex, lastUses)
+	ctx.bringToTop(a, aConsume)
+	bConsume := ctx.operandConsume(b, args, bindingIndex, lastUses)
+	ctx.bringToTop(b, bConsume)
 
 	ctx.sm.pop()
 	ctx.sm.pop()
 	ctx.emitOp(StackOp{Op: "opcode", Code: "OP_MUL"})
 	ctx.sm.push("") // intermediate
 
-	cIsLast := ctx.isLastUse(c, bindingIndex, lastUses)
-	ctx.bringToTop(c, cIsLast)
+	cConsume := ctx.operandConsume(c, args, bindingIndex, lastUses)
+	ctx.bringToTop(c, cConsume)
 
 	ctx.sm.pop()
 	ctx.sm.pop()
@@ -3681,10 +3721,10 @@ func (ctx *loweringContext) lowerPercentOf(bindingName string, args []string, bi
 	}
 	amount, bps := args[0], args[1]
 
-	amountIsLast := ctx.isLastUse(amount, bindingIndex, lastUses)
-	ctx.bringToTop(amount, amountIsLast)
-	bpsIsLast := ctx.isLastUse(bps, bindingIndex, lastUses)
-	ctx.bringToTop(bps, bpsIsLast)
+	amountConsume := ctx.operandConsume(amount, args, bindingIndex, lastUses)
+	ctx.bringToTop(amount, amountConsume)
+	bpsConsume := ctx.operandConsume(bps, args, bindingIndex, lastUses)
+	ctx.bringToTop(bps, bpsConsume)
 
 	ctx.sm.pop()
 	ctx.sm.pop()
@@ -3758,10 +3798,10 @@ func (ctx *loweringContext) lowerGcd(bindingName string, args []string, bindingI
 	}
 	a, b := args[0], args[1]
 
-	aIsLast := ctx.isLastUse(a, bindingIndex, lastUses)
-	ctx.bringToTop(a, aIsLast)
-	bIsLast := ctx.isLastUse(b, bindingIndex, lastUses)
-	ctx.bringToTop(b, bIsLast)
+	aConsume := ctx.operandConsume(a, args, bindingIndex, lastUses)
+	ctx.bringToTop(a, aConsume)
+	bConsume := ctx.operandConsume(b, args, bindingIndex, lastUses)
+	ctx.bringToTop(b, bConsume)
 
 	ctx.sm.pop()
 	ctx.sm.pop()
@@ -3804,10 +3844,10 @@ func (ctx *loweringContext) lowerDivmod(bindingName string, args []string, bindi
 	}
 	a, b := args[0], args[1]
 
-	aIsLast := ctx.isLastUse(a, bindingIndex, lastUses)
-	ctx.bringToTop(a, aIsLast)
-	bIsLast := ctx.isLastUse(b, bindingIndex, lastUses)
-	ctx.bringToTop(b, bIsLast)
+	aConsume := ctx.operandConsume(a, args, bindingIndex, lastUses)
+	ctx.bringToTop(a, aConsume)
+	bConsume := ctx.operandConsume(b, args, bindingIndex, lastUses)
+	ctx.bringToTop(b, bConsume)
 
 	ctx.sm.pop()
 	ctx.sm.pop()
@@ -4313,7 +4353,7 @@ func (ctx *loweringContext) lowerVerifyWOTS(bindingName string, args []string, b
 
 	// Bring args to top: msg, sig, pubkey
 	for _, arg := range args {
-		ctx.bringToTop(arg, ctx.isLastUse(arg, bindingIndex, lastUses))
+		ctx.bringToTop(arg, ctx.operandConsume(arg, args, bindingIndex, lastUses))
 	}
 	for i := 0; i < 3; i++ {
 		ctx.sm.pop()
@@ -4333,7 +4373,7 @@ func (ctx *loweringContext) lowerVerifySLHDSA(bindingName, paramKey string, args
 
 	// Bring args to top: msg, sig, pubkey
 	for _, arg := range args {
-		ctx.bringToTop(arg, ctx.isLastUse(arg, bindingIndex, lastUses))
+		ctx.bringToTop(arg, ctx.operandConsume(arg, args, bindingIndex, lastUses))
 	}
 	for i := 0; i < 3; i++ {
 		ctx.sm.pop()
@@ -4354,7 +4394,7 @@ func (ctx *loweringContext) lowerSha256Compress(bindingName string, args []strin
 		panic("sha256Compress requires 2 arguments: state, block")
 	}
 	for _, arg := range args {
-		ctx.bringToTop(arg, ctx.isLastUse(arg, bindingIndex, lastUses))
+		ctx.bringToTop(arg, ctx.operandConsume(arg, args, bindingIndex, lastUses))
 	}
 	for i := 0; i < 2; i++ {
 		ctx.sm.pop()
@@ -4371,7 +4411,7 @@ func (ctx *loweringContext) lowerSha256Finalize(bindingName string, args []strin
 		panic("sha256Finalize requires 3 arguments: state, remaining, msgBitLen")
 	}
 	for _, arg := range args {
-		ctx.bringToTop(arg, ctx.isLastUse(arg, bindingIndex, lastUses))
+		ctx.bringToTop(arg, ctx.operandConsume(arg, args, bindingIndex, lastUses))
 	}
 	for i := 0; i < 3; i++ {
 		ctx.sm.pop()
@@ -4392,7 +4432,7 @@ func (ctx *loweringContext) lowerBlake3Compress(bindingName string, args []strin
 		panic("blake3Compress requires 2 arguments: chainingValue, block")
 	}
 	for _, arg := range args {
-		ctx.bringToTop(arg, ctx.isLastUse(arg, bindingIndex, lastUses))
+		ctx.bringToTop(arg, ctx.operandConsume(arg, args, bindingIndex, lastUses))
 	}
 	for i := 0; i < 2; i++ {
 		ctx.sm.pop()
@@ -4409,7 +4449,7 @@ func (ctx *loweringContext) lowerBlake3Hash(bindingName string, args []string, b
 		panic("blake3Hash requires 1 argument: message")
 	}
 	for _, arg := range args {
-		ctx.bringToTop(arg, ctx.isLastUse(arg, bindingIndex, lastUses))
+		ctx.bringToTop(arg, ctx.operandConsume(arg, args, bindingIndex, lastUses))
 	}
 	ctx.sm.pop()
 
@@ -4437,8 +4477,8 @@ func isEcBuiltin(name string) bool {
 func (ctx *loweringContext) lowerEcBuiltin(bindingName, funcName string, args []string, bindingIndex int, lastUses map[string]int) {
 	// Bring args to top in order
 	for _, arg := range args {
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 	for range args {
 		ctx.sm.pop()
@@ -4493,8 +4533,8 @@ func isNistEcBuiltin(name string) bool {
 func (ctx *loweringContext) lowerNistEcBuiltin(bindingName, funcName string, args []string, bindingIndex int, lastUses map[string]int) {
 	// Bring args to top in order
 	for _, arg := range args {
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 	for range args {
 		ctx.sm.pop()
@@ -4541,8 +4581,8 @@ func (ctx *loweringContext) lowerVerifyECDSA(bindingName, funcName string, args 
 	}
 	// Bring all 3 args to top in order: msg, sig, pubkey
 	for _, arg := range args {
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 	ctx.sm.pop() // pubkey
 	ctx.sm.pop() // sig
@@ -4580,8 +4620,8 @@ func isBBFieldBuiltin(name string) bool {
 func (ctx *loweringContext) lowerBBFieldBuiltin(bindingName, funcName string, args []string, bindingIndex int, lastUses map[string]int) {
 	// Bring all args to stack top in order
 	for _, arg := range args {
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 	for range args {
 		ctx.sm.pop()
@@ -4642,8 +4682,8 @@ func isKBFieldBuiltin(name string) bool {
 func (ctx *loweringContext) lowerKBFieldBuiltin(bindingName, funcName string, args []string, bindingIndex int, lastUses map[string]int) {
 	// Bring all args to stack top in order
 	for _, arg := range args {
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 	for range args {
 		ctx.sm.pop()
@@ -4705,8 +4745,8 @@ func isBN254Builtin(name string) bool {
 
 func (ctx *loweringContext) lowerBN254Builtin(bindingName, funcName string, args []string, bindingIndex int, lastUses map[string]int) {
 	for _, arg := range args {
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 	for range args {
 		ctx.sm.pop()
@@ -4782,8 +4822,8 @@ func (ctx *loweringContext) lowerMerkleRoot(bindingName, funcName string, args [
 	// Bring leaf, proof, index to stack top for the codegen
 	for i := 0; i < 3; i++ {
 		arg := args[i]
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 	// Pop the 3 args — the codegen consumes them and produces 1 result
 	for i := 0; i < 3; i++ {
@@ -4842,8 +4882,8 @@ func (ctx *loweringContext) lowerMerkleRootPoseidon2KB(bindingName string, args 
 	runtimeArgCount := nArgs - 1 // all except depth
 	for i := 0; i < runtimeArgCount; i++ {
 		arg := args[i]
-		isLast := ctx.isLastUse(arg, bindingIndex, lastUses)
-		ctx.bringToTop(arg, isLast)
+		consume := ctx.operandConsume(arg, args, bindingIndex, lastUses)
+		ctx.bringToTop(arg, consume)
 	}
 	// Pop all runtime args — the codegen consumes them and produces 8 results
 	for i := 0; i < runtimeArgCount; i++ {

--- a/compilers/go/compiler/repeated_operand_consume_test.go
+++ b/compilers/go/compiler/repeated_operand_consume_test.go
@@ -1,0 +1,136 @@
+package compiler
+
+import "testing"
+
+// TestRepeatedOperandConsume_BinOpSameRefTwice ports the repeated-operand
+// consume fix from the TS tier (packages/runar-compiler/src/__tests__/
+// repeated-operand-consume.test.ts).
+//
+// A binding whose ANF value reads the SAME ref at more than one operand
+// position (e.g. `t := x + x`) used to make an independent last-use consume
+// decision per operand load. A consume-mode bringToTop of a ref already on
+// top of the stack is a pure no-op, so a single stack slot ended up backing
+// two operand positions and the bare OP_ADD underflowed at runtime (or,
+// with the ref buried below other live slots, paired the wrong slot).
+//
+// Canonical rule (merged in TS, ported here): an operand load may consume
+// (ROLL / move) its ref only when this binding is the ref's last use AND the
+// ref occurs exactly once in the value's FULL operand list. Repeated refs
+// copy (PICK / DUP) at every position; the original lingers and is cleaned
+// by the existing method epilogue.
+//
+// Unreachable from the language frontend (pass 04 gives every operand a
+// fresh temp); fully reachable via CompileFromIR / CLI --ir.
+//
+// Expected hex (byte-identical with the TS tier for the same ANF, fold-off,
+// placeholder constructor slot): 767693009c77
+// = OP_DUP OP_DUP OP_ADD OP_0 OP_NUMEQUAL OP_NIP
+func TestRepeatedOperandConsume_BinOpSameRefTwice(t *testing.T) {
+	irJSON := []byte(`{
+  "contractName": "Repeat",
+  "properties": [{ "name": "target", "type": "bigint", "readonly": true }],
+  "methods": [
+    {
+      "name": "unlock",
+      "params": [{ "name": "x", "type": "bigint" }],
+      "body": [
+        { "name": "t0", "value": { "kind": "bin_op", "op": "+", "left": "x", "right": "x" } },
+        { "name": "t1", "value": { "kind": "load_prop", "name": "target" } },
+        { "name": "t2", "value": { "kind": "bin_op", "op": "===", "left": "t0", "right": "t1" } },
+        { "name": "t3", "value": { "kind": "assert", "value": "t2" } }
+      ],
+      "isPublic": true
+    }
+  ]
+}`)
+
+	artifact, err := CompileFromIRBytes(irJSON, CompileOptions{DisableConstantFolding: true})
+	if err != nil {
+		t.Fatalf("CompileFromIRBytes failed: %v", err)
+	}
+
+	const want = "767693009c77" // DUP DUP ADD OP_0 NUMEQUAL NIP (TS-tier reference)
+	if artifact.Script != want {
+		t.Errorf("repeated-operand script mismatch:\n  got:  %s\n  want: %s\n  asm:  %s",
+			artifact.Script, want, artifact.ASM)
+	}
+}
+
+// TestRepeatedOperandConsume_CallSameRefTwice covers the builtin-call arg
+// loop: `t := min(x, x)` must copy x at both argument positions.
+func TestRepeatedOperandConsume_CallSameRefTwice(t *testing.T) {
+	irJSON := []byte(`{
+  "contractName": "Repeat",
+  "properties": [{ "name": "target", "type": "bigint", "readonly": true }],
+  "methods": [
+    {
+      "name": "unlock",
+      "params": [{ "name": "x", "type": "bigint" }],
+      "body": [
+        { "name": "t0", "value": { "kind": "call", "func": "min", "args": ["x", "x"] } },
+        { "name": "t1", "value": { "kind": "load_prop", "name": "target" } },
+        { "name": "t2", "value": { "kind": "bin_op", "op": "===", "left": "t0", "right": "t1" } },
+        { "name": "t3", "value": { "kind": "assert", "value": "t2" } }
+      ],
+      "isPublic": true
+    }
+  ]
+}`)
+
+	artifact, err := CompileFromIRBytes(irJSON, CompileOptions{DisableConstantFolding: true})
+	if err != nil {
+		t.Fatalf("CompileFromIRBytes failed: %v", err)
+	}
+
+	// DUP DUP MIN OP_0 NUMEQUAL NIP — same shape as the bin_op case with
+	// OP_MIN (0xa3) in place of OP_ADD.
+	const want = "7676a3009c77"
+	if artifact.Script != want {
+		t.Errorf("repeated-operand min(x,x) script mismatch:\n  got:  %s\n  want: %s\n  asm:  %s",
+			artifact.Script, want, artifact.ASM)
+	}
+}
+
+// TestRepeatedOperandConsume_BuriedBelowLiveSlot covers the wrong-slot
+// pairing variant: at `t0 := x + x` the stack is [x, y] (y live on top), so
+// a naive "last occurrence may still consume" rule pairs x with y instead of
+// duplicating x.
+func TestRepeatedOperandConsume_BuriedBelowLiveSlot(t *testing.T) {
+	irJSON := []byte(`{
+  "contractName": "Repeat",
+  "properties": [{ "name": "target", "type": "bigint", "readonly": true }],
+  "methods": [
+    {
+      "name": "unlock",
+      "params": [
+        { "name": "x", "type": "bigint" },
+        { "name": "y", "type": "bigint" }
+      ],
+      "body": [
+        { "name": "t0", "value": { "kind": "bin_op", "op": "+", "left": "x", "right": "x" } },
+        { "name": "t1", "value": { "kind": "bin_op", "op": "+", "left": "t0", "right": "y" } },
+        { "name": "t2", "value": { "kind": "load_prop", "name": "target" } },
+        { "name": "t3", "value": { "kind": "bin_op", "op": "===", "left": "t1", "right": "t2" } },
+        { "name": "t4", "value": { "kind": "assert", "value": "t3" } }
+      ],
+      "isPublic": true
+    }
+  ]
+}`)
+
+	artifact, err := CompileFromIRBytes(irJSON, CompileOptions{DisableConstantFolding: true})
+	if err != nil {
+		t.Fatalf("CompileFromIRBytes failed: %v", err)
+	}
+
+	// x at depth 1 is copied at both positions (OVER, then DUP of the
+	// fresh copy), added, y is moved up for the second add, compared
+	// against the placeholder target, and the lingering x is nipped by
+	// the epilogue.
+	// OVER DUP ADD SWAP ADD OP_0 NUMEQUAL NIP (TS-tier reference)
+	const want = "7876937c93009c77"
+	if artifact.Script != want {
+		t.Errorf("repeated-operand buried-slot script mismatch:\n  got:  %s\n  want: %s\n  asm:  %s",
+			artifact.Script, want, artifact.ASM)
+	}
+}

--- a/compilers/rust/src/codegen/stack.rs
+++ b/compilers/rust/src/codegen/stack.rs
@@ -797,6 +797,38 @@ impl LoweringContext {
         }
     }
 
+    /// Consume-vs-copy decision for one operand of a multi-operand ANF value.
+    ///
+    /// `operands` is the FULL operand-ref list of the value (including
+    /// `operand_ref` itself). The load may consume (ROLL / move) the ref only
+    /// when this binding is the ref's last use AND the ref occurs exactly
+    /// once in the operand list. A ref that is read at more than one operand
+    /// position of the same value must be copied (PICK / DUP) at EVERY
+    /// position: each operand position needs its own stack slot, and a
+    /// consume-mode load of a ref that is already on top of the stack is a
+    /// no-op (see `bring_to_top`), so two consume-mode loads of the same ref
+    /// would leave a single slot for an opcode that pops one item per operand
+    /// (e.g. `t := x + x` underflowing OP_ADD), or — when the ref sits below
+    /// other live slots — silently pair the opcode with the wrong slot. The
+    /// original value then simply stays on the stack, exactly like any ref
+    /// whose last use is a later binding.
+    ///
+    /// Unreachable from the frontend (ANF lowering gives every operand a
+    /// fresh temp); reachable via `compile_from_ir` / CLI `--ir` hand-written
+    /// ANF.
+    fn operand_consume<S: AsRef<str>>(
+        &self,
+        operand_ref: &str,
+        operands: &[S],
+        current_index: usize,
+        last_uses: &HashMap<String, usize>,
+    ) -> bool {
+        if !self.is_last_use(operand_ref, current_index, last_uses) {
+            return false;
+        }
+        operands.iter().filter(|o| o.as_ref() == operand_ref).count() <= 1
+    }
+
     fn bring_to_top(&mut self, name: &str, consume: bool) {
         let depth = self
             .sm
@@ -1202,11 +1234,11 @@ impl LoweringContext {
         last_uses: &HashMap<String, usize>,
         result_type: Option<&str>,
     ) {
-        let left_is_last = self.is_last_use(left, binding_index, last_uses);
-        self.bring_to_top(left, left_is_last);
+        let left_consume = self.operand_consume(left, &[left, right], binding_index, last_uses);
+        self.bring_to_top(left, left_consume);
 
-        let right_is_last = self.is_last_use(right, binding_index, last_uses);
-        self.bring_to_top(right, right_is_last);
+        let right_consume = self.operand_consume(right, &[left, right], binding_index, last_uses);
+        self.bring_to_top(right, right_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -1491,8 +1523,8 @@ impl LoweringContext {
 
         // General builtin: push args in order, then emit opcodes
         for arg in args {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
 
         for _ in args {
@@ -1576,8 +1608,8 @@ impl LoweringContext {
         // Bind call arguments to private method params.
         for (i, arg) in args.iter().enumerate() {
             if i < method.params.len() {
-                let is_last = self.is_last_use(arg, binding_index, last_uses);
-                self.bring_to_top(arg, is_last);
+                let consume = self.operand_consume(arg, args, binding_index, last_uses);
+                self.bring_to_top(arg, consume);
                 self.sm.pop();
 
                 let param_name = &method.params[i].name;
@@ -2086,12 +2118,14 @@ impl LoweringContext {
         let state_bytes_ref = &args[1];
 
         // Bring stateBytes to stack first.
-        let sb_last = self.is_last_use(state_bytes_ref, binding_index, last_uses);
-        self.bring_to_top(state_bytes_ref, sb_last);
+        let sb_consume =
+            self.operand_consume(state_bytes_ref, &[preimage_ref, state_bytes_ref], binding_index, last_uses);
+        self.bring_to_top(state_bytes_ref, sb_consume);
 
         // Extract amount from preimage for the continuation output.
-        let pre_last = self.is_last_use(preimage_ref, binding_index, last_uses);
-        self.bring_to_top(preimage_ref, pre_last);
+        let pre_consume =
+            self.operand_consume(preimage_ref, &[preimage_ref, state_bytes_ref], binding_index, last_uses);
+        self.bring_to_top(preimage_ref, pre_consume);
 
         // Extract amount: last 52 bytes, take 8 bytes at offset 0.
         self.emit_op(StackOp::Opcode("OP_SIZE".into()));
@@ -2192,15 +2226,17 @@ impl LoweringContext {
         let state_bytes_ref = &args[1];
         let new_amount_ref = &args[2];
 
+        let cso_operands = [preimage_ref, state_bytes_ref, new_amount_ref];
+
         // Consume preimage ref (no longer needed — we use _codePart and _newAmount).
-        let pre_last = self.is_last_use(preimage_ref, binding_index, last_uses);
-        self.bring_to_top(preimage_ref, pre_last);
+        let pre_consume = self.operand_consume(preimage_ref, &cso_operands, binding_index, last_uses);
+        self.bring_to_top(preimage_ref, pre_consume);
         self.emit_op(StackOp::Drop);
         self.sm.pop();
 
         // Step 1: Convert _newAmount to 8-byte LE and save to altstack.
-        let amount_last = self.is_last_use(new_amount_ref, binding_index, last_uses);
-        self.bring_to_top(new_amount_ref, amount_last);
+        let amount_consume = self.operand_consume(new_amount_ref, &cso_operands, binding_index, last_uses);
+        self.bring_to_top(new_amount_ref, amount_consume);
         self.emit_op(StackOp::Push(PushValue::Int(BigInt::from(8))));
         self.sm.push("");
         self.emit_op(StackOp::Opcode("OP_NUM2BIN".into()));
@@ -2211,8 +2247,8 @@ impl LoweringContext {
         self.sm.pop();
 
         // Step 2: Bring stateBytes to stack.
-        let sb_last = self.is_last_use(state_bytes_ref, binding_index, last_uses);
-        self.bring_to_top(state_bytes_ref, sb_last);
+        let sb_consume = self.operand_consume(state_bytes_ref, &cso_operands, binding_index, last_uses);
+        self.bring_to_top(state_bytes_ref, sb_consume);
 
         // Step 3: Bring _codePart to top (PICK — never consume, reused across outputs)
         self.bring_to_top("_codePart", false);
@@ -2283,8 +2319,8 @@ impl LoweringContext {
         self.sm.push("");
 
         // Push the 20-byte PKH
-        let pkh_last = self.is_last_use(pkh_ref, binding_index, last_uses);
-        self.bring_to_top(pkh_ref, pkh_last);
+        let pkh_consume = self.operand_consume(pkh_ref, &[pkh_ref, amount_ref], binding_index, last_uses);
+        self.bring_to_top(pkh_ref, pkh_consume);
         // CAT: prefix || pkh
         self.emit_op(StackOp::Opcode("OP_CAT".into()));
         self.sm.pop();
@@ -2302,8 +2338,8 @@ impl LoweringContext {
         // --- Stack: [..., 0x1976a914{pkh}88ac] ---
 
         // Step 2: Prepend amount as 8-byte LE.
-        let amount_last = self.is_last_use(amount_ref, binding_index, last_uses);
-        self.bring_to_top(amount_ref, amount_last);
+        let amount_consume = self.operand_consume(amount_ref, &[pkh_ref, amount_ref], binding_index, last_uses);
+        self.bring_to_top(amount_ref, amount_consume);
         self.emit_op(StackOp::Push(PushValue::Int(BigInt::from(8))));
         self.sm.push("");
         self.emit_op(StackOp::Opcode("OP_NUM2BIN".into()));
@@ -2343,6 +2379,9 @@ impl LoweringContext {
             .filter(|p| !p.readonly)
             .cloned()
             .collect();
+        let output_operands: Vec<&str> = std::iter::once(satoshis)
+            .chain(state_values.iter().map(|s| s.as_str()))
+            .collect();
 
         // Step 1: Bring _codePart to top (PICK — never consume, reused across outputs)
         self.bring_to_top("_codePart", false);
@@ -2364,8 +2403,8 @@ impl LoweringContext {
             }
             let prop = &state_props[i];
 
-            let is_last = self.is_last_use(value_ref, binding_index, last_uses);
-            self.bring_to_top(value_ref, is_last);
+            let consume = self.operand_consume(value_ref, &output_operands, binding_index, last_uses);
+            self.bring_to_top(value_ref, consume);
 
             if prop.prop_type == "bigint" {
                 self.emit_op(StackOp::Push(PushValue::Int(BigInt::from(8))));
@@ -2405,8 +2444,8 @@ impl LoweringContext {
         // --- Stack: [..., varint+script] ---
 
         // Step 6: Prepend satoshis as 8-byte LE.
-        let is_last_satoshis = self.is_last_use(satoshis, binding_index, last_uses);
-        self.bring_to_top(satoshis, is_last_satoshis);
+        let satoshis_consume = self.operand_consume(satoshis, &output_operands, binding_index, last_uses);
+        self.bring_to_top(satoshis, satoshis_consume);
         self.emit_op(StackOp::Push(PushValue::Int(BigInt::from(8))));
         self.sm.push("");
         self.emit_op(StackOp::Opcode("OP_NUM2BIN".to_string()));
@@ -2438,8 +2477,9 @@ impl LoweringContext {
         last_uses: &HashMap<String, usize>,
     ) {
         // Step 1: Bring scriptBytes to top
-        let script_is_last = self.is_last_use(script_bytes, binding_index, last_uses);
-        self.bring_to_top(script_bytes, script_is_last);
+        let script_consume =
+            self.operand_consume(script_bytes, &[satoshis, script_bytes], binding_index, last_uses);
+        self.bring_to_top(script_bytes, script_consume);
 
         // Step 2: Compute varint prefix for script length
         self.emit_op(StackOp::Opcode("OP_SIZE".to_string())); // [script, len]
@@ -2456,8 +2496,9 @@ impl LoweringContext {
         self.sm.push("");
 
         // Step 4: Prepend satoshis as 8-byte LE
-        let sat_is_last = self.is_last_use(satoshis, binding_index, last_uses);
-        self.bring_to_top(satoshis, sat_is_last);
+        let sat_consume =
+            self.operand_consume(satoshis, &[satoshis, script_bytes], binding_index, last_uses);
+        self.bring_to_top(satoshis, sat_consume);
         self.emit_op(StackOp::Push(PushValue::Int(BigInt::from(8))));
         self.sm.push("");
         self.emit_op(StackOp::Opcode("OP_NUM2BIN".to_string()));
@@ -2575,10 +2616,18 @@ impl LoweringContext {
         self.emit_op(StackOp::Push(PushValue::Int(BigInt::from(0))));
         self.sm.push("");
 
+        // A ref repeated across the combined element list (e.g. the same
+        // pubkey twice) must be copied at every position — see operand_consume.
+        let msig_operands: Vec<&str> = sig_elems
+            .iter()
+            .map(|s| s.as_str())
+            .chain(pk_elems.iter().map(|s| s.as_str()))
+            .collect();
+
         // Bring each sig element to TOS in declaration order.
         for sig in &sig_elems {
-            let is_last = self.is_last_use(sig, binding_index, last_uses);
-            self.bring_to_top(sig, is_last);
+            let consume = self.operand_consume(sig, &msig_operands, binding_index, last_uses);
+            self.bring_to_top(sig, consume);
         }
 
         // Push nSigs.
@@ -2587,8 +2636,8 @@ impl LoweringContext {
 
         // Bring each pubkey element to TOS in declaration order.
         for pk in &pk_elems {
-            let is_last = self.is_last_use(pk, binding_index, last_uses);
-            self.bring_to_top(pk, is_last);
+            let consume = self.operand_consume(pk, &msig_operands, binding_index, last_uses);
+            self.bring_to_top(pk, consume);
         }
 
         // Push nPKs.
@@ -3390,12 +3439,12 @@ impl LoweringContext {
         let index = &args[1];
 
         // Push the data (ByteString) onto the stack
-        let obj_is_last = self.is_last_use(obj, binding_index, last_uses);
-        self.bring_to_top(obj, obj_is_last);
+        let obj_consume = self.operand_consume(obj, args, binding_index, last_uses);
+        self.bring_to_top(obj, obj_consume);
 
         // Push the index onto the stack
-        let index_is_last = self.is_last_use(index, binding_index, last_uses);
-        self.bring_to_top(index, index_is_last);
+        let index_consume = self.operand_consume(index, args, binding_index, last_uses);
+        self.bring_to_top(index, index_consume);
 
         // OP_SPLIT at index: stack = [..., left, right]
         self.sm.pop();  // index consumed
@@ -3494,11 +3543,11 @@ impl LoweringContext {
         let start = &args[1];
         let length = &args[2];
 
-        let data_is_last = self.is_last_use(data, binding_index, last_uses);
-        self.bring_to_top(data, data_is_last);
+        let data_consume = self.operand_consume(data, args, binding_index, last_uses);
+        self.bring_to_top(data, data_consume);
 
-        let start_is_last = self.is_last_use(start, binding_index, last_uses);
-        self.bring_to_top(start, start_is_last);
+        let start_consume = self.operand_consume(start, args, binding_index, last_uses);
+        self.bring_to_top(start, start_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -3511,8 +3560,8 @@ impl LoweringContext {
         let right_part = self.sm.pop();
         self.sm.push(&right_part);
 
-        let len_is_last = self.is_last_use(length, binding_index, last_uses);
-        self.bring_to_top(length, len_is_last);
+        let len_consume = self.operand_consume(length, args, binding_index, last_uses);
+        self.bring_to_top(length, len_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -3543,8 +3592,8 @@ impl LoweringContext {
 
         // Bring all 4 args to the top in argument order: msg sig padding pubKey
         for arg in args {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
 
         // Pop all 4 args from stack map
@@ -3603,11 +3652,11 @@ impl LoweringContext {
         let data = &args[0];
         let length = &args[1];
 
-        let data_is_last = self.is_last_use(data, binding_index, last_uses);
-        self.bring_to_top(data, data_is_last);
+        let data_consume = self.operand_consume(data, args, binding_index, last_uses);
+        self.bring_to_top(data, data_consume);
 
-        let length_is_last = self.is_last_use(length, binding_index, last_uses);
-        self.bring_to_top(length, length_is_last);
+        let length_consume = self.operand_consume(length, args, binding_index, last_uses);
+        self.bring_to_top(length, length_consume);
 
         self.sm.pop(); // len
         self.sm.pop(); // data
@@ -3636,8 +3685,8 @@ impl LoweringContext {
         assert!(args.len() >= 3, "verifyWOTS requires 3 arguments: msg, sig, pubkey");
 
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in 0..3 { self.sm.pop(); }
 
@@ -3666,8 +3715,8 @@ impl LoweringContext {
 
         // Bring args to top in order: msg, sig, pubkey
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in 0..3 {
             self.sm.pop();
@@ -3696,8 +3745,8 @@ impl LoweringContext {
             "sha256Compress requires 2 arguments: state, block"
         );
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in 0..2 {
             self.sm.pop();
@@ -3721,8 +3770,8 @@ impl LoweringContext {
             "sha256Finalize requires 3 arguments: state, remaining, msgBitLen"
         );
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in 0..3 {
             self.sm.pop();
@@ -3746,8 +3795,8 @@ impl LoweringContext {
             "blake3Compress requires 2 arguments: chainingValue, block"
         );
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in 0..2 {
             self.sm.pop();
@@ -3771,8 +3820,8 @@ impl LoweringContext {
             "blake3Hash requires 1 argument: message"
         );
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in 0..1 {
             self.sm.pop();
@@ -3794,8 +3843,8 @@ impl LoweringContext {
     ) {
         // Bring args to top in order
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in args {
             self.sm.pop();
@@ -3835,8 +3884,8 @@ impl LoweringContext {
     ) {
         // Bring args to top in order
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in args {
             self.sm.pop();
@@ -3883,8 +3932,8 @@ impl LoweringContext {
         );
         // Bring all 3 args to top in order: msg, sig, pubkey
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         self.sm.pop(); // pubkey
         self.sm.pop(); // sig
@@ -3916,8 +3965,8 @@ impl LoweringContext {
     ) {
         // Bring all args to stack top
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in args {
             self.sm.pop();
@@ -3959,8 +4008,8 @@ impl LoweringContext {
     ) {
         // Bring all args to stack top
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in args {
             self.sm.pop();
@@ -4002,8 +4051,8 @@ impl LoweringContext {
     ) {
         // Bring all args to stack top in order
         for arg in args.iter() {
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         for _ in args {
             self.sm.pop();
@@ -4080,8 +4129,8 @@ impl LoweringContext {
         // Bring leaf, proof, index to stack top for the codegen
         for i in 0..3 {
             let arg = &args[i];
-            let is_last = self.is_last_use(arg, binding_index, last_uses);
-            self.bring_to_top(arg, is_last);
+            let consume = self.operand_consume(arg, args, binding_index, last_uses);
+            self.bring_to_top(arg, consume);
         }
         // Pop the 3 args -- the codegen consumes them and produces 1 result
         for _ in 0..3 {
@@ -4112,11 +4161,11 @@ impl LoweringContext {
     ) {
         assert!(args.len() >= 2, "safediv requires 2 arguments");
 
-        let a_is_last = self.is_last_use(&args[0], binding_index, last_uses);
-        self.bring_to_top(&args[0], a_is_last);
+        let a_consume = self.operand_consume(&args[0], args, binding_index, last_uses);
+        self.bring_to_top(&args[0], a_consume);
 
-        let b_is_last = self.is_last_use(&args[1], binding_index, last_uses);
-        self.bring_to_top(&args[1], b_is_last);
+        let b_consume = self.operand_consume(&args[1], args, binding_index, last_uses);
+        self.bring_to_top(&args[1], b_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -4141,11 +4190,11 @@ impl LoweringContext {
     ) {
         assert!(args.len() >= 2, "safemod requires 2 arguments");
 
-        let a_is_last = self.is_last_use(&args[0], binding_index, last_uses);
-        self.bring_to_top(&args[0], a_is_last);
+        let a_consume = self.operand_consume(&args[0], args, binding_index, last_uses);
+        self.bring_to_top(&args[0], a_consume);
 
-        let b_is_last = self.is_last_use(&args[1], binding_index, last_uses);
-        self.bring_to_top(&args[1], b_is_last);
+        let b_consume = self.operand_consume(&args[1], args, binding_index, last_uses);
+        self.bring_to_top(&args[1], b_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -4170,19 +4219,19 @@ impl LoweringContext {
     ) {
         assert!(args.len() >= 3, "clamp requires 3 arguments");
 
-        let val_is_last = self.is_last_use(&args[0], binding_index, last_uses);
-        self.bring_to_top(&args[0], val_is_last);
+        let val_consume = self.operand_consume(&args[0], args, binding_index, last_uses);
+        self.bring_to_top(&args[0], val_consume);
 
-        let lo_is_last = self.is_last_use(&args[1], binding_index, last_uses);
-        self.bring_to_top(&args[1], lo_is_last);
+        let lo_consume = self.operand_consume(&args[1], args, binding_index, last_uses);
+        self.bring_to_top(&args[1], lo_consume);
 
         self.sm.pop();
         self.sm.pop();
         self.emit_op(StackOp::Opcode("OP_MAX".to_string()));
         self.sm.push(""); // intermediate result
 
-        let hi_is_last = self.is_last_use(&args[2], binding_index, last_uses);
-        self.bring_to_top(&args[2], hi_is_last);
+        let hi_consume = self.operand_consume(&args[2], args, binding_index, last_uses);
+        self.bring_to_top(&args[2], hi_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -4205,11 +4254,11 @@ impl LoweringContext {
     ) {
         assert!(args.len() >= 2, "pow requires 2 arguments");
 
-        let base_is_last = self.is_last_use(&args[0], binding_index, last_uses);
-        self.bring_to_top(&args[0], base_is_last);
+        let base_consume = self.operand_consume(&args[0], args, binding_index, last_uses);
+        self.bring_to_top(&args[0], base_consume);
 
-        let exp_is_last = self.is_last_use(&args[1], binding_index, last_uses);
-        self.bring_to_top(&args[1], exp_is_last);
+        let exp_consume = self.operand_consume(&args[1], args, binding_index, last_uses);
+        self.bring_to_top(&args[1], exp_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -4251,19 +4300,19 @@ impl LoweringContext {
     ) {
         assert!(args.len() >= 3, "mulDiv requires 3 arguments");
 
-        let a_is_last = self.is_last_use(&args[0], binding_index, last_uses);
-        self.bring_to_top(&args[0], a_is_last);
+        let a_consume = self.operand_consume(&args[0], args, binding_index, last_uses);
+        self.bring_to_top(&args[0], a_consume);
 
-        let b_is_last = self.is_last_use(&args[1], binding_index, last_uses);
-        self.bring_to_top(&args[1], b_is_last);
+        let b_consume = self.operand_consume(&args[1], args, binding_index, last_uses);
+        self.bring_to_top(&args[1], b_consume);
 
         self.sm.pop();
         self.sm.pop();
         self.emit_op(StackOp::Opcode("OP_MUL".to_string()));
         self.sm.push(""); // a*b
 
-        let c_is_last = self.is_last_use(&args[2], binding_index, last_uses);
-        self.bring_to_top(&args[2], c_is_last);
+        let c_consume = self.operand_consume(&args[2], args, binding_index, last_uses);
+        self.bring_to_top(&args[2], c_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -4284,11 +4333,11 @@ impl LoweringContext {
     ) {
         assert!(args.len() >= 2, "percentOf requires 2 arguments");
 
-        let amount_is_last = self.is_last_use(&args[0], binding_index, last_uses);
-        self.bring_to_top(&args[0], amount_is_last);
+        let amount_consume = self.operand_consume(&args[0], args, binding_index, last_uses);
+        self.bring_to_top(&args[0], amount_consume);
 
-        let bps_is_last = self.is_last_use(&args[1], binding_index, last_uses);
-        self.bring_to_top(&args[1], bps_is_last);
+        let bps_consume = self.operand_consume(&args[1], args, binding_index, last_uses);
+        self.bring_to_top(&args[1], bps_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -4365,11 +4414,11 @@ impl LoweringContext {
     ) {
         assert!(args.len() >= 2, "gcd requires 2 arguments");
 
-        let a_is_last = self.is_last_use(&args[0], binding_index, last_uses);
-        self.bring_to_top(&args[0], a_is_last);
+        let a_consume = self.operand_consume(&args[0], args, binding_index, last_uses);
+        self.bring_to_top(&args[0], a_consume);
 
-        let b_is_last = self.is_last_use(&args[1], binding_index, last_uses);
-        self.bring_to_top(&args[1], b_is_last);
+        let b_consume = self.operand_consume(&args[1], args, binding_index, last_uses);
+        self.bring_to_top(&args[1], b_consume);
 
         self.sm.pop();
         self.sm.pop();
@@ -4421,11 +4470,11 @@ impl LoweringContext {
     ) {
         assert!(args.len() >= 2, "divmod requires 2 arguments");
 
-        let a_is_last = self.is_last_use(&args[0], binding_index, last_uses);
-        self.bring_to_top(&args[0], a_is_last);
+        let a_consume = self.operand_consume(&args[0], args, binding_index, last_uses);
+        self.bring_to_top(&args[0], a_consume);
 
-        let b_is_last = self.is_last_use(&args[1], binding_index, last_uses);
-        self.bring_to_top(&args[1], b_is_last);
+        let b_consume = self.operand_consume(&args[1], args, binding_index, last_uses);
+        self.bring_to_top(&args[1], b_consume);
 
         self.sm.pop();
         self.sm.pop();

--- a/compilers/rust/tests/repeated_operand_consume_tests.rs
+++ b/compilers/rust/tests/repeated_operand_consume_tests.rs
@@ -1,0 +1,131 @@
+//! Repeated-operand consume fix, ported from the TS tier
+//! (packages/runar-compiler/src/__tests__/repeated-operand-consume.test.ts).
+//!
+//! A binding whose ANF value reads the SAME ref at more than one operand
+//! position (e.g. `t := x + x`) used to make an independent last-use consume
+//! decision per operand load. A consume-mode bring_to_top of a ref already on
+//! top of the stack is a pure no-op, so a single stack slot ended up backing
+//! two operand positions and the bare OP_ADD underflowed at runtime (or, with
+//! the ref buried below other live slots, paired the wrong slot).
+//!
+//! Canonical rule (merged in TS, ported here): an operand load may consume
+//! (ROLL / move) its ref only when this binding is the ref's last use AND the
+//! ref occurs exactly once in the value's FULL operand list. Repeated refs
+//! copy (PICK / DUP) at every position; the original lingers and is cleaned
+//! by the existing method epilogue.
+//!
+//! Unreachable from the language frontend (ANF lowering gives every operand a
+//! fresh temp); fully reachable via `compile_from_ir` / CLI `--ir`.
+//!
+//! Expected hex strings below are the TS-tier reference outputs for the same
+//! ANF (fold-off, placeholder constructor slot) and must stay byte-identical
+//! across all 7 tiers.
+
+use runar_compiler_rust::{compile_from_ir_str_with_options, CompileOptions};
+
+fn fold_off() -> CompileOptions {
+    CompileOptions {
+        disable_constant_folding: true,
+        ..CompileOptions::default()
+    }
+}
+
+#[test]
+fn bin_op_same_ref_twice_copies_at_both_positions() {
+    let ir_json = r#"{
+  "contractName": "Repeat",
+  "properties": [{ "name": "target", "type": "bigint", "readonly": true }],
+  "methods": [
+    {
+      "name": "unlock",
+      "params": [{ "name": "x", "type": "bigint" }],
+      "body": [
+        { "name": "t0", "value": { "kind": "bin_op", "op": "+", "left": "x", "right": "x" } },
+        { "name": "t1", "value": { "kind": "load_prop", "name": "target" } },
+        { "name": "t2", "value": { "kind": "bin_op", "op": "===", "left": "t0", "right": "t1" } },
+        { "name": "t3", "value": { "kind": "assert", "value": "t2" } }
+      ],
+      "isPublic": true
+    }
+  ]
+}"#;
+
+    let artifact = compile_from_ir_str_with_options(ir_json, &fold_off())
+        .expect("compile_from_ir_str failed");
+
+    // DUP DUP ADD OP_0 NUMEQUAL NIP (TS-tier reference)
+    assert_eq!(
+        artifact.script, "767693009c77",
+        "repeated-operand script mismatch, asm: {}",
+        artifact.asm
+    );
+}
+
+#[test]
+fn call_same_ref_in_two_arg_positions() {
+    let ir_json = r#"{
+  "contractName": "Repeat",
+  "properties": [{ "name": "target", "type": "bigint", "readonly": true }],
+  "methods": [
+    {
+      "name": "unlock",
+      "params": [{ "name": "x", "type": "bigint" }],
+      "body": [
+        { "name": "t0", "value": { "kind": "call", "func": "min", "args": ["x", "x"] } },
+        { "name": "t1", "value": { "kind": "load_prop", "name": "target" } },
+        { "name": "t2", "value": { "kind": "bin_op", "op": "===", "left": "t0", "right": "t1" } },
+        { "name": "t3", "value": { "kind": "assert", "value": "t2" } }
+      ],
+      "isPublic": true
+    }
+  ]
+}"#;
+
+    let artifact = compile_from_ir_str_with_options(ir_json, &fold_off())
+        .expect("compile_from_ir_str failed");
+
+    // DUP DUP MIN OP_0 NUMEQUAL NIP (TS-tier reference)
+    assert_eq!(
+        artifact.script, "7676a3009c77",
+        "repeated-operand min(x,x) script mismatch, asm: {}",
+        artifact.asm
+    );
+}
+
+#[test]
+fn repeated_ref_buried_below_live_slot() {
+    // At `t0 := x + x` the stack is [x, y] (y live on top): a naive "last
+    // occurrence may still consume" rule pairs x with the wrong slot instead
+    // of duplicating x.
+    let ir_json = r#"{
+  "contractName": "Repeat",
+  "properties": [{ "name": "target", "type": "bigint", "readonly": true }],
+  "methods": [
+    {
+      "name": "unlock",
+      "params": [
+        { "name": "x", "type": "bigint" },
+        { "name": "y", "type": "bigint" }
+      ],
+      "body": [
+        { "name": "t0", "value": { "kind": "bin_op", "op": "+", "left": "x", "right": "x" } },
+        { "name": "t1", "value": { "kind": "bin_op", "op": "+", "left": "t0", "right": "y" } },
+        { "name": "t2", "value": { "kind": "load_prop", "name": "target" } },
+        { "name": "t3", "value": { "kind": "bin_op", "op": "===", "left": "t1", "right": "t2" } },
+        { "name": "t4", "value": { "kind": "assert", "value": "t3" } }
+      ],
+      "isPublic": true
+    }
+  ]
+}"#;
+
+    let artifact = compile_from_ir_str_with_options(ir_json, &fold_off())
+        .expect("compile_from_ir_str failed");
+
+    // OVER DUP ADD SWAP ADD OP_0 NUMEQUAL NIP (TS-tier reference)
+    assert_eq!(
+        artifact.script, "7876937c93009c77",
+        "repeated-operand buried-slot script mismatch, asm: {}",
+        artifact.asm
+    );
+}


### PR DESCRIPTION
Ports the repeated-operand consume fix (PR #62, TS tier) to Go (`compilers/go/codegen/stack.go`) and Rust (`compilers/rust/src/codegen/stack.rs`), 1:1 against the TS `operandConsume` reference: **consume = isLastUse AND the ref occurs exactly once in the value's full operand list**; repeated refs copy at every position.

- Failing-first native tests per tier through the real IR-loader paths (pre-fix: stack underflow / wrong-slot pairing).
- Cross-tier hex byte-identical with TS for all three reproducer shapes: `767693009c77`, `7676a3009c77` (min(x,x)), `7876937c93009c77` (buried ref).
- Full suites green: `go test ./...` all packages; `cargo test` 21 suites 0 failures — existing goldens byte-identical (no drift on the non-repeated path).