### PR TITLE
fix(compiler): copy repeated operand refs in stack lowering (Python/Zig/Ruby/Java tiers)

### DIFF
--- a/compilers/java/src/main/java/runar/compiler/passes/StackLower.java
+++ b/compilers/java/src/main/java/runar/compiler/passes/StackLower.java
@@ -672,6 +672,32 @@ public final class StackLower {
             return last <= currentIndex;
         }
 
+        /**
+         * Consume-vs-copy decision for one operand of a multi-operand ANF value.
+         *
+         * <p>{@code operands} is the FULL operand-ref list of the value (including
+         * {@code ref} itself). The load may consume (ROLL / move) the ref only when
+         * this binding is the ref's last use AND the ref occurs exactly once in the
+         * operand list. A ref read at more than one operand position of the same
+         * value must be copied (PICK / DUP) at EVERY position: a consume-mode
+         * bringToTop of a ref already on top of the stack is a no-op, so two
+         * consume-mode loads of the same ref would leave a single slot for an opcode
+         * that pops one item per operand (e.g. {@code t := x + x} underflowing
+         * OP_ADD), or silently pair the opcode with the wrong slot. The original then
+         * stays on the stack and the existing method epilogue cleans it up.
+         * Unreachable from the frontend (every operand gets a fresh temp); reachable
+         * via AnfLoader / CLI --ir hand-written ANF.
+         */
+        boolean operandConsume(String ref, List<String> operands, int currentIndex,
+                               Map<String, Integer> lastUses) {
+            if (!isLastUse(ref, currentIndex, lastUses)) return false;
+            int occurrences = 0;
+            for (String o : operands) {
+                if (o.equals(ref)) occurrences++;
+            }
+            return occurrences <= 1;
+        }
+
         // ---------------- lower_bindings ----------------
 
         void lowerBindings(List<AnfBinding> bindings, boolean terminalAssert) {
@@ -881,8 +907,9 @@ public final class StackLower {
 
         void lowerBinOp(String bindingName, String op, String left, String right,
                         int idx, Map<String, Integer> lastUses, String resultType) {
-            bringToTop(left, isLastUse(left, idx, lastUses));
-            bringToTop(right, isLastUse(right, idx, lastUses));
+            List<String> binOperands = List.of(left, right);
+            bringToTop(left, operandConsume(left, binOperands, idx, lastUses));
+            bringToTop(right, operandConsume(right, binOperands, idx, lastUses));
             sm.pop();
             sm.pop();
 
@@ -1093,7 +1120,7 @@ public final class StackLower {
 
             // General builtin path
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < args.size(); i++) sm.pop();
 
@@ -1134,7 +1161,7 @@ public final class StackLower {
                     "sha256Compress requires 2 arguments: state, block");
             }
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < 2; i++) sm.pop();
 
@@ -1153,7 +1180,7 @@ public final class StackLower {
                     "verifySLHDSA requires 3 arguments: msg, sig, pubkey");
             }
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < 3; i++) sm.pop();
 
@@ -1168,7 +1195,7 @@ public final class StackLower {
         void lowerEcBuiltin(String bindingName, String funcName, List<String> args,
                             int idx, Map<String, Integer> lastUses) {
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < args.size(); i++) sm.pop();
 
@@ -1187,7 +1214,7 @@ public final class StackLower {
                     funcName + " requires 3 arguments: msg, sig, pubkey");
             }
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < args.size(); i++) sm.pop();
 
@@ -1208,7 +1235,7 @@ public final class StackLower {
                     funcName + " requires " + expected + " argument" + (expected == 1 ? "" : "s"));
             }
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < args.size(); i++) sm.pop();
 
@@ -1228,7 +1255,7 @@ public final class StackLower {
                 throw new RuntimeException(funcName + " requires 3 arguments: msg, sig, pubkey");
             }
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < args.size(); i++) sm.pop();
 
@@ -1246,7 +1273,7 @@ public final class StackLower {
                     funcName + " requires 4 arguments: msg, sig, padding, pubkey");
             }
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < args.size(); i++) sm.pop();
 
@@ -1264,7 +1291,7 @@ public final class StackLower {
                     "sha256Finalize requires 3 arguments: state, remaining, msgBitLen");
             }
             for (String a : args) {
-                bringToTop(a, isLastUse(a, idx, lastUses));
+                bringToTop(a, operandConsume(a, args, idx, lastUses));
             }
             for (int i = 0; i < 3; i++) sm.pop();
 
@@ -1298,9 +1325,14 @@ public final class StackLower {
             emitOp(new PushOp(PushValue.of(0)));
             sm.push("");
 
+            // A ref repeated across the combined element list (e.g. the same
+            // pubkey twice) must be copied at every position — see operandConsume.
+            List<String> msigOperands = new ArrayList<>(sigElems);
+            msigOperands.addAll(pkElems);
+
             // Bring each sig element to TOS in declaration order.
             for (String sig : sigElems) {
-                bringToTop(sig, isLastUse(sig, idx, lastUses));
+                bringToTop(sig, operandConsume(sig, msigOperands, idx, lastUses));
             }
 
             // Push nSigs.
@@ -1309,7 +1341,7 @@ public final class StackLower {
 
             // Bring each pubkey element to TOS in declaration order.
             for (String pk : pkElems) {
-                bringToTop(pk, isLastUse(pk, idx, lastUses));
+                bringToTop(pk, operandConsume(pk, msigOperands, idx, lastUses));
             }
 
             // Push nPKs.
@@ -1344,8 +1376,8 @@ public final class StackLower {
             String start = args.get(1);
             String length = args.get(2);
 
-            bringToTop(data, isLastUse(data, idx, lastUses));
-            bringToTop(start, isLastUse(start, idx, lastUses));
+            bringToTop(data, operandConsume(data, args, idx, lastUses));
+            bringToTop(start, operandConsume(start, args, idx, lastUses));
 
             // OP_SPLIT consumes [data, start] -> [left, right]
             sm.pop();
@@ -1360,7 +1392,7 @@ public final class StackLower {
             String rightPart = sm.pop();
             sm.push(rightPart);
 
-            bringToTop(length, isLastUse(length, idx, lastUses));
+            bringToTop(length, operandConsume(length, args, idx, lastUses));
 
             // OP_SPLIT consumes [right, length] -> [result, remainder]
             sm.pop();
@@ -1393,8 +1425,8 @@ public final class StackLower {
             String a = args.get(0);
             String b = args.get(1);
 
-            bringToTop(a, isLastUse(a, idx, lastUses));
-            bringToTop(b, isLastUse(b, idx, lastUses));
+            bringToTop(a, operandConsume(a, args, idx, lastUses));
+            bringToTop(b, operandConsume(b, args, idx, lastUses));
 
             // DUP b, assert b != 0, then divide / mod.
             // Stack: a b -> a b b -> a b (b!=0) -> [verify pops] -> a b -> a/b or a%b
@@ -1427,8 +1459,8 @@ public final class StackLower {
             String amount = args.get(0);
             String bps = args.get(1);
 
-            bringToTop(amount, isLastUse(amount, idx, lastUses));
-            bringToTop(bps, isLastUse(bps, idx, lastUses));
+            bringToTop(amount, operandConsume(amount, args, idx, lastUses));
+            bringToTop(bps, operandConsume(bps, args, idx, lastUses));
 
             sm.pop();
             sm.pop();
@@ -1460,14 +1492,14 @@ public final class StackLower {
             String lo = args.get(1);
             String hi = args.get(2);
 
-            bringToTop(val, isLastUse(val, idx, lastUses));
-            bringToTop(lo, isLastUse(lo, idx, lastUses));
+            bringToTop(val, operandConsume(val, args, idx, lastUses));
+            bringToTop(lo, operandConsume(lo, args, idx, lastUses));
             sm.pop();
             sm.pop();
             emitOp(new OpcodeOp("OP_MAX"));
             sm.push(""); // intermediate max(val, lo)
 
-            bringToTop(hi, isLastUse(hi, idx, lastUses));
+            bringToTop(hi, operandConsume(hi, args, idx, lastUses));
             sm.pop();
             sm.pop();
             emitOp(new OpcodeOp("OP_MIN"));
@@ -1492,8 +1524,8 @@ public final class StackLower {
             String base = args.get(0);
             String exp = args.get(1);
 
-            bringToTop(base, isLastUse(base, idx, lastUses));
-            bringToTop(exp, isLastUse(exp, idx, lastUses));
+            bringToTop(base, operandConsume(base, args, idx, lastUses));
+            bringToTop(exp, operandConsume(exp, args, idx, lastUses));
             sm.pop();
             sm.pop();
 
@@ -1531,14 +1563,14 @@ public final class StackLower {
             String b = args.get(1);
             String c = args.get(2);
 
-            bringToTop(a, isLastUse(a, idx, lastUses));
-            bringToTop(b, isLastUse(b, idx, lastUses));
+            bringToTop(a, operandConsume(a, args, idx, lastUses));
+            bringToTop(b, operandConsume(b, args, idx, lastUses));
             sm.pop();
             sm.pop();
             emitOp(new OpcodeOp("OP_MUL"));
             sm.push(""); // a*b
 
-            bringToTop(c, isLastUse(c, idx, lastUses));
+            bringToTop(c, operandConsume(c, args, idx, lastUses));
             sm.pop();
             sm.pop();
             emitOp(new OpcodeOp("OP_DIV"));
@@ -1597,8 +1629,8 @@ public final class StackLower {
             String a = args.get(0);
             String b = args.get(1);
 
-            bringToTop(a, isLastUse(a, idx, lastUses));
-            bringToTop(b, isLastUse(b, idx, lastUses));
+            bringToTop(a, operandConsume(a, args, idx, lastUses));
+            bringToTop(b, operandConsume(b, args, idx, lastUses));
             sm.pop();
             sm.pop();
 
@@ -1635,8 +1667,8 @@ public final class StackLower {
             String a = args.get(0);
             String b = args.get(1);
 
-            bringToTop(a, isLastUse(a, idx, lastUses));
-            bringToTop(b, isLastUse(b, idx, lastUses));
+            bringToTop(a, operandConsume(a, args, idx, lastUses));
+            bringToTop(b, operandConsume(b, args, idx, lastUses));
             sm.pop();
             sm.pop();
 
@@ -1751,7 +1783,7 @@ public final class StackLower {
             for (int i = 0; i < args.size() && i < m.params().size(); i++) {
                 String paramName = m.params().get(i).name();
                 String arg = args.get(i);
-                bringToTop(arg, isLastUse(arg, idx, lastUses));
+                bringToTop(arg, operandConsume(arg, args, idx, lastUses));
                 sm.pop();
 
                 if (sm.has(paramName)) {
@@ -2565,6 +2597,9 @@ public final class StackLower {
                             String preimage, int idx, Map<String, Integer> lastUses) {
             List<AnfProperty> stateProps = new ArrayList<>();
             for (AnfProperty p : properties) if (!p.readonly()) stateProps.add(p);
+            List<String> outputOperands = new ArrayList<>();
+            outputOperands.add(satoshis);
+            outputOperands.addAll(stateValues);
 
             // Step 1: Bring _codePart to top (PICK)
             bringToTop("_codePart", false);
@@ -2581,7 +2616,7 @@ public final class StackLower {
             for (int i = 0; i < cnt; i++) {
                 String valueRef = stateValues.get(i);
                 AnfProperty prop = stateProps.get(i);
-                bringToTop(valueRef, isLastUse(valueRef, idx, lastUses));
+                bringToTop(valueRef, operandConsume(valueRef, outputOperands, idx, lastUses));
                 if ("bigint".equals(prop.type())) {
                     emitOp(new PushOp(PushValue.of(8)));
                     sm.push("");
@@ -2613,7 +2648,7 @@ public final class StackLower {
             sm.push("");
 
             // Step 6: Prepend satoshis as 8-byte LE
-            bringToTop(satoshis, isLastUse(satoshis, idx, lastUses));
+            bringToTop(satoshis, operandConsume(satoshis, outputOperands, idx, lastUses));
             emitOp(new PushOp(PushValue.of(8)));
             sm.push("");
             emitOp(new OpcodeOp("OP_NUM2BIN"));
@@ -2631,7 +2666,7 @@ public final class StackLower {
 
         void lowerAddRawOutput(String bindingName, String satoshis, String scriptBytes,
                                int idx, Map<String, Integer> lastUses) {
-            bringToTop(scriptBytes, isLastUse(scriptBytes, idx, lastUses));
+            bringToTop(scriptBytes, operandConsume(scriptBytes, List.of(satoshis, scriptBytes), idx, lastUses));
 
             emitOp(new OpcodeOp("OP_SIZE"));
             sm.push("");
@@ -2643,7 +2678,7 @@ public final class StackLower {
             emitOp(new OpcodeOp("OP_CAT"));
             sm.push("");
 
-            bringToTop(satoshis, isLastUse(satoshis, idx, lastUses));
+            bringToTop(satoshis, operandConsume(satoshis, List.of(satoshis, scriptBytes), idx, lastUses));
             emitOp(new PushOp(PushValue.of(8)));
             sm.push("");
             emitOp(new OpcodeOp("OP_NUM2BIN"));
@@ -2667,7 +2702,7 @@ public final class StackLower {
 
             emitOp(new PushOp(PushValue.ofHex("1976a914")));
             sm.push("");
-            bringToTop(pkh, isLastUse(pkh, idx, lastUses));
+            bringToTop(pkh, operandConsume(pkh, args, idx, lastUses));
             emitOp(new OpcodeOp("OP_CAT"));
             sm.pop(); sm.pop();
             sm.push("");
@@ -2678,7 +2713,7 @@ public final class StackLower {
             sm.pop(); sm.pop();
             sm.push("");
 
-            bringToTop(amount, isLastUse(amount, idx, lastUses));
+            bringToTop(amount, operandConsume(amount, args, idx, lastUses));
             emitOp(new PushOp(PushValue.of(8)));
             sm.push("");
             emitOp(new OpcodeOp("OP_NUM2BIN"));
@@ -2701,9 +2736,9 @@ public final class StackLower {
             String stateBytes = args.get(1);
 
             // stateBytes
-            bringToTop(stateBytes, isLastUse(stateBytes, idx, lastUses));
+            bringToTop(stateBytes, operandConsume(stateBytes, args, idx, lastUses));
             // preimage
-            bringToTop(preimage, isLastUse(preimage, idx, lastUses));
+            bringToTop(preimage, operandConsume(preimage, args, idx, lastUses));
 
             // Extract amount: last 52 bytes, take 8
             emitOp(new OpcodeOp("OP_SIZE"));
@@ -2775,12 +2810,12 @@ public final class StackLower {
             String newAmount = args.get(2);
 
             // drop preimage
-            bringToTop(preimage, isLastUse(preimage, idx, lastUses));
+            bringToTop(preimage, operandConsume(preimage, args, idx, lastUses));
             emitOp(new DropOp());
             sm.pop();
 
             // newAmount -> 8-byte LE -> altstack
-            bringToTop(newAmount, isLastUse(newAmount, idx, lastUses));
+            bringToTop(newAmount, operandConsume(newAmount, args, idx, lastUses));
             emitOp(new PushOp(PushValue.of(8)));
             sm.push("");
             emitOp(new OpcodeOp("OP_NUM2BIN"));
@@ -2789,7 +2824,7 @@ public final class StackLower {
             emitOp(new OpcodeOp("OP_TOALTSTACK"));
             sm.pop();
 
-            bringToTop(stateBytes, isLastUse(stateBytes, idx, lastUses));
+            bringToTop(stateBytes, operandConsume(stateBytes, args, idx, lastUses));
             bringToTop("_codePart", false);
 
             emitOp(new PushOp(PushValue.ofHex("6a")));

--- a/compilers/java/src/test/java/runar/compiler/passes/RepeatedOperandConsumeTest.java
+++ b/compilers/java/src/test/java/runar/compiler/passes/RepeatedOperandConsumeTest.java
@@ -1,0 +1,119 @@
+package runar.compiler.passes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import runar.compiler.Cli;
+import runar.compiler.ir.anf.AnfProgram;
+import runar.compiler.ir.stack.StackProgram;
+
+/**
+ * Repeated-operand consume bug (hand-written ANF via AnfLoader / CLI --ir).
+ *
+ * <p>Mirrors packages/runar-compiler/src/__tests__/repeated-operand-consume.test.ts.
+ *
+ * <p>A binding whose ANF value reads the SAME ref at more than one operand
+ * position used to make an independent last-use consume decision per load; a
+ * consume-mode bringToTop of a ref already on top of the stack is a no-op, so
+ * {@code t := x + x} left a single stack slot for OP_ADD (underflow at
+ * runtime), or paired the opcode with the wrong slot when the ref was buried.
+ * Canonical rule: an operand load may consume (ROLL) its ref only when this
+ * binding is the ref's last use AND the ref occurs exactly once in the value's
+ * FULL operand list. Repeated refs copy (PICK / DUP) at every position.
+ * Unreachable from the frontend (every operand gets a fresh temp); reachable
+ * via hand-written IR.
+ */
+class RepeatedOperandConsumeTest {
+
+    private static String programJson(String params, String body) {
+        return """
+            {
+              "contractName": "Repeat",
+              "properties": [{"name": "target", "type": "bigint", "readonly": true}],
+              "methods": [
+                {
+                  "name": "unlock",
+                  "params": [%s],
+                  "body": [%s],
+                  "isPublic": true
+                }
+              ]
+            }
+            """.formatted(params, body);
+    }
+
+    /** Mirror the CLI --ir --hex --disable-constant-folding pipeline. */
+    private static String compileIrToHex(String json) {
+        AnfProgram anf = AnfLoader.parse(json);
+        anf = Cli.optimizeAnf(anf, true);
+        StackProgram stack = StackLower.run(anf);
+        StackProgram optimised = Peephole.run(stack);
+        return Emit.run(optimised);
+    }
+
+    @Test
+    void binOpSameRefTwice() {
+        // unlock(x) { assert(x + x === target) }
+        String json = programJson(
+            "{\"name\": \"x\", \"type\": \"bigint\"}",
+            """
+            {"name": "t0", "value": {"kind": "bin_op", "op": "+", "left": "x", "right": "x"}},
+            {"name": "t1", "value": {"kind": "load_prop", "name": "target"}},
+            {"name": "t2", "value": {"kind": "bin_op", "op": "===", "left": "t0", "right": "t1"}},
+            {"name": "t3", "value": {"kind": "assert", "value": "t2"}}
+            """);
+        // Both loads of x must COPY: DUP DUP ADD <placeholder OP_0> NUMEQUAL NIP.
+        // Cross-tier canonical hex, byte-identical with the TS tier.
+        assertEquals("767693009c77", compileIrToHex(json));
+    }
+
+    @Test
+    void callSameRefInTwoArgPositions() {
+        // unlock(x) { assert(min(x, x) === target) }
+        String json = programJson(
+            "{\"name\": \"x\", \"type\": \"bigint\"}",
+            """
+            {"name": "t0", "value": {"kind": "call", "func": "min", "args": ["x", "x"]}},
+            {"name": "t1", "value": {"kind": "load_prop", "name": "target"}},
+            {"name": "t2", "value": {"kind": "bin_op", "op": "===", "left": "t0", "right": "t1"}},
+            {"name": "t3", "value": {"kind": "assert", "value": "t2"}}
+            """);
+        // DUP DUP MIN <placeholder OP_0> NUMEQUAL NIP
+        assertEquals("7676a3009c77", compileIrToHex(json));
+    }
+
+    @Test
+    void repeatedRefBuriedBelowLiveSlot() {
+        // unlock(x, y) { assert(x + x + y === target) } — at t0 the stack is
+        // [x, y]: x sits at depth 1, so a naive rule pairs OP_ADD with the
+        // wrong slot instead of copying x twice.
+        String json = programJson(
+            "{\"name\": \"x\", \"type\": \"bigint\"}, {\"name\": \"y\", \"type\": \"bigint\"}",
+            """
+            {"name": "t0", "value": {"kind": "bin_op", "op": "+", "left": "x", "right": "x"}},
+            {"name": "t1", "value": {"kind": "bin_op", "op": "+", "left": "t0", "right": "y"}},
+            {"name": "t2", "value": {"kind": "load_prop", "name": "target"}},
+            {"name": "t3", "value": {"kind": "bin_op", "op": "===", "left": "t1", "right": "t2"}},
+            {"name": "t4", "value": {"kind": "assert", "value": "t3"}}
+            """);
+        // OVER DUP ADD SWAP ADD OP_0 NUMEQUAL NIP — byte-identical with TS.
+        assertEquals("7876937c93009c77", compileIrToHex(json));
+    }
+
+    @Test
+    void distinctRefsUnchanged() {
+        // Frontend-shaped ANF (fresh temp per operand) must not shift bytes.
+        String json = programJson(
+            "{\"name\": \"x\", \"type\": \"bigint\"}",
+            """
+            {"name": "t0", "value": {"kind": "load_param", "name": "x"}},
+            {"name": "t1", "value": {"kind": "load_param", "name": "x"}},
+            {"name": "t2", "value": {"kind": "bin_op", "op": "+", "left": "t0", "right": "t1"}},
+            {"name": "t3", "value": {"kind": "load_prop", "name": "target"}},
+            {"name": "t4", "value": {"kind": "bin_op", "op": "===", "left": "t2", "right": "t3"}},
+            {"name": "t5", "value": {"kind": "assert", "value": "t4"}}
+            """);
+        // DUP SWAP ADD <placeholder OP_0> NUMEQUAL — canonical frontend Dbl shape.
+        assertEquals("767c93009c", compileIrToHex(json));
+    }
+}

--- a/compilers/python/runar_compiler/codegen/stack.py
+++ b/compilers/python/runar_compiler/codegen/stack.py
@@ -792,6 +792,27 @@ class _LoweringContext:
             return True
         return last <= current_index
 
+    def _operand_consume(self, ref: str, operands: list[str], binding_index: int,
+                         last_uses: dict[str, int]) -> bool:
+        """Consume-vs-copy decision for one operand of a multi-operand ANF value.
+
+        ``operands`` is the FULL operand-ref list of the value (including
+        ``ref`` itself). The load may consume (ROLL / move) the ref only when
+        this binding is the ref's last use AND the ref occurs exactly once in
+        the operand list. A ref read at more than one operand position of the
+        same value must be copied (PICK / DUP) at EVERY position: a
+        consume-mode bring_to_top of a ref already on top of the stack is a
+        no-op, so two consume-mode loads of the same ref would leave a single
+        slot for an opcode that pops one item per operand (e.g. ``t := x + x``
+        underflowing OP_ADD), or silently pair the opcode with the wrong slot.
+        The original then stays on the stack and the existing method epilogue
+        cleans it up. Unreachable from the frontend (pass 04 gives every
+        operand a fresh temp); reachable via compile_from_ir hand-written ANF.
+        """
+        if not self._is_last_use(ref, binding_index, last_uses):
+            return False
+        return operands.count(ref) <= 1
+
     # -----------------------------------------------------------------
     # lower_bindings
     # -----------------------------------------------------------------
@@ -1014,11 +1035,11 @@ class _LoweringContext:
 
     def _lower_bin_op(self, binding_name: str, op: str, left: str, right: str,
                       binding_index: int, last_uses: dict[str, int], result_type: str) -> None:
-        left_is_last = self._is_last_use(left, binding_index, last_uses)
-        self.bring_to_top(left, left_is_last)
+        left_consume = self._operand_consume(left, [left, right], binding_index, last_uses)
+        self.bring_to_top(left, left_consume)
 
-        right_is_last = self._is_last_use(right, binding_index, last_uses)
-        self.bring_to_top(right, right_is_last)
+        right_consume = self._operand_consume(right, [left, right], binding_index, last_uses)
+        self.bring_to_top(right, right_consume)
 
         self.sm.pop()
         self.sm.pop()
@@ -1242,8 +1263,8 @@ class _LoweringContext:
 
         # General builtin: push args in order, then emit opcodes
         for arg in args:
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
 
         # Pop all args
         for _ in args:
@@ -1313,8 +1334,8 @@ class _LoweringContext:
         for i, arg in enumerate(args):
             if i < len(method.params):
                 param_name = method.params[i].name
-                is_last = self._is_last_use(arg, binding_index, last_uses)
-                self.bring_to_top(arg, is_last)
+                consume = self._operand_consume(arg, args, binding_index, last_uses)
+                self.bring_to_top(arg, consume)
                 self.sm.pop()
 
                 # If param_name already exists on the stack, temporarily rename
@@ -1727,12 +1748,14 @@ class _LoweringContext:
         state_bytes_ref = args[1]
 
         # Bring stateBytes to stack first.
-        state_last = self._is_last_use(state_bytes_ref, binding_index, last_uses)
-        self.bring_to_top(state_bytes_ref, state_last)
+        state_consume = self._operand_consume(
+            state_bytes_ref, [preimage_ref, state_bytes_ref], binding_index, last_uses)
+        self.bring_to_top(state_bytes_ref, state_consume)
 
         # Extract amount from preimage for the continuation output.
-        pre_last = self._is_last_use(preimage_ref, binding_index, last_uses)
-        self.bring_to_top(preimage_ref, pre_last)
+        pre_consume = self._operand_consume(
+            preimage_ref, [preimage_ref, state_bytes_ref], binding_index, last_uses)
+        self.bring_to_top(preimage_ref, pre_consume)
 
         # Extract amount: last 52 bytes, take 8 bytes at offset 0.
         self.emit_op(StackOp(op="opcode", code="OP_SIZE"))
@@ -1833,15 +1856,17 @@ class _LoweringContext:
         state_bytes_ref = args[1]
         new_amount_ref = args[2]
 
+        cso_operands = [preimage_ref, state_bytes_ref, new_amount_ref]
+
         # Consume preimage ref (no longer needed -- we use _codePart and _newAmount).
-        pre_last = self._is_last_use(preimage_ref, binding_index, last_uses)
-        self.bring_to_top(preimage_ref, pre_last)
+        pre_consume = self._operand_consume(preimage_ref, cso_operands, binding_index, last_uses)
+        self.bring_to_top(preimage_ref, pre_consume)
         self.emit_op(StackOp(op="drop"))
         self.sm.pop()
 
         # Step 1: Convert _newAmount to 8-byte LE and save to altstack.
-        amount_last = self._is_last_use(new_amount_ref, binding_index, last_uses)
-        self.bring_to_top(new_amount_ref, amount_last)
+        amount_consume = self._operand_consume(new_amount_ref, cso_operands, binding_index, last_uses)
+        self.bring_to_top(new_amount_ref, amount_consume)
         self.emit_op(StackOp(op="push", value=big_int_push(8)))
         self.sm.push("")
         self.emit_op(StackOp(op="opcode", code="OP_NUM2BIN"))
@@ -1852,8 +1877,8 @@ class _LoweringContext:
         self.sm.pop()
 
         # Step 2: Bring stateBytes to stack.
-        state_last = self._is_last_use(state_bytes_ref, binding_index, last_uses)
-        self.bring_to_top(state_bytes_ref, state_last)
+        state_consume = self._operand_consume(state_bytes_ref, cso_operands, binding_index, last_uses)
+        self.bring_to_top(state_bytes_ref, state_consume)
 
         # Step 3: Bring _codePart to top (PICK -- never consume, reused across outputs)
         self.bring_to_top("_codePart", False)
@@ -1921,7 +1946,9 @@ class _LoweringContext:
         self.sm.push("")
 
         # Push the 20-byte PKH
-        self.bring_to_top(pkh_ref, self._is_last_use(pkh_ref, binding_index, last_uses))
+        self.bring_to_top(
+            pkh_ref,
+            self._operand_consume(pkh_ref, [pkh_ref, amount_ref], binding_index, last_uses))
         # CAT: prefix || pkh
         self.emit_op(StackOp(op="opcode", code="OP_CAT"))
         self.sm.pop()
@@ -1939,7 +1966,9 @@ class _LoweringContext:
         # --- Stack: [..., 0x1976a914{pkh}88ac] ---
 
         # Step 2: Prepend amount as 8-byte LE.
-        self.bring_to_top(amount_ref, self._is_last_use(amount_ref, binding_index, last_uses))
+        self.bring_to_top(
+            amount_ref,
+            self._operand_consume(amount_ref, [pkh_ref, amount_ref], binding_index, last_uses))
         self.emit_op(StackOp(op="push", value=big_int_push(8)))
         self.sm.push("")
         self.emit_op(StackOp(op="opcode", code="OP_NUM2BIN"))
@@ -2291,6 +2320,7 @@ class _LoweringContext:
         # Uses _codePart implicit parameter (passed by SDK) instead of extracting
         # codePart from the preimage. This is simpler and works with OP_CODESEPARATOR.
         state_props = [p for p in self.properties if not p.readonly]
+        output_operands = [satoshis, *state_values]
 
         # Step 1: Bring _codePart to top (PICK -- never consume, reused across outputs)
         self.bring_to_top("_codePart", False)
@@ -2310,8 +2340,8 @@ class _LoweringContext:
             value_ref = state_values[i]
             prop = state_props[i]
 
-            is_last = self._is_last_use(value_ref, binding_index, last_uses)
-            self.bring_to_top(value_ref, is_last)
+            consume = self._operand_consume(value_ref, output_operands, binding_index, last_uses)
+            self.bring_to_top(value_ref, consume)
 
             # Convert numeric/boolean values to fixed-width bytes
             if prop.type == "bigint":
@@ -2353,8 +2383,8 @@ class _LoweringContext:
         # --- Stack: [..., varint+script] ---
 
         # Step 6: Prepend satoshis as 8-byte LE.
-        is_last_sat = self._is_last_use(satoshis, binding_index, last_uses)
-        self.bring_to_top(satoshis, is_last_sat)
+        satoshis_consume = self._operand_consume(satoshis, output_operands, binding_index, last_uses)
+        self.bring_to_top(satoshis, satoshis_consume)
         self.emit_op(StackOp(op="push", value=big_int_push(8)))
         self.sm.push("")
         self.emit_op(StackOp(op="opcode", code="OP_NUM2BIN"))
@@ -2385,8 +2415,9 @@ class _LoweringContext:
         The scriptBytes are used as-is (no codePart/state insertion).
         """
         # Step 1: Bring scriptBytes to top
-        script_is_last = self._is_last_use(script_bytes, binding_index, last_uses)
-        self.bring_to_top(script_bytes, script_is_last)
+        script_consume = self._operand_consume(
+            script_bytes, [satoshis, script_bytes], binding_index, last_uses)
+        self.bring_to_top(script_bytes, script_consume)
 
         # Step 2: Compute varint prefix for script length
         self.emit_op(StackOp(op="opcode", code="OP_SIZE"))
@@ -2403,8 +2434,9 @@ class _LoweringContext:
         self.sm.push("")
 
         # Step 4: Prepend satoshis as 8-byte LE
-        sat_is_last = self._is_last_use(satoshis, binding_index, last_uses)
-        self.bring_to_top(satoshis, sat_is_last)
+        sat_consume = self._operand_consume(
+            satoshis, [satoshis, script_bytes], binding_index, last_uses)
+        self.bring_to_top(satoshis, sat_consume)
         self.emit_op(StackOp(op="push", value=big_int_push(8)))
         self.sm.push("")
         self.emit_op(StackOp(op="opcode", code="OP_NUM2BIN"))
@@ -2510,10 +2542,14 @@ class _LoweringContext:
         self.emit_op(StackOp(op="push", value=big_int_push(0)))
         self.sm.push("")
 
+        # A ref repeated across the combined element list (e.g. the same
+        # pubkey twice) must be copied at every position -- see _operand_consume.
+        msig_operands = [*sig_elems, *pk_elems]
+
         # Bring each sig element to TOS in declaration order.
         for sig in sig_elems:
-            is_last = self._is_last_use(sig, binding_index, last_uses)
-            self.bring_to_top(sig, is_last)
+            consume = self._operand_consume(sig, msig_operands, binding_index, last_uses)
+            self.bring_to_top(sig, consume)
 
         # Push nSigs.
         self.emit_op(StackOp(op="push", value=big_int_push(len(sig_elems))))
@@ -2521,8 +2557,8 @@ class _LoweringContext:
 
         # Bring each pubkey element to TOS in declaration order.
         for pk in pk_elems:
-            is_last = self._is_last_use(pk, binding_index, last_uses)
-            self.bring_to_top(pk, is_last)
+            consume = self._operand_consume(pk, msig_operands, binding_index, last_uses)
+            self.bring_to_top(pk, consume)
 
         # Push nPKs.
         self.emit_op(StackOp(op="push", value=big_int_push(len(pk_elems))))
@@ -2915,11 +2951,11 @@ class _LoweringContext:
 
         obj, index = args[0], args[1]
 
-        obj_is_last = self._is_last_use(obj, binding_index, last_uses)
-        self.bring_to_top(obj, obj_is_last)
+        obj_consume = self._operand_consume(obj, args, binding_index, last_uses)
+        self.bring_to_top(obj, obj_consume)
 
-        index_is_last = self._is_last_use(index, binding_index, last_uses)
-        self.bring_to_top(index, index_is_last)
+        index_consume = self._operand_consume(index, args, binding_index, last_uses)
+        self.bring_to_top(index, index_consume)
 
         # OP_SPLIT at index
         self.sm.pop()
@@ -2969,11 +3005,11 @@ class _LoweringContext:
 
         data, start, length = args[0], args[1], args[2]
 
-        data_is_last = self._is_last_use(data, binding_index, last_uses)
-        self.bring_to_top(data, data_is_last)
+        data_consume = self._operand_consume(data, args, binding_index, last_uses)
+        self.bring_to_top(data, data_consume)
 
-        start_is_last = self._is_last_use(start, binding_index, last_uses)
-        self.bring_to_top(start, start_is_last)
+        start_consume = self._operand_consume(start, args, binding_index, last_uses)
+        self.bring_to_top(start, start_consume)
 
         # Split at start position
         self.sm.pop()
@@ -2989,8 +3025,8 @@ class _LoweringContext:
         self.sm.push(right_part)
 
         # Push length
-        len_is_last = self._is_last_use(length, binding_index, last_uses)
-        self.bring_to_top(length, len_is_last)
+        len_consume = self._operand_consume(length, args, binding_index, last_uses)
+        self.bring_to_top(length, len_consume)
 
         # Split at length
         self.sm.pop()
@@ -3023,7 +3059,7 @@ class _LoweringContext:
 
         # Bring all 4 args to the top in argument order: msg sig padding pubKey
         for arg in args:
-            self.bring_to_top(arg, self._is_last_use(arg, binding_index, last_uses))
+            self.bring_to_top(arg, self._operand_consume(arg, args, binding_index, last_uses))
 
         # Pop all 4 args
         for _ in range(4):
@@ -3073,11 +3109,11 @@ class _LoweringContext:
             raise RuntimeError("right requires 2 arguments")
         data, length = args[0], args[1]
 
-        data_is_last = self._is_last_use(data, binding_index, last_uses)
-        self.bring_to_top(data, data_is_last)
+        data_consume = self._operand_consume(data, args, binding_index, last_uses)
+        self.bring_to_top(data, data_consume)
 
-        length_is_last = self._is_last_use(length, binding_index, last_uses)
-        self.bring_to_top(length, length_is_last)
+        length_consume = self._operand_consume(length, args, binding_index, last_uses)
+        self.bring_to_top(length, length_consume)
 
         self.sm.pop()
         self.sm.pop()
@@ -3103,11 +3139,11 @@ class _LoweringContext:
             raise RuntimeError(f"{func_name} requires 2 arguments")
         a, b = args[0], args[1]
 
-        a_is_last = self._is_last_use(a, binding_index, last_uses)
-        self.bring_to_top(a, a_is_last)
+        a_consume = self._operand_consume(a, args, binding_index, last_uses)
+        self.bring_to_top(a, a_consume)
 
-        b_is_last = self._is_last_use(b, binding_index, last_uses)
-        self.bring_to_top(b, b_is_last)
+        b_consume = self._operand_consume(b, args, binding_index, last_uses)
+        self.bring_to_top(b, b_consume)
 
         # DUP b, check non-zero, then divide/mod
         self.emit_op(StackOp(op="opcode", code="OP_DUP"))
@@ -3130,19 +3166,19 @@ class _LoweringContext:
             raise RuntimeError("clamp requires 3 arguments")
         val, lo, hi = args[0], args[1], args[2]
 
-        val_is_last = self._is_last_use(val, binding_index, last_uses)
-        self.bring_to_top(val, val_is_last)
+        val_consume = self._operand_consume(val, args, binding_index, last_uses)
+        self.bring_to_top(val, val_consume)
 
-        lo_is_last = self._is_last_use(lo, binding_index, last_uses)
-        self.bring_to_top(lo, lo_is_last)
+        lo_consume = self._operand_consume(lo, args, binding_index, last_uses)
+        self.bring_to_top(lo, lo_consume)
 
         self.sm.pop()
         self.sm.pop()
         self.emit_op(StackOp(op="opcode", code="OP_MAX"))
         self.sm.push("")
 
-        hi_is_last = self._is_last_use(hi, binding_index, last_uses)
-        self.bring_to_top(hi, hi_is_last)
+        hi_consume = self._operand_consume(hi, args, binding_index, last_uses)
+        self.bring_to_top(hi, hi_consume)
 
         self.sm.pop()
         self.sm.pop()
@@ -3157,11 +3193,11 @@ class _LoweringContext:
             raise RuntimeError("pow requires 2 arguments")
         base, exp = args[0], args[1]
 
-        base_is_last = self._is_last_use(base, binding_index, last_uses)
-        self.bring_to_top(base, base_is_last)
+        base_consume = self._operand_consume(base, args, binding_index, last_uses)
+        self.bring_to_top(base, base_consume)
 
-        exp_is_last = self._is_last_use(exp, binding_index, last_uses)
-        self.bring_to_top(exp, exp_is_last)
+        exp_consume = self._operand_consume(exp, args, binding_index, last_uses)
+        self.bring_to_top(exp, exp_consume)
 
         self.sm.pop()
         self.sm.pop()
@@ -3195,18 +3231,18 @@ class _LoweringContext:
             raise RuntimeError("mulDiv requires 3 arguments")
         a, b, c = args[0], args[1], args[2]
 
-        a_is_last = self._is_last_use(a, binding_index, last_uses)
-        self.bring_to_top(a, a_is_last)
-        b_is_last = self._is_last_use(b, binding_index, last_uses)
-        self.bring_to_top(b, b_is_last)
+        a_consume = self._operand_consume(a, args, binding_index, last_uses)
+        self.bring_to_top(a, a_consume)
+        b_consume = self._operand_consume(b, args, binding_index, last_uses)
+        self.bring_to_top(b, b_consume)
 
         self.sm.pop()
         self.sm.pop()
         self.emit_op(StackOp(op="opcode", code="OP_MUL"))
         self.sm.push("")
 
-        c_is_last = self._is_last_use(c, binding_index, last_uses)
-        self.bring_to_top(c, c_is_last)
+        c_consume = self._operand_consume(c, args, binding_index, last_uses)
+        self.bring_to_top(c, c_consume)
 
         self.sm.pop()
         self.sm.pop()
@@ -3221,10 +3257,10 @@ class _LoweringContext:
             raise RuntimeError("percentOf requires 2 arguments")
         amount, bps = args[0], args[1]
 
-        amount_is_last = self._is_last_use(amount, binding_index, last_uses)
-        self.bring_to_top(amount, amount_is_last)
-        bps_is_last = self._is_last_use(bps, binding_index, last_uses)
-        self.bring_to_top(bps, bps_is_last)
+        amount_consume = self._operand_consume(amount, args, binding_index, last_uses)
+        self.bring_to_top(amount, amount_consume)
+        bps_consume = self._operand_consume(bps, args, binding_index, last_uses)
+        self.bring_to_top(bps, bps_consume)
 
         self.sm.pop()
         self.sm.pop()
@@ -3279,10 +3315,10 @@ class _LoweringContext:
             raise RuntimeError("gcd requires 2 arguments")
         a, b = args[0], args[1]
 
-        a_is_last = self._is_last_use(a, binding_index, last_uses)
-        self.bring_to_top(a, a_is_last)
-        b_is_last = self._is_last_use(b, binding_index, last_uses)
-        self.bring_to_top(b, b_is_last)
+        a_consume = self._operand_consume(a, args, binding_index, last_uses)
+        self.bring_to_top(a, a_consume)
+        b_consume = self._operand_consume(b, args, binding_index, last_uses)
+        self.bring_to_top(b, b_consume)
 
         self.sm.pop()
         self.sm.pop()
@@ -3316,10 +3352,10 @@ class _LoweringContext:
             raise RuntimeError("divmod requires 2 arguments")
         a, b = args[0], args[1]
 
-        a_is_last = self._is_last_use(a, binding_index, last_uses)
-        self.bring_to_top(a, a_is_last)
-        b_is_last = self._is_last_use(b, binding_index, last_uses)
-        self.bring_to_top(b, b_is_last)
+        a_consume = self._operand_consume(a, args, binding_index, last_uses)
+        self.bring_to_top(a, a_consume)
+        b_consume = self._operand_consume(b, args, binding_index, last_uses)
+        self.bring_to_top(b, b_consume)
 
         self.sm.pop()
         self.sm.pop()
@@ -3384,7 +3420,7 @@ class _LoweringContext:
 
         # Bring args to top
         for arg in args:
-            self.bring_to_top(arg, self._is_last_use(arg, binding_index, last_uses))
+            self.bring_to_top(arg, self._operand_consume(arg, args, binding_index, last_uses))
         for _ in range(3):
             self.sm.pop()
 
@@ -3406,7 +3442,7 @@ class _LoweringContext:
             raise RuntimeError("verifySLHDSA requires 3 arguments: msg, sig, pubkey")
 
         for arg in args:
-            self.bring_to_top(arg, self._is_last_use(arg, binding_index, last_uses))
+            self.bring_to_top(arg, self._operand_consume(arg, args, binding_index, last_uses))
         for _ in range(3):
             self.sm.pop()
 
@@ -3432,7 +3468,7 @@ class _LoweringContext:
         if len(args) < 2:
             raise RuntimeError("sha256Compress requires 2 arguments: state, block")
         for arg in args:
-            self.bring_to_top(arg, self._is_last_use(arg, binding_index, last_uses))
+            self.bring_to_top(arg, self._operand_consume(arg, args, binding_index, last_uses))
         for _ in range(2):
             self.sm.pop()
 
@@ -3447,7 +3483,7 @@ class _LoweringContext:
         if len(args) < 3:
             raise RuntimeError("sha256Finalize requires 3 arguments: state, remaining, msgBitLen")
         for arg in args:
-            self.bring_to_top(arg, self._is_last_use(arg, binding_index, last_uses))
+            self.bring_to_top(arg, self._operand_consume(arg, args, binding_index, last_uses))
         for _ in range(3):
             self.sm.pop()
 
@@ -3466,7 +3502,7 @@ class _LoweringContext:
         if len(args) < 2:
             raise RuntimeError("blake3Compress requires 2 arguments: chainingValue, block")
         for arg in args:
-            self.bring_to_top(arg, self._is_last_use(arg, binding_index, last_uses))
+            self.bring_to_top(arg, self._operand_consume(arg, args, binding_index, last_uses))
         for _ in range(2):
             self.sm.pop()
 
@@ -3481,7 +3517,7 @@ class _LoweringContext:
         if len(args) < 1:
             raise RuntimeError("blake3Hash requires 1 argument: message")
         for arg in args:
-            self.bring_to_top(arg, self._is_last_use(arg, binding_index, last_uses))
+            self.bring_to_top(arg, self._operand_consume(arg, args, binding_index, last_uses))
         for _ in range(1):
             self.sm.pop()
 
@@ -3500,8 +3536,8 @@ class _LoweringContext:
                           last_uses: dict[str, int]) -> None:
         # Bring args to top in order
         for arg in args:
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
         for _ in args:
             self.sm.pop()
 
@@ -3545,8 +3581,8 @@ class _LoweringContext:
                                args: list[str], binding_index: int,
                                last_uses: dict[str, int]) -> None:
         for arg in args:
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
         for _ in args:
             self.sm.pop()
 
@@ -3579,8 +3615,8 @@ class _LoweringContext:
                             args: list[str], binding_index: int,
                             last_uses: dict[str, int]) -> None:
         for arg in args:
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
         for _ in args:
             self.sm.pop()
 
@@ -3604,8 +3640,8 @@ class _LoweringContext:
                           last_uses: dict[str, int]) -> None:
         # Bring args to top in order
         for arg in args:
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
         for _ in args:
             self.sm.pop()
 
@@ -3626,8 +3662,8 @@ class _LoweringContext:
                           last_uses: dict[str, int]) -> None:
         # Bring args to top in order
         for arg in args:
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
         for _ in args:
             self.sm.pop()
 
@@ -3648,8 +3684,8 @@ class _LoweringContext:
                              last_uses: dict[str, int]) -> None:
         # Bring args to top in order
         for arg in args:
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
         for _ in args:
             self.sm.pop()
 
@@ -3708,8 +3744,8 @@ class _LoweringContext:
         runtime_arg_count = n_args - 1  # all except depth
         for i in range(runtime_arg_count):
             arg = args[i]
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
         # Pop all runtime args -- the codegen consumes them and produces 8 results
         for _ in range(runtime_arg_count):
             self.sm.pop()
@@ -3763,8 +3799,8 @@ class _LoweringContext:
         # Bring leaf, proof, index to stack top for the codegen
         for i in range(3):
             arg = args[i]
-            is_last = self._is_last_use(arg, binding_index, last_uses)
-            self.bring_to_top(arg, is_last)
+            consume = self._operand_consume(arg, args, binding_index, last_uses)
+            self.bring_to_top(arg, consume)
         # Pop the 3 args -- the codegen consumes them and produces 1 result
         for _ in range(3):
             self.sm.pop()

--- a/compilers/python/tests/test_repeated_operand_consume.py
+++ b/compilers/python/tests/test_repeated_operand_consume.py
@@ -1,0 +1,95 @@
+"""Repeated-operand consume bug (hand-written ANF via compile_from_ir / --ir).
+
+Mirrors packages/runar-compiler/src/__tests__/repeated-operand-consume.test.ts.
+
+A binding whose ANF value reads the SAME ref at more than one operand
+position used to make an independent last-use consume decision per load;
+a consume-mode bring_to_top of a ref already on top of the stack is a
+no-op, so `t := x + x` left a single stack slot for OP_ADD (underflow at
+runtime), or paired the opcode with the wrong slot when the ref was
+buried. Canonical rule: an operand load may consume (ROLL) its ref only
+when this binding is the ref's last use AND the ref occurs exactly once
+in the value's FULL operand list. Repeated refs copy (PICK / DUP) at
+every position. Unreachable from the frontend (pass 04 gives every
+operand a fresh temp); reachable via hand-written IR.
+"""
+
+from __future__ import annotations
+
+import json
+
+from runar_compiler.compiler import compile_from_ir_bytes
+
+
+def _program_json(params: list[str], body: list[dict]) -> bytes:
+    return json.dumps({
+        "contractName": "Repeat",
+        "properties": [{"name": "target", "type": "bigint", "readonly": True}],
+        "methods": [
+            {
+                "name": "unlock",
+                "params": [{"name": p, "type": "bigint"} for p in params],
+                "body": body,
+                "isPublic": True,
+            }
+        ],
+    }).encode("utf-8")
+
+
+class TestRepeatedOperandConsume:
+    def test_bin_op_same_ref_twice(self):
+        # unlock(x) { assert(x + x === target) }
+        ir = _program_json(["x"], [
+            {"name": "t0", "value": {"kind": "bin_op", "op": "+", "left": "x", "right": "x"}},
+            {"name": "t1", "value": {"kind": "load_prop", "name": "target"}},
+            {"name": "t2", "value": {"kind": "bin_op", "op": "===", "left": "t0", "right": "t1"}},
+            {"name": "t3", "value": {"kind": "assert", "value": "t2"}},
+        ])
+        artifact = compile_from_ir_bytes(ir, disable_constant_folding=True)
+        # Both loads of x must COPY: DUP DUP ADD <placeholder OP_0> NUMEQUAL NIP.
+        # Cross-tier canonical hex, byte-identical with the TS tier.
+        assert artifact.script == "767693009c77"
+
+    def test_call_same_ref_in_two_arg_positions(self):
+        # unlock(x) { assert(min(x, x) === target) }
+        ir = _program_json(["x"], [
+            {"name": "t0", "value": {"kind": "call", "func": "min", "args": ["x", "x"]}},
+            {"name": "t1", "value": {"kind": "load_prop", "name": "target"}},
+            {"name": "t2", "value": {"kind": "bin_op", "op": "===", "left": "t0", "right": "t1"}},
+            {"name": "t3", "value": {"kind": "assert", "value": "t2"}},
+        ])
+        artifact = compile_from_ir_bytes(ir, disable_constant_folding=True)
+        # DUP DUP MIN <placeholder OP_0> NUMEQUAL NIP
+        assert artifact.script == "7676a3009c77"
+
+    def test_repeated_ref_buried_below_live_slot(self):
+        # unlock(x, y) { assert(x + x + y === target) } — at t0 the stack is
+        # [x, y]: x sits at depth 1, so a naive rule pairs OP_ADD with the
+        # wrong slot instead of copying x twice.
+        ir = _program_json(["x", "y"], [
+            {"name": "t0", "value": {"kind": "bin_op", "op": "+", "left": "x", "right": "x"}},
+            {"name": "t1", "value": {"kind": "bin_op", "op": "+", "left": "t0", "right": "y"}},
+            {"name": "t2", "value": {"kind": "load_prop", "name": "target"}},
+            {"name": "t3", "value": {"kind": "bin_op", "op": "===", "left": "t1", "right": "t2"}},
+            {"name": "t4", "value": {"kind": "assert", "value": "t3"}},
+        ])
+        artifact = compile_from_ir_bytes(ir, disable_constant_folding=True)
+        # Both loads of x must COPY (OVER then DUP): the ADD must not consume
+        # x or pair with y. x is dead afterwards and is NIPped by the
+        # epilogue. Byte-identical with the TS tier:
+        # OVER DUP ADD SWAP ADD OP_0 NUMEQUAL NIP
+        assert artifact.script == "7876937c93009c77"
+
+    def test_distinct_refs_unchanged(self):
+        # Frontend-shaped ANF (fresh temp per operand) must not shift bytes.
+        ir = _program_json(["x"], [
+            {"name": "t0", "value": {"kind": "load_param", "name": "x"}},
+            {"name": "t1", "value": {"kind": "load_param", "name": "x"}},
+            {"name": "t2", "value": {"kind": "bin_op", "op": "+", "left": "t0", "right": "t1"}},
+            {"name": "t3", "value": {"kind": "load_prop", "name": "target"}},
+            {"name": "t4", "value": {"kind": "bin_op", "op": "===", "left": "t2", "right": "t3"}},
+            {"name": "t5", "value": {"kind": "assert", "value": "t4"}},
+        ])
+        artifact = compile_from_ir_bytes(ir, disable_constant_folding=True)
+        # DUP SWAP ADD <placeholder OP_0> NUMEQUAL — canonical frontend Dbl shape.
+        assert artifact.script == "767c93009c"

--- a/compilers/ruby/lib/runar_compiler/codegen/stack.rb
+++ b/compilers/ruby/lib/runar_compiler/codegen/stack.rb
@@ -1139,6 +1139,26 @@ module RunarCompiler::Codegen
       last <= current_index
     end
 
+    # Consume-vs-copy decision for one operand of a multi-operand ANF value.
+    #
+    # `operands` is the FULL operand-ref list of the value (including `ref`
+    # itself). The load may consume (ROLL / move) the ref only when this
+    # binding is the ref's last use AND the ref occurs exactly once in the
+    # operand list. A ref read at more than one operand position of the same
+    # value must be copied (PICK / DUP) at EVERY position: a consume-mode
+    # bring_to_top of a ref already on top of the stack is a no-op, so two
+    # consume-mode loads of the same ref would leave a single slot for an
+    # opcode that pops one item per operand (e.g. `t := x + x` underflowing
+    # OP_ADD), or silently pair the opcode with the wrong slot. The original
+    # then stays on the stack and the existing method epilogue cleans it up.
+    # Unreachable from the frontend (every operand gets a fresh temp);
+    # reachable via compile_from_ir hand-written ANF.
+    def _operand_consume(ref, operands, binding_index, last_uses)
+      return false unless _is_last_use(ref, binding_index, last_uses)
+
+      operands.count(ref) <= 1
+    end
+
     # -----------------------------------------------------------------
     # load_param
     # -----------------------------------------------------------------
@@ -1266,11 +1286,11 @@ module RunarCompiler::Codegen
     # -----------------------------------------------------------------
 
     def _lower_bin_op(binding_name, op, left, right, binding_index, last_uses, result_type)
-      left_is_last = _is_last_use(left, binding_index, last_uses)
-      bring_to_top(left, left_is_last)
+      left_consume = _operand_consume(left, [left, right], binding_index, last_uses)
+      bring_to_top(left, left_consume)
 
-      right_is_last = _is_last_use(right, binding_index, last_uses)
-      bring_to_top(right, right_is_last)
+      right_consume = _operand_consume(right, [left, right], binding_index, last_uses)
+      bring_to_top(right, right_consume)
 
       @sm.pop
       @sm.pop
@@ -1535,8 +1555,8 @@ module RunarCompiler::Codegen
 
       # General builtin: push args in order, then emit opcodes
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
 
       # Pop all args
@@ -1608,8 +1628,8 @@ module RunarCompiler::Codegen
         next unless i < method.params.length
 
         param_name = method.params[i].name
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
         @sm.pop
 
         # If param_name already exists on the stack, temporarily rename
@@ -2051,9 +2071,13 @@ module RunarCompiler::Codegen
       @sm.push(nil)
 
       # Bring each sig element to TOS in declaration order.
+      # A ref repeated across the combined element list (e.g. the same
+      # pubkey twice) must be copied at every position -- see _operand_consume.
+      msig_operands = sig_elems + pk_elems
+
       sig_elems.each do |sig|
-        is_last = _is_last_use(sig, binding_index, last_uses)
-        bring_to_top(sig, is_last)
+        consume = _operand_consume(sig, msig_operands, binding_index, last_uses)
+        bring_to_top(sig, consume)
       end
 
       # Push nSigs.
@@ -2062,8 +2086,8 @@ module RunarCompiler::Codegen
 
       # Bring each pubkey element to TOS in declaration order.
       pk_elems.each do |pk|
-        is_last = _is_last_use(pk, binding_index, last_uses)
-        bring_to_top(pk, is_last)
+        consume = _operand_consume(pk, msig_operands, binding_index, last_uses)
+        bring_to_top(pk, consume)
       end
 
       # Push nPKs.
@@ -2127,8 +2151,8 @@ module RunarCompiler::Codegen
 
       data, start, length = args[0], args[1], args[2]
 
-      bring_to_top(data, _is_last_use(data, binding_index, last_uses))
-      bring_to_top(start, _is_last_use(start, binding_index, last_uses))
+      bring_to_top(data, _operand_consume(data, args, binding_index, last_uses))
+      bring_to_top(start, _operand_consume(start, args, binding_index, last_uses))
 
       # Split at start position
       @sm.pop; @sm.pop
@@ -2143,7 +2167,7 @@ module RunarCompiler::Codegen
       @sm.push(right_part)
 
       # Push length
-      bring_to_top(length, _is_last_use(length, binding_index, last_uses))
+      bring_to_top(length, _operand_consume(length, args, binding_index, last_uses))
 
       # Split at length
       @sm.pop; @sm.pop
@@ -2162,8 +2186,8 @@ module RunarCompiler::Codegen
     def _lower_verify_wots(binding_name, args, binding_index, last_uses)
       require_relative "wots"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
       emit_fn = ->(op) { emit_op(op) }
@@ -2175,8 +2199,8 @@ module RunarCompiler::Codegen
     def _lower_verify_slh_dsa(binding_name, param_key, args, binding_index, last_uses)
       require_relative "slh_dsa"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
       emit_fn = ->(op) { emit_op(op) }
@@ -2188,8 +2212,8 @@ module RunarCompiler::Codegen
     def _lower_sha256_compress(binding_name, args, binding_index, last_uses)
       require_relative "sha256"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
       emit_fn = ->(op) { emit_op(op) }
@@ -2201,8 +2225,8 @@ module RunarCompiler::Codegen
     def _lower_sha256_finalize(binding_name, args, binding_index, last_uses)
       require_relative "sha256"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
       emit_fn = ->(op) { emit_op(op) }
@@ -2214,8 +2238,8 @@ module RunarCompiler::Codegen
     def _lower_blake3_compress(binding_name, args, binding_index, last_uses)
       require_relative "blake3"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
       emit_fn = ->(op) { emit_op(op) }
@@ -2227,8 +2251,8 @@ module RunarCompiler::Codegen
     def _lower_blake3_hash(binding_name, args, binding_index, last_uses)
       require_relative "blake3"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
       emit_fn = ->(op) { emit_op(op) }
@@ -2240,8 +2264,8 @@ module RunarCompiler::Codegen
     def _lower_ec_builtin(binding_name, func_name, args, binding_index, last_uses)
       require_relative "ec"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
 
@@ -2255,8 +2279,8 @@ module RunarCompiler::Codegen
     def _lower_nist_ec_builtin(binding_name, func_name, args, binding_index, last_uses)
       require_relative "p256_p384"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
 
@@ -2274,8 +2298,8 @@ module RunarCompiler::Codegen
       end
       # Bring all 3 args to top in order: msg, sig, pubkey
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       @sm.pop # pubkey
       @sm.pop # sig
@@ -2291,8 +2315,8 @@ module RunarCompiler::Codegen
     def _lower_bb_builtin(binding_name, func_name, args, binding_index, last_uses)
       require_relative "babybear"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
 
@@ -2306,8 +2330,8 @@ module RunarCompiler::Codegen
     def _lower_kb_builtin(binding_name, func_name, args, binding_index, last_uses)
       require_relative "koalabear"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
 
@@ -2321,8 +2345,8 @@ module RunarCompiler::Codegen
     def _lower_bn254_builtin(binding_name, func_name, args, binding_index, last_uses)
       require_relative "bn254"
       args.each do |arg|
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       args.length.times { @sm.pop }
 
@@ -2370,8 +2394,8 @@ module RunarCompiler::Codegen
       runtime_arg_count = n_args - 1 # all except depth
       runtime_arg_count.times do |i|
         arg = args[i]
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       # Pop all runtime args — the codegen consumes them and produces 8 results
       runtime_arg_count.times { @sm.pop }
@@ -2416,8 +2440,8 @@ module RunarCompiler::Codegen
       # Bring leaf, proof, index to stack top for the codegen
       3.times do |i|
         arg = args[i]
-        is_last = _is_last_use(arg, binding_index, last_uses)
-        bring_to_top(arg, is_last)
+        consume = _operand_consume(arg, args, binding_index, last_uses)
+        bring_to_top(arg, consume)
       end
       # Pop the 3 args -- the codegen consumes them and produces 1 result
       3.times { @sm.pop }
@@ -2438,10 +2462,10 @@ module RunarCompiler::Codegen
       # safediv(a, b) / safemod(a, b): assert b != 0, then div/mod
       raise "#{func_name} requires 2 arguments" if args.length < 2
 
-      is_last_a = _is_last_use(args[0], binding_index, last_uses)
-      bring_to_top(args[0], is_last_a)
-      is_last_b = _is_last_use(args[1], binding_index, last_uses)
-      bring_to_top(args[1], is_last_b)
+      consume_a = _operand_consume(args[0], args, binding_index, last_uses)
+      bring_to_top(args[0], consume_a)
+      consume_b = _operand_consume(args[1], args, binding_index, last_uses)
+      bring_to_top(args[1], consume_b)
 
       # DUP b, check non-zero, then divide/mod
       emit_opcode("OP_DUP"); @sm.push("")
@@ -2460,13 +2484,13 @@ module RunarCompiler::Codegen
       # clamp(val, lo, hi) -> min(max(val, lo), hi)
       raise "clamp requires 3 arguments" if args.length < 3
 
-      bring_to_top(args[0], _is_last_use(args[0], binding_index, last_uses))
-      bring_to_top(args[1], _is_last_use(args[1], binding_index, last_uses))
+      bring_to_top(args[0], _operand_consume(args[0], args, binding_index, last_uses))
+      bring_to_top(args[1], _operand_consume(args[1], args, binding_index, last_uses))
 
       @sm.pop; @sm.pop
       emit_opcode("OP_MAX"); @sm.push("")
 
-      bring_to_top(args[2], _is_last_use(args[2], binding_index, last_uses))
+      bring_to_top(args[2], _operand_consume(args[2], args, binding_index, last_uses))
 
       @sm.pop; @sm.pop
       emit_opcode("OP_MIN")
@@ -2478,10 +2502,10 @@ module RunarCompiler::Codegen
     def _lower_pow(binding_name, args, binding_index, last_uses)
       raise "pow requires 2 arguments" if args.length < 2
 
-      is_last_base = _is_last_use(args[0], binding_index, last_uses)
-      bring_to_top(args[0], is_last_base)
-      is_last_exp = _is_last_use(args[1], binding_index, last_uses)
-      bring_to_top(args[1], is_last_exp)
+      consume_base = _operand_consume(args[0], args, binding_index, last_uses)
+      bring_to_top(args[0], consume_base)
+      consume_exp = _operand_consume(args[1], args, binding_index, last_uses)
+      bring_to_top(args[1], consume_exp)
 
       @sm.pop; @sm.pop
 
@@ -2509,16 +2533,16 @@ module RunarCompiler::Codegen
     def _lower_mul_div(binding_name, args, binding_index, last_uses)
       raise "mulDiv requires 3 arguments" if args.length < 3
 
-      is_last_a = _is_last_use(args[0], binding_index, last_uses)
-      bring_to_top(args[0], is_last_a)
-      is_last_b = _is_last_use(args[1], binding_index, last_uses)
-      bring_to_top(args[1], is_last_b)
+      consume_a = _operand_consume(args[0], args, binding_index, last_uses)
+      bring_to_top(args[0], consume_a)
+      consume_b = _operand_consume(args[1], args, binding_index, last_uses)
+      bring_to_top(args[1], consume_b)
 
       @sm.pop; @sm.pop
       emit_opcode("OP_MUL"); @sm.push("")
 
-      is_last_c = _is_last_use(args[2], binding_index, last_uses)
-      bring_to_top(args[2], is_last_c)
+      consume_c = _operand_consume(args[2], args, binding_index, last_uses)
+      bring_to_top(args[2], consume_c)
 
       @sm.pop; @sm.pop
       emit_opcode("OP_DIV")
@@ -2531,10 +2555,10 @@ module RunarCompiler::Codegen
       # percentOf(amount, bps) -> (amount * bps) / 10000
       raise "percentOf requires 2 arguments" if args.length < 2
 
-      is_last_a = _is_last_use(args[0], binding_index, last_uses)
-      bring_to_top(args[0], is_last_a)
-      is_last_b = _is_last_use(args[1], binding_index, last_uses)
-      bring_to_top(args[1], is_last_b)
+      consume_a = _operand_consume(args[0], args, binding_index, last_uses)
+      bring_to_top(args[0], consume_a)
+      consume_b = _operand_consume(args[1], args, binding_index, last_uses)
+      bring_to_top(args[1], consume_b)
 
       @sm.pop; @sm.pop
       emit_opcode("OP_MUL"); @sm.push("")
@@ -2582,10 +2606,10 @@ module RunarCompiler::Codegen
     def _lower_gcd(binding_name, args, binding_index, last_uses)
       raise "gcd requires 2 arguments" if args.length < 2
 
-      is_last_a = _is_last_use(args[0], binding_index, last_uses)
-      bring_to_top(args[0], is_last_a)
-      is_last_b = _is_last_use(args[1], binding_index, last_uses)
-      bring_to_top(args[1], is_last_b)
+      consume_a = _operand_consume(args[0], args, binding_index, last_uses)
+      bring_to_top(args[0], consume_a)
+      consume_b = _operand_consume(args[1], args, binding_index, last_uses)
+      bring_to_top(args[1], consume_b)
 
       @sm.pop; @sm.pop
 
@@ -2614,10 +2638,10 @@ module RunarCompiler::Codegen
     def _lower_divmod(binding_name, args, binding_index, last_uses)
       raise "divmod requires 2 arguments" if args.length < 2
 
-      is_last_a = _is_last_use(args[0], binding_index, last_uses)
-      bring_to_top(args[0], is_last_a)
-      is_last_b = _is_last_use(args[1], binding_index, last_uses)
-      bring_to_top(args[1], is_last_b)
+      consume_a = _operand_consume(args[0], args, binding_index, last_uses)
+      bring_to_top(args[0], consume_a)
+      consume_b = _operand_consume(args[1], args, binding_index, last_uses)
+      bring_to_top(args[1], consume_b)
 
       @sm.pop; @sm.pop
 
@@ -2687,10 +2711,10 @@ module RunarCompiler::Codegen
     def _lower_right(binding_name, args, binding_index, last_uses)
       # right(bs, n) -> last n bytes of bs
       if args.length >= 2
-        is_last_bs = _is_last_use(args[0], binding_index, last_uses)
-        bring_to_top(args[0], is_last_bs)
-        is_last_n = _is_last_use(args[1], binding_index, last_uses)
-        bring_to_top(args[1], is_last_n)
+        consume_bs = _operand_consume(args[0], args, binding_index, last_uses)
+        bring_to_top(args[0], consume_bs)
+        consume_n = _operand_consume(args[1], args, binding_index, last_uses)
+        bring_to_top(args[1], consume_n)
 
         # Stack: [bs, n]
         # Compute skip = SIZE - n, then SPLIT, NIP
@@ -3164,6 +3188,7 @@ module RunarCompiler::Codegen
 
     def _lower_add_output(binding_name, satoshis, state_values, _preimage, binding_index, last_uses)
       state_props = @properties.reject(&:readonly)
+      output_operands = [satoshis] + state_values
 
       # Step 1: Bring _codePart to top (PICK -- never consume)
       bring_to_top("_codePart", false)
@@ -3178,8 +3203,8 @@ module RunarCompiler::Codegen
         value_ref = state_values[i]
         prop = state_props[i]
 
-        is_last = _is_last_use(value_ref, binding_index, last_uses)
-        bring_to_top(value_ref, is_last)
+        consume = _operand_consume(value_ref, output_operands, binding_index, last_uses)
+        bring_to_top(value_ref, consume)
 
         if prop.type == "bigint"
           emit_push_int(8); @sm.push("")
@@ -3205,8 +3230,8 @@ module RunarCompiler::Codegen
       emit_opcode("OP_CAT"); @sm.push("")
 
       # Step 6: Prepend satoshis as 8-byte LE
-      is_last_sat = _is_last_use(satoshis, binding_index, last_uses)
-      bring_to_top(satoshis, is_last_sat)
+      sat_consume = _operand_consume(satoshis, output_operands, binding_index, last_uses)
+      bring_to_top(satoshis, sat_consume)
       emit_push_int(8); @sm.push("")
       emit_opcode("OP_NUM2BIN"); @sm.pop
       emit_op({ op: "swap" }); @sm.swap
@@ -3224,8 +3249,8 @@ module RunarCompiler::Codegen
 
     def _lower_add_raw_output(binding_name, satoshis, script_bytes, binding_index, last_uses)
       # Step 1: Bring scriptBytes to top
-      script_is_last = _is_last_use(script_bytes, binding_index, last_uses)
-      bring_to_top(script_bytes, script_is_last)
+      script_consume = _operand_consume(script_bytes, [satoshis, script_bytes], binding_index, last_uses)
+      bring_to_top(script_bytes, script_consume)
 
       # Step 2: Compute varint prefix for script length
       emit_opcode("OP_SIZE"); @sm.push("")
@@ -3237,8 +3262,8 @@ module RunarCompiler::Codegen
       emit_opcode("OP_CAT"); @sm.push("")
 
       # Step 4: Prepend satoshis as 8-byte LE
-      sat_is_last = _is_last_use(satoshis, binding_index, last_uses)
-      bring_to_top(satoshis, sat_is_last)
+      sat_consume = _operand_consume(satoshis, [satoshis, script_bytes], binding_index, last_uses)
+      bring_to_top(satoshis, sat_consume)
       emit_push_int(8); @sm.push("")
       emit_opcode("OP_NUM2BIN"); @sm.pop
       emit_op({ op: "swap" }); @sm.swap
@@ -3302,12 +3327,12 @@ module RunarCompiler::Codegen
       state_bytes_ref = args[1]
 
       # Bring stateBytes to stack first
-      state_last = _is_last_use(state_bytes_ref, binding_index, last_uses)
-      bring_to_top(state_bytes_ref, state_last)
+      state_consume = _operand_consume(state_bytes_ref, [preimage_ref, state_bytes_ref], binding_index, last_uses)
+      bring_to_top(state_bytes_ref, state_consume)
 
       # Extract amount from preimage for the continuation output
-      pre_last = _is_last_use(preimage_ref, binding_index, last_uses)
-      bring_to_top(preimage_ref, pre_last)
+      pre_consume = _operand_consume(preimage_ref, [preimage_ref, state_bytes_ref], binding_index, last_uses)
+      bring_to_top(preimage_ref, pre_consume)
 
       # Extract amount: last 52 bytes, take 8 bytes at offset 0
       emit_opcode("OP_SIZE"); @sm.push("")
@@ -3363,21 +3388,23 @@ module RunarCompiler::Codegen
       state_bytes_ref = args[1]
       new_amount_ref = args[2]
 
+      cso_operands = [preimage_ref, state_bytes_ref, new_amount_ref]
+
       # Consume preimage ref (no longer needed)
-      pre_last = _is_last_use(preimage_ref, binding_index, last_uses)
-      bring_to_top(preimage_ref, pre_last)
+      pre_consume = _operand_consume(preimage_ref, cso_operands, binding_index, last_uses)
+      bring_to_top(preimage_ref, pre_consume)
       emit_op({ op: "drop" }); @sm.pop
 
       # Step 1: Convert _newAmount to 8-byte LE and save to altstack
-      amount_last = _is_last_use(new_amount_ref, binding_index, last_uses)
-      bring_to_top(new_amount_ref, amount_last)
+      amount_consume = _operand_consume(new_amount_ref, cso_operands, binding_index, last_uses)
+      bring_to_top(new_amount_ref, amount_consume)
       emit_push_int(8); @sm.push("")
       emit_opcode("OP_NUM2BIN"); @sm.pop; @sm.pop; @sm.push("")
       emit_opcode("OP_TOALTSTACK"); @sm.pop
 
       # Step 2: Bring stateBytes to stack
-      state_last = _is_last_use(state_bytes_ref, binding_index, last_uses)
-      bring_to_top(state_bytes_ref, state_last)
+      state_consume = _operand_consume(state_bytes_ref, cso_operands, binding_index, last_uses)
+      bring_to_top(state_bytes_ref, state_consume)
 
       # Step 3: Bring _codePart to top (PICK -- never consume)
       bring_to_top("_codePart", false)
@@ -3421,7 +3448,7 @@ module RunarCompiler::Codegen
       @sm.push("")
 
       # Push the 20-byte PKH
-      bring_to_top(pkh_ref, _is_last_use(pkh_ref, binding_index, last_uses))
+      bring_to_top(pkh_ref, _operand_consume(pkh_ref, [pkh_ref, amount_ref], binding_index, last_uses))
       # CAT: prefix || pkh
       emit_opcode("OP_CAT"); @sm.pop; @sm.pop; @sm.push("")
 
@@ -3432,7 +3459,7 @@ module RunarCompiler::Codegen
       emit_opcode("OP_CAT"); @sm.pop; @sm.pop; @sm.push("")
 
       # Step 2: Prepend amount as 8-byte LE
-      bring_to_top(amount_ref, _is_last_use(amount_ref, binding_index, last_uses))
+      bring_to_top(amount_ref, _operand_consume(amount_ref, [pkh_ref, amount_ref], binding_index, last_uses))
       emit_push_int(8); @sm.push("")
       emit_opcode("OP_NUM2BIN"); @sm.pop
       emit_op({ op: "swap" }); @sm.swap
@@ -3453,7 +3480,7 @@ module RunarCompiler::Codegen
       require_relative "rabin"
 
       args.each do |arg|
-        bring_to_top(arg, _is_last_use(arg, binding_index, last_uses))
+        bring_to_top(arg, _operand_consume(arg, args, binding_index, last_uses))
       end
 
       4.times { @sm.pop }

--- a/compilers/ruby/test/test_repeated_operand_consume.rb
+++ b/compilers/ruby/test/test_repeated_operand_consume.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Repeated-operand consume bug (hand-written ANF via compile_from_ir / --ir).
+#
+# Mirrors packages/runar-compiler/src/__tests__/repeated-operand-consume.test.ts.
+#
+# A binding whose ANF value reads the SAME ref at more than one operand
+# position used to make an independent last-use consume decision per load; a
+# consume-mode bring_to_top of a ref already on top of the stack is a no-op,
+# so `t := x + x` left a single stack slot for OP_ADD (underflow at runtime),
+# or paired the opcode with the wrong slot when the ref was buried. Canonical
+# rule: an operand load may consume (ROLL) its ref only when this binding is
+# the ref's last use AND the ref occurs exactly once in the value's FULL
+# operand list. Repeated refs copy (PICK / DUP) at every position.
+# Unreachable from the frontend (every operand gets a fresh temp); reachable
+# via hand-written IR.
+
+require_relative "test_helper"
+require "json"
+
+class TestRepeatedOperandConsume < Minitest::Test
+  def program_json(params, body)
+    JSON.generate(
+      "contractName" => "Repeat",
+      "properties" => [{ "name" => "target", "type" => "bigint", "readonly" => true }],
+      "methods" => [
+        {
+          "name" => "unlock",
+          "params" => params.map { |p| { "name" => p, "type" => "bigint" } },
+          "body" => body,
+          "isPublic" => true
+        }
+      ]
+    )
+  end
+
+  def compile_ir(json)
+    RunarCompiler.compile_from_ir_bytes(json, disable_constant_folding: true)
+  end
+
+  def test_bin_op_same_ref_twice
+    # unlock(x) { assert(x + x === target) }
+    ir = program_json(["x"], [
+      { "name" => "t0", "value" => { "kind" => "bin_op", "op" => "+", "left" => "x", "right" => "x" } },
+      { "name" => "t1", "value" => { "kind" => "load_prop", "name" => "target" } },
+      { "name" => "t2", "value" => { "kind" => "bin_op", "op" => "===", "left" => "t0", "right" => "t1" } },
+      { "name" => "t3", "value" => { "kind" => "assert", "value" => "t2" } }
+    ])
+    artifact = compile_ir(ir)
+    # Both loads of x must COPY: DUP DUP ADD <placeholder OP_0> NUMEQUAL NIP.
+    # Cross-tier canonical hex, byte-identical with the TS tier.
+    assert_equal "767693009c77", artifact.script
+  end
+
+  def test_call_same_ref_in_two_arg_positions
+    # unlock(x) { assert(min(x, x) === target) }
+    ir = program_json(["x"], [
+      { "name" => "t0", "value" => { "kind" => "call", "func" => "min", "args" => %w[x x] } },
+      { "name" => "t1", "value" => { "kind" => "load_prop", "name" => "target" } },
+      { "name" => "t2", "value" => { "kind" => "bin_op", "op" => "===", "left" => "t0", "right" => "t1" } },
+      { "name" => "t3", "value" => { "kind" => "assert", "value" => "t2" } }
+    ])
+    artifact = compile_ir(ir)
+    # DUP DUP MIN <placeholder OP_0> NUMEQUAL NIP
+    assert_equal "7676a3009c77", artifact.script
+  end
+
+  def test_repeated_ref_buried_below_live_slot
+    # unlock(x, y) { assert(x + x + y === target) } -- at t0 the stack is
+    # [x, y]: x sits at depth 1, so a naive rule pairs OP_ADD with the wrong
+    # slot instead of copying x twice.
+    ir = program_json(%w[x y], [
+      { "name" => "t0", "value" => { "kind" => "bin_op", "op" => "+", "left" => "x", "right" => "x" } },
+      { "name" => "t1", "value" => { "kind" => "bin_op", "op" => "+", "left" => "t0", "right" => "y" } },
+      { "name" => "t2", "value" => { "kind" => "load_prop", "name" => "target" } },
+      { "name" => "t3", "value" => { "kind" => "bin_op", "op" => "===", "left" => "t1", "right" => "t2" } },
+      { "name" => "t4", "value" => { "kind" => "assert", "value" => "t3" } }
+    ])
+    artifact = compile_ir(ir)
+    # OVER DUP ADD SWAP ADD OP_0 NUMEQUAL NIP -- byte-identical with TS.
+    assert_equal "7876937c93009c77", artifact.script
+  end
+
+  def test_distinct_refs_unchanged
+    # Frontend-shaped ANF (fresh temp per operand) must not shift bytes.
+    ir = program_json(["x"], [
+      { "name" => "t0", "value" => { "kind" => "load_param", "name" => "x" } },
+      { "name" => "t1", "value" => { "kind" => "load_param", "name" => "x" } },
+      { "name" => "t2", "value" => { "kind" => "bin_op", "op" => "+", "left" => "t0", "right" => "t1" } },
+      { "name" => "t3", "value" => { "kind" => "load_prop", "name" => "target" } },
+      { "name" => "t4", "value" => { "kind" => "bin_op", "op" => "===", "left" => "t2", "right" => "t3" } },
+      { "name" => "t5", "value" => { "kind" => "assert", "value" => "t4" } }
+    ])
+    artifact = compile_ir(ir)
+    # DUP SWAP ADD <placeholder OP_0> NUMEQUAL -- canonical frontend Dbl shape.
+    assert_equal "767c93009c", artifact.script
+  end
+end

--- a/compilers/zig/src/passes/stack_lower.zig
+++ b/compilers/zig/src/passes/stack_lower.zig
@@ -477,6 +477,34 @@ const LowerCtx = struct {
         try self.bringToTop(name, consume);
     }
 
+    /// Consume-vs-copy decision for one operand of a multi-operand ANF value.
+    ///
+    /// `operands` is the FULL operand-ref list of the value (including `name`
+    /// itself). The load may consume (ROLL / move) the ref only when this
+    /// binding is the ref's last use AND the ref occurs exactly once in the
+    /// operand list. A ref read at more than one operand position of the same
+    /// value must be copied (PICK / DUP) at EVERY position: a consume-mode
+    /// bringToTop of a ref already on top of the stack is a no-op, so two
+    /// consume-mode loads of the same ref would leave a single slot for an
+    /// opcode that pops one item per operand (e.g. `t := x + x` underflowing
+    /// OP_ADD), or silently pair the opcode with the wrong slot. The original
+    /// then stays on the stack and the existing method epilogue cleans it up.
+    /// Unreachable from the frontend (every operand gets a fresh temp);
+    /// reachable via compile-ir hand-written ANF.
+    fn operandConsume(self: *const LowerCtx, name: []const u8, operands: []const []const u8) bool {
+        if (!self.isLastUse(name)) return false;
+        var occurrences: usize = 0;
+        for (operands) |o| {
+            if (std.mem.eql(u8, o, name)) occurrences += 1;
+        }
+        return occurrences <= 1;
+    }
+
+    /// bringToTop with the repeated-operand-aware consume decision.
+    fn bringToTopOperand(self: *LowerCtx, name: []const u8, operands: []const []const u8) !void {
+        try self.bringToTop(name, self.operandConsume(name, operands));
+    }
+
     /// Drain branch-private residue from below TOS at the end of a branch
     /// body, so both branches converge to a layout the parent stack model can
     /// faithfully describe before OP_ENDIF (issue #36).
@@ -1032,7 +1060,7 @@ const LowerCtx = struct {
         for (args, 0..) |arg, idx| {
             if (idx >= method.params.len) break;
             const param_name = method.params[idx].name;
-            const consume = self.isLastUse(arg);
+            const consume = self.operandConsume(arg, args);
             try self.bringToTop(arg, consume);
             _ = self.stack.pop();
 
@@ -1224,8 +1252,9 @@ const LowerCtx = struct {
     }
 
     fn lowerBinaryOp(self: *LowerCtx, bind_name: []const u8, bop: types.ANFBinaryOp) !void {
-        try self.bringToTopAuto(bop.left);
-        try self.bringToTopAuto(bop.right);
+        const bin_operands = [_][]const u8{ bop.left, bop.right };
+        try self.bringToTopOperand(bop.left, &bin_operands);
+        try self.bringToTopOperand(bop.right, &bin_operands);
 
         const is_bytes = if (bop.result_type) |t| std.mem.eql(u8, t, "bytes") else false;
 
@@ -1674,7 +1703,7 @@ const LowerCtx = struct {
             // Wave 3 placeholders — consume args and push placeholder
             .ecPairing, .schnorrVerify => {
                 for (args) |arg| {
-                    try self.bringToTopAuto(arg);
+                    try self.bringToTopOperand(arg, args);
                     _ = self.stack.pop();
                 }
                 try self.emitPushInt(0);
@@ -1688,7 +1717,7 @@ const LowerCtx = struct {
         if (args.len < crypto_builtins.requiredArgCount(builtin)) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -1720,7 +1749,7 @@ const LowerCtx = struct {
         if (args.len < sha256_emitters.requiredArgCount(builtin)) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -1758,7 +1787,7 @@ const LowerCtx = struct {
         if (args.len < crypto_builtins.requiredArgCount(builtin)) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -1790,7 +1819,7 @@ const LowerCtx = struct {
         if (args.len < crypto_builtins.requiredArgCount(builtin)) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -1867,7 +1896,7 @@ const LowerCtx = struct {
         if (args.len < crypto_builtins.requiredArgCount(builtin)) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -1892,7 +1921,7 @@ const LowerCtx = struct {
         if (args.len < crypto_builtins.requiredArgCount(builtin)) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -1922,7 +1951,7 @@ const LowerCtx = struct {
         if (args.len < required) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -1952,7 +1981,7 @@ const LowerCtx = struct {
         if (args.len < required) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -1980,7 +2009,7 @@ const LowerCtx = struct {
         if (args.len < required) return LowerError.InvalidBuiltin;
 
         for (args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (args) |_| {
             _ = self.stack.pop();
@@ -2024,7 +2053,7 @@ const LowerCtx = struct {
         // Bring remaining args to the stack top.
         const runtime_args = args[0 .. args.len - 1];
         for (runtime_args) |arg| {
-            try self.bringToTopAuto(arg);
+            try self.bringToTopOperand(arg, args);
         }
         for (runtime_args) |_| {
             _ = self.stack.pop();
@@ -2070,7 +2099,7 @@ const LowerCtx = struct {
 
         // Bring leaf, proof, index to stack top for the codegen
         for (0..3) |i| {
-            try self.bringToTopAuto(args[i]);
+            try self.bringToTopOperand(args[i], args);
         }
         // Pop the 3 args -- the codegen consumes them and produces 1 result
         for (0..3) |_| {
@@ -2122,8 +2151,8 @@ const LowerCtx = struct {
 
     fn lowerSimpleBinaryBuiltin(self: *LowerCtx, bind_name: []const u8, args: []const []const u8, op: Opcode) !void {
         if (args.len < 2) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
         try self.emitOp(op);
         _ = self.stack.pop();
         _ = self.stack.pop();
@@ -2162,9 +2191,14 @@ const LowerCtx = struct {
         try self.emitPushInt(0);
         try self.stack.push(self.allocator, null);
 
+        // A ref repeated across the combined element list (e.g. the same
+        // pubkey twice) must be copied at every position — see operandConsume.
+        const msig_operands = try std.mem.concat(self.allocator, []const u8, &.{ sig_elems, pk_elems });
+        defer self.allocator.free(msig_operands);
+
         // Bring each sig element to TOS in declaration order.
         for (sig_elems) |sig| {
-            const consume = self.isLastUse(sig);
+            const consume = self.operandConsume(sig, msig_operands);
             try self.bringToTop(sig, consume);
         }
 
@@ -2174,7 +2208,7 @@ const LowerCtx = struct {
 
         // Bring each pubkey element to TOS in declaration order.
         for (pk_elems) |pk| {
-            const consume = self.isLastUse(pk);
+            const consume = self.operandConsume(pk, msig_operands);
             try self.bringToTop(pk, consume);
         }
 
@@ -2213,9 +2247,9 @@ const LowerCtx = struct {
 
     fn lowerWithin(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 3) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
-        try self.bringToTopAuto(args[2]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
+        try self.bringToTopOperand(args[2], args);
         try self.emitOp(.op_within);
         _ = self.stack.pop();
         _ = self.stack.pop();
@@ -2234,8 +2268,8 @@ const LowerCtx = struct {
 
     fn lowerSplit(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 2) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]); // data
-        try self.bringToTopAuto(args[1]); // position
+        try self.bringToTopOperand(args[0], args); // data
+        try self.bringToTopOperand(args[1], args); // position
         try self.emitOp(.op_split);
         // OP_SPLIT consumes data + position, produces left + right (two outputs)
         _ = self.stack.pop();
@@ -2247,8 +2281,8 @@ const LowerCtx = struct {
 
     fn lowerLeft(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 2) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]); // data
-        try self.bringToTopAuto(args[1]); // length
+        try self.bringToTopOperand(args[0], args); // data
+        try self.bringToTopOperand(args[1], args); // length
         try self.emitOp(.op_split);
         try self.emitOp(.op_drop); // drop right, keep left
         _ = self.stack.pop();
@@ -2259,8 +2293,8 @@ const LowerCtx = struct {
 
     fn lowerSubstr(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 3) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]); // s
-        try self.bringToTopAuto(args[1]); // start
+        try self.bringToTopOperand(args[0], args); // s
+        try self.bringToTopOperand(args[1], args); // start
         try self.emitOp(.op_split);
         try self.emitOp(.op_nip); // drop left, keep right
         _ = self.stack.pop();
@@ -2268,7 +2302,7 @@ const LowerCtx = struct {
         try self.stack.push(self.allocator, null);
         self.trackDepth();
 
-        try self.bringToTopAuto(args[2]); // length
+        try self.bringToTopOperand(args[2], args); // length
         try self.emitOp(.op_split);
         try self.emitOp(.op_drop); // drop rest, keep substr
         _ = self.stack.pop();
@@ -2289,8 +2323,8 @@ const LowerCtx = struct {
 
     fn lowerSafeDivMod(self: *LowerCtx, bind_name: []const u8, args: []const []const u8, final_op: Opcode) !void {
         if (args.len < 2) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
         try self.emitOp(.op_dup);
         try self.emitOp(.op_0notequal);
         try self.emitOp(.op_verify);
@@ -2311,8 +2345,8 @@ const LowerCtx = struct {
 
     fn lowerPow(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 2) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
         _ = self.stack.pop();
         _ = self.stack.pop();
 
@@ -2338,14 +2372,14 @@ const LowerCtx = struct {
 
     fn lowerMulDiv(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 3) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
         try self.emitOp(.op_mul);
         _ = self.stack.pop();
         _ = self.stack.pop();
         try self.stack.push(self.allocator, null);
         self.trackDepth();
-        try self.bringToTopAuto(args[2]);
+        try self.bringToTopOperand(args[2], args);
         try self.emitOp(.op_div);
         _ = self.stack.pop();
         _ = self.stack.pop();
@@ -2355,8 +2389,8 @@ const LowerCtx = struct {
 
     fn lowerPercentOf(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 2) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
         _ = self.stack.pop();
         _ = self.stack.pop();
         try self.emitOp(.op_mul);
@@ -2392,8 +2426,8 @@ const LowerCtx = struct {
 
     fn lowerGcd(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 2) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
         _ = self.stack.pop();
         _ = self.stack.pop();
         try self.emitOp(.op_abs);
@@ -2442,8 +2476,8 @@ const LowerCtx = struct {
         // different intermediate stack shape, breaking byte-level parity
         // with the other 6 tiers (caught by the math-demo conformance
         // fixture once the divmod method was added).
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
         _ = self.stack.pop();
         _ = self.stack.pop();
         try self.emitOp(.op_2dup);
@@ -2483,14 +2517,14 @@ const LowerCtx = struct {
 
     fn lowerClamp(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 3) return LowerError.InvalidBuiltin;
-        try self.bringToTopAuto(args[0]);
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[0], args);
+        try self.bringToTopOperand(args[1], args);
         try self.emitOp(.op_max);
         _ = self.stack.pop();
         _ = self.stack.pop();
         try self.stack.push(self.allocator, null);
         self.trackDepth();
-        try self.bringToTopAuto(args[2]);
+        try self.bringToTopOperand(args[2], args);
         try self.emitOp(.op_min);
         _ = self.stack.pop();
         _ = self.stack.pop();
@@ -2784,7 +2818,7 @@ const LowerCtx = struct {
         if (args.len < 2) return LowerError.InvalidBuiltin;
         try self.emitPushData(&stateful_templates.p2pkh_prefix_with_len);
         try self.stack.push(self.allocator, null);
-        try self.bringToTopAuto(args[0]);
+        try self.bringToTopOperand(args[0], args);
         try self.emitOp(.op_cat);
         _ = self.stack.pop();
         _ = self.stack.pop();
@@ -2797,7 +2831,7 @@ const LowerCtx = struct {
         _ = self.stack.pop();
         try self.stack.push(self.allocator, null);
 
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[1], args);
         try self.emitPushInt(8);
         try self.stack.push(self.allocator, null);
         try self.emitOp(.op_num2bin);
@@ -3333,11 +3367,11 @@ const LowerCtx = struct {
     fn lowerComputeStateOutput(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 3) return LowerError.InvalidBuiltin;
 
-        try self.bringToTopAuto(args[0]);
+        try self.bringToTopOperand(args[0], args);
         try self.emitOp(.op_drop);
         _ = self.stack.pop();
 
-        try self.bringToTopAuto(args[2]);
+        try self.bringToTopOperand(args[2], args);
         try self.emitPushInt(8);
         try self.stack.push(self.allocator, null);
         try self.emitOp(.op_num2bin);
@@ -3347,7 +3381,7 @@ const LowerCtx = struct {
         try self.emitOp(.op_toaltstack);
         _ = self.stack.pop();
 
-        try self.bringToTopAuto(args[1]);
+        try self.bringToTopOperand(args[1], args);
         try self.bringToTop("_codePart", false);
 
         try self.emitPushData(&stateful_templates.op_return_byte);
@@ -3398,8 +3432,8 @@ const LowerCtx = struct {
     fn lowerComputeStateOutputHash(self: *LowerCtx, bind_name: []const u8, args: []const []const u8) !void {
         if (args.len < 2) return LowerError.InvalidBuiltin;
 
-        try self.bringToTopAuto(args[1]);
-        try self.bringToTopAuto(args[0]);
+        try self.bringToTopOperand(args[1], args);
+        try self.bringToTopOperand(args[0], args);
 
         try self.emitOp(.op_size);
         try self.stack.push(self.allocator, null);
@@ -4054,6 +4088,13 @@ const LowerCtx = struct {
     // ========================================================================
 
     fn lowerAddOutput(self: *LowerCtx, bind_name: []const u8, ao: types.ANFAddOutput) !void {
+        const output_operands = try std.mem.concat(
+            self.allocator,
+            []const u8,
+            &.{ &.{ao.satoshis}, ao.state_values },
+        );
+        defer self.allocator.free(output_operands);
+
         var state_prop_count: usize = 0;
         for (self.program.properties) |prop| {
             if (!prop.readonly) state_prop_count += 1;
@@ -4075,7 +4116,7 @@ const LowerCtx = struct {
             const value_ref = ao.state_values[state_index];
             state_index += 1;
 
-            try self.bringToTopAuto(value_ref);
+            try self.bringToTopOperand(value_ref, output_operands);
             if (isNumericStateType(prop.type_info)) {
                 const width: i64 = if (prop.type_info == .boolean) 1 else 8;
                 try self.emitPushInt(width);
@@ -4108,7 +4149,7 @@ const LowerCtx = struct {
         try self.stack.push(self.allocator, null);
         self.trackDepth();
 
-        try self.bringToTopAuto(ao.satoshis);
+        try self.bringToTopOperand(ao.satoshis, output_operands);
         try self.emitPushInt(8);
         try self.stack.push(self.allocator, null);
         try self.emitOp(.op_num2bin);
@@ -4126,7 +4167,7 @@ const LowerCtx = struct {
     }
 
     fn lowerAddRawOutput(self: *LowerCtx, bind_name: []const u8, aro: types.ANFAddRawOutput) !void {
-        try self.bringToTopAuto(aro.script_bytes);
+        try self.bringToTopOperand(aro.script_bytes, &.{ aro.satoshis, aro.script_bytes });
         try self.emitOp(.op_size);
         try self.stack.push(self.allocator, null);
         try self.emitVarintEncoding();
@@ -4141,7 +4182,7 @@ const LowerCtx = struct {
         try self.stack.push(self.allocator, null);
         self.trackDepth();
 
-        try self.bringToTopAuto(aro.satoshis);
+        try self.bringToTopOperand(aro.satoshis, &.{ aro.satoshis, aro.script_bytes });
         try self.emitPushInt(8);
         try self.stack.push(self.allocator, null);
         try self.emitOp(.op_num2bin);

--- a/compilers/zig/src/test_main.zig
+++ b/compilers/zig/src/test_main.zig
@@ -27,6 +27,7 @@ test {
     _ = @import("passes/constant_fold.zig");
     _ = @import("passes/ec_optimizer.zig");
     _ = @import("tests/e2e.zig");
+    _ = @import("tests/repeated_operand_consume.zig");
     _ = @import("tests/math_builtins.zig");
     _ = @import("tests/hash_builtins.zig");
     _ = @import("tests/check_multisig.zig");

--- a/compilers/zig/src/tests/repeated_operand_consume.zig
+++ b/compilers/zig/src/tests/repeated_operand_consume.zig
@@ -1,0 +1,159 @@
+//! Repeated-operand consume bug (hand-written ANF via compile-ir).
+//!
+//! Mirrors packages/runar-compiler/src/__tests__/repeated-operand-consume.test.ts.
+//!
+//! A binding whose ANF value reads the SAME ref at more than one operand
+//! position used to make an independent last-use consume decision per load;
+//! a consume-mode bringToTop of a ref already on top of the stack is a
+//! no-op, so `t := x + x` left a single stack slot for OP_ADD (underflow at
+//! runtime), or paired the opcode with the wrong slot when the ref was
+//! buried. Canonical rule: an operand load may consume (ROLL) its ref only
+//! when this binding is the ref's last use AND the ref occurs exactly once
+//! in the value's FULL operand list. Repeated refs copy (PICK / DUP) at
+//! every position. Unreachable from the frontend (every operand gets a
+//! fresh temp); reachable via hand-written IR.
+
+const std = @import("std");
+const json_parser = @import("../ir/json.zig");
+const types = @import("../ir/types.zig");
+const stack_lower = @import("../passes/stack_lower.zig");
+const peephole = @import("../passes/peephole.zig");
+const emit = @import("../codegen/emit.zig");
+
+/// Mirror main.zig's compileFromIR --hex pipeline:
+/// parse ANF JSON -> stack lower -> peephole -> emitArtifact -> "script" hex.
+fn compileIrToHex(allocator: std.mem.Allocator, json: []const u8) ![]const u8 {
+    const program = try json_parser.parseANFProgram(allocator, json);
+    const stack_program = try stack_lower.lower(allocator, program);
+    const optimized_methods = try peephole.optimize(allocator, stack_program.methods);
+    const optimized_stack_program = types.StackProgram{
+        .methods = optimized_methods,
+        .contract_name = stack_program.contract_name,
+        .properties = stack_program.properties,
+        .constructor_params = stack_program.constructor_params,
+    };
+    const artifact = try emit.emitArtifact(allocator, optimized_stack_program, program);
+    const marker = "\"script\":\"";
+    const idx = std.mem.indexOf(u8, artifact, marker) orelse return error.MissingHex;
+    const after = idx + marker.len;
+    const end = std.mem.indexOfPos(u8, artifact, after, "\"") orelse return error.MissingHex;
+    return artifact[after..end];
+}
+
+test "bin_op with the same ref twice: t := x + x" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // unlock(x) { assert(x + x === target) }
+    const json =
+        \\{
+        \\  "contractName": "Repeat",
+        \\  "properties": [{"name": "target", "type": "bigint", "readonly": true}],
+        \\  "methods": [{
+        \\    "name": "unlock",
+        \\    "params": [{"name": "x", "type": "bigint"}],
+        \\    "body": [
+        \\      {"name": "t0", "value": {"kind": "bin_op", "op": "+", "left": "x", "right": "x"}},
+        \\      {"name": "t1", "value": {"kind": "load_prop", "name": "target"}},
+        \\      {"name": "t2", "value": {"kind": "bin_op", "op": "===", "left": "t0", "right": "t1"}},
+        \\      {"name": "t3", "value": {"kind": "assert", "value": "t2"}}
+        \\    ],
+        \\    "isPublic": true
+        \\  }]
+        \\}
+    ;
+    const hex = try compileIrToHex(a, json);
+    // Both loads of x must COPY: DUP DUP ADD <placeholder OP_0> NUMEQUAL NIP.
+    // Cross-tier canonical hex, byte-identical with the TS tier.
+    try std.testing.expectEqualStrings("767693009c77", hex);
+}
+
+test "call with the same ref in two argument positions: min(x, x)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // unlock(x) { assert(min(x, x) === target) }
+    const json =
+        \\{
+        \\  "contractName": "Repeat",
+        \\  "properties": [{"name": "target", "type": "bigint", "readonly": true}],
+        \\  "methods": [{
+        \\    "name": "unlock",
+        \\    "params": [{"name": "x", "type": "bigint"}],
+        \\    "body": [
+        \\      {"name": "t0", "value": {"kind": "call", "func": "min", "args": ["x", "x"]}},
+        \\      {"name": "t1", "value": {"kind": "load_prop", "name": "target"}},
+        \\      {"name": "t2", "value": {"kind": "bin_op", "op": "===", "left": "t0", "right": "t1"}},
+        \\      {"name": "t3", "value": {"kind": "assert", "value": "t2"}}
+        \\    ],
+        \\    "isPublic": true
+        \\  }]
+        \\}
+    ;
+    const hex = try compileIrToHex(a, json);
+    // DUP DUP MIN <placeholder OP_0> NUMEQUAL NIP
+    try std.testing.expectEqualStrings("7676a3009c77", hex);
+}
+
+test "repeated ref buried below another live slot" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // unlock(x, y) { assert(x + x + y === target) } — at t0 the stack is
+    // [x, y]: x sits at depth 1, so a naive rule pairs OP_ADD with the
+    // wrong slot instead of copying x twice.
+    const json =
+        \\{
+        \\  "contractName": "Repeat",
+        \\  "properties": [{"name": "target", "type": "bigint", "readonly": true}],
+        \\  "methods": [{
+        \\    "name": "unlock",
+        \\    "params": [{"name": "x", "type": "bigint"}, {"name": "y", "type": "bigint"}],
+        \\    "body": [
+        \\      {"name": "t0", "value": {"kind": "bin_op", "op": "+", "left": "x", "right": "x"}},
+        \\      {"name": "t1", "value": {"kind": "bin_op", "op": "+", "left": "t0", "right": "y"}},
+        \\      {"name": "t2", "value": {"kind": "load_prop", "name": "target"}},
+        \\      {"name": "t3", "value": {"kind": "bin_op", "op": "===", "left": "t1", "right": "t2"}},
+        \\      {"name": "t4", "value": {"kind": "assert", "value": "t3"}}
+        \\    ],
+        \\    "isPublic": true
+        \\  }]
+        \\}
+    ;
+    const hex = try compileIrToHex(a, json);
+    // OVER DUP ADD SWAP ADD OP_0 NUMEQUAL NIP — byte-identical with TS.
+    try std.testing.expectEqualStrings("7876937c93009c77", hex);
+}
+
+test "bin_op with distinct refs is unchanged (frontend canonical shape)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Frontend-shaped ANF (fresh temp per operand) must not shift bytes.
+    const json =
+        \\{
+        \\  "contractName": "Repeat",
+        \\  "properties": [{"name": "target", "type": "bigint", "readonly": true}],
+        \\  "methods": [{
+        \\    "name": "unlock",
+        \\    "params": [{"name": "x", "type": "bigint"}],
+        \\    "body": [
+        \\      {"name": "t0", "value": {"kind": "load_param", "name": "x"}},
+        \\      {"name": "t1", "value": {"kind": "load_param", "name": "x"}},
+        \\      {"name": "t2", "value": {"kind": "bin_op", "op": "+", "left": "t0", "right": "t1"}},
+        \\      {"name": "t3", "value": {"kind": "load_prop", "name": "target"}},
+        \\      {"name": "t4", "value": {"kind": "bin_op", "op": "===", "left": "t2", "right": "t3"}},
+        \\      {"name": "t5", "value": {"kind": "assert", "value": "t4"}}
+        \\    ],
+        \\    "isPublic": true
+        \\  }]
+        \\}
+    ;
+    const hex = try compileIrToHex(a, json);
+    // DUP SWAP ADD <placeholder OP_0> NUMEQUAL — canonical frontend Dbl shape.
+    try std.testing.expectEqualStrings("767c93009c", hex);
+}


### PR DESCRIPTION
Completes the 7-tier port of the repeated-operand consume fix (PR #62 TS, PR #67 Go+Rust) to Python, Zig, Ruby, and Java, against the TS `operandConsume` reference: **consume = isLastUse AND the ref occurs exactly once in the value's full operand list**; repeated refs copy at every position.

- Failing-first native tests per tier (pre-fix: 'value not found on stack' / wrong-slot pairing; post-fix all green).
- Reproducer hex byte-identical across ALL FIVE tiers here + TS: `767693009c77`, `min(x,x)` = `7676a3009c77`, buried-ref = `7876937c93009c77`, distinct-temp control = `767c93009c`.
- Full suites green: pytest 1026 passed; zig build test 642/642; rake all 53 files; gradle full suite — existing goldens byte-identical.