### PR TITLE
fix: make Dependency Audit workflow pass across all four failing tiers

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -43,7 +43,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          # Must match (or exceed) the `go` directive in the workspace's
+          # go.mod files (currently go 1.26). govulncheck refuses to scan
+          # packages that require a newer Go version than it was built with,
+          # so a stale pin here fails every scan step with "package requires
+          # newer Go version".
+          go-version: '1.26'
           cache: false
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -110,49 +115,40 @@ jobs:
         run: cd integration/python && pip-audit -r requirements.txt
 
   # ---------------------------------------------------------------------------
-  # Java - OWASP Dependency-Check (gradle plugin). The plugin is declared
-  # in compilers/java/build.gradle.kts and packages/runar-java/build.gradle.kts
-  # with failBuildOnCVSS = 7.0 (= HIGH/CRITICAL), which is exactly the
-  # severity gate this workflow promises. MEDIUM/LOW findings still land in
-  # the HTML/JSON report uploaded as a CI artifact.
+  # Java - osv-scanner against committed Gradle dependency lockfiles.
   #
-  # The NVD API key is optional but strongly recommended (anonymous downloads
-  # are heavily throttled and frequently 403 in CI). If NVD_API_KEY is set
-  # in the repo's secrets it's wired through; otherwise the plugin falls back
-  # to anonymous polling and the job is best-effort for that run.
+  # We deliberately do NOT use the OWASP Dependency-Check Gradle plugin here.
+  # Since NVD moved to its API-key model, anonymous NVD database mirroring is
+  # heavily throttled and routinely fails in CI, and this repo has no
+  # NVD_API_KEY secret configured — a dependencyCheckAnalyze job would be
+  # flaky-by-design. osv-scanner queries OSV.dev (which mirrors the GitHub
+  # Advisory Database's Maven ecosystem — the primary advisory source for
+  # JVM dependencies) headlessly, with no API key required.
+  #
+  # Both Gradle projects enable dependencyLocking and commit gradle.lockfile.
+  # With lock state present, Gradle fails any normal build (compile/test in
+  # ci.yml) if build.gradle.kts dependency versions change without
+  # regenerating the lockfile (`gradle dependencies --write-locks`), so the
+  # scanned lockfile cannot silently drift from the real dependency graph.
+  # osv-scanner exits non-zero on any known vulnerability, matching the
+  # fail-on-any-advisory behaviour of the Rust / Python / Ruby jobs above.
   # ---------------------------------------------------------------------------
   java-audit:
-    name: Java - OWASP dep-check
+    name: Java - osv-scanner (Gradle lockfiles)
     runs-on: ubuntu-latest
-    env:
-      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
-      - uses: gradle/actions/setup-gradle@v4
-      - name: Cache OWASP NVD database
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/dependency-check-data
-          key: owasp-nvd-${{ runner.os }}-${{ hashFiles('compilers/java/build.gradle.kts', 'packages/runar-java/build.gradle.kts') }}
-          restore-keys: |
-            owasp-nvd-${{ runner.os }}-
+      - name: Install osv-scanner
+        run: |
+          curl -fsSL -o osv-scanner \
+            https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64
+          chmod +x osv-scanner
+          sudo mv osv-scanner /usr/local/bin/osv-scanner
+          osv-scanner --version
       - name: Scan compilers/java
-        run: cd compilers/java && gradle dependencyCheckAnalyze --no-daemon
+        run: osv-scanner scan --lockfile compilers/java/gradle.lockfile
       - name: Scan packages/runar-java
-        run: cd packages/runar-java && gradle dependencyCheckAnalyze --no-daemon
-      - name: Upload dep-check reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: java-owasp-dep-check-reports
-          path: |
-            compilers/java/build/reports/dependency-check-report.*
-            packages/runar-java/build/reports/dependency-check-report.*
-          if-no-files-found: ignore
+        run: osv-scanner scan --lockfile packages/runar-java/gradle.lockfile
 
   # ---------------------------------------------------------------------------
   # Ruby - bundler-audit (rubysec). Runs against every Gemfile in the repo

--- a/compilers/java/build.gradle.kts
+++ b/compilers/java/build.gradle.kts
@@ -16,6 +16,14 @@ repositories {
     mavenCentral()
 }
 
+// Lock all configurations so the resolved dependency graph is committed as
+// gradle.lockfile. The Dependency Audit CI workflow scans that lockfile with
+// osv-scanner; regenerate with `gradle dependencies --write-locks` whenever
+// a dependency version changes.
+dependencyLocking {
+    lockAllConfigurations()
+}
+
 dependencies {
     // Placeholder deps. Populated in milestone 3 (parse/validate/typecheck).
     // implementation("com.github.javaparser:javaparser-core:3.25.10")

--- a/compilers/java/gradle.lockfile
+++ b/compilers/java/gradle.lockfile
@@ -1,0 +1,14 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.2=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.2=testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-params:5.10.2=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter:5.10.2=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.10.2=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.10.2=testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:1.10.2=testRuntimeClasspath
+org.junit:junit-bom:5.10.2=testCompileClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,compileClasspath,runtimeClasspath,testAnnotationProcessor

--- a/examples/end2end-example/ruby/Gemfile
+++ b/examples/end2end-example/ruby/Gemfile
@@ -3,5 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'runar-lang', path: '../../../packages/runar-rb'
-gem 'bsv-sdk', '~> 0.2'
 gem 'rspec', '~> 3.0'

--- a/examples/end2end-example/ruby/Gemfile.lock
+++ b/examples/end2end-example/ruby/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    bsv-sdk (0.2.1)
     diff-lcs (1.6.2)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -27,7 +26,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bsv-sdk (~> 0.2)
   rspec (~> 3.0)
   runar-lang!
 

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -1054,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/go.work
+++ b/go.work
@@ -1,5 +1,7 @@
 go 1.26
 
+toolchain go1.26.4
+
 use (
 	./compilers/go
 	./conformance

--- a/integration/ruby/Gemfile
+++ b/integration/ruby/Gemfile
@@ -4,5 +4,4 @@ source 'https://rubygems.org'
 
 gem 'rspec', '~> 3.12'
 gem 'base64'
-gem 'bsv-sdk'
 gem 'runar-lang', path: '../../packages/runar-rb'

--- a/integration/ruby/Gemfile.lock
+++ b/integration/ruby/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
-    bsv-sdk (0.2.1)
     diff-lcs (1.6.2)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -29,7 +28,6 @@ PLATFORMS
 
 DEPENDENCIES
   base64
-  bsv-sdk
   rspec (~> 3.12)
   runar-lang!
 

--- a/integration/rust/Cargo.lock
+++ b/integration/rust/Cargo.lock
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/packages/runar-java/build.gradle.kts
+++ b/packages/runar-java/build.gradle.kts
@@ -35,9 +35,17 @@ repositories {
     mavenCentral()
 }
 
+// Lock all configurations so the resolved dependency graph is committed as
+// gradle.lockfile. The Dependency Audit CI workflow scans that lockfile with
+// osv-scanner; regenerate with `gradle dependencies --write-locks` whenever
+// a dependency version changes.
+dependencyLocking {
+    lockAllConfigurations()
+}
+
 dependencies {
     // secp256k1 ECDSA + SHA-256 / RIPEMD-160 / BIP-143 sighash.
-    api("org.bouncycastle:bcprov-jdk18on:1.78")
+    api("org.bouncycastle:bcprov-jdk18on:1.84")
 
     // Frontend-only access to the Rúnar Java compiler so CompileCheck can
     // run parse → validate → expand-fixed-arrays → typecheck without

--- a/packages/runar-java/gradle.lockfile
+++ b/packages/runar-java/gradle.lockfile
@@ -1,0 +1,15 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
+org.bouncycastle:bcprov-jdk18on:1.84=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.2=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.2=testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-params:5.10.2=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter:5.10.2=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.10.2=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.10.2=testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:1.10.2=testRuntimeClasspath
+org.junit:junit-bom:5.10.2=testCompileClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,testAnnotationProcessor

--- a/packages/runar-rb/Gemfile.lock
+++ b/packages/runar-rb/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     logger (1.7.0)
     ostruct (0.6.3)
     prism (1.9.0)
-    rbs (4.0.0)
+    rbs (4.0.2)
       logger
       prism (>= 1.6.0)
       tsort
@@ -28,7 +28,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    ruby-lsp (0.26.8)
+    ruby-lsp (0.26.9)
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 5)

--- a/packages/runar-rs/Cargo.lock
+++ b/packages/runar-rs/Cargo.lock
@@ -1045,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Fixes the four failing jobs in the **Dependency Audit** workflow (run 27328221271).

## Go — govulncheck

**Root cause:** toolchain mismatch, not a dependency vulnerability. The workflow pinned `setup-go` to **1.24** while every `go.mod` in the workspace requires **go 1.26**, so the govulncheck binary (auto-built with go1.25) refused to load any package: `package requires newer Go version go1.26 (application built with go1.25)`.

**Resolution:**
- Workflow `go-version` pin bumped `1.24` → `1.26`.
- With the scan actually running, govulncheck then flagged **reachable Go stdlib vulnerabilities** (via `net/http`, `crypto/x509`, `crypto/tls`, `net/url`, `net/textproto` usage in the SDK provider code): GO-2026-5039, GO-2026-5037, GO-2026-4971, GO-2026-4947, GO-2026-4946, GO-2026-4918, GO-2026-4870, GO-2026-4866, GO-2026-4601, GO-2026-4600, GO-2026-4599 — all fixed in go1.26.x patch releases. Added `toolchain go1.26.4` to `go.work` so every workspace build (local and CI) uses the patched stdlib. This is a real version bump, not an ignore.

Verified: `govulncheck ./...` passes in all 5 scanned modules (compilers/go, packages/runar-go, conformance, integration/go, examples/go). `go test ./...` green in compilers/go and packages/runar-go.

## Rust — cargo audit

| Advisory | Crate | Resolution |
|---|---|---|
| RUSTSEC-2026-0104 (CRL parsing panic) | rustls-webpki 0.103.10 | `cargo update -p rustls-webpki` → **0.103.13** |
| RUSTSEC-2026-0099 (wildcard name constraints) | rustls-webpki 0.103.10 | same bump |
| RUSTSEC-2026-0098 (URI name constraints) | rustls-webpki 0.103.10 | same bump |

Patch-level bump applied to packages/runar-rs, examples/rust, and integration/rust (compilers/rust and runar-rs-macros don't carry the crate). The `rand 0.8.5` RUSTSEC-2026-0097 entry is a *warning* (unsound, no fix in 0.8.x), which cargo-audit does not fail on — left as-is.

Verified: `cargo audit` passes in all 5 scanned dirs; `cargo test` green in packages/runar-rs and examples/rust (8/8 suites); integration/rust test binaries build (running them needs a live regtest node).

## Ruby — bundler-audit

| Advisory | Gem | Resolution |
|---|---|---|
| CVE-2026-34060 / GHSA-c4r5-fxqw-vh93 (Critical, arbitrary code execution) | ruby-lsp 0.26.8 | `bundle lock --update=ruby-lsp` → **0.26.9** (advisory fix version) in packages/runar-rb |
| CVE-2026-40069 / GHSA-9hfr-gw99-8rhx (High, ARC broadcaster treats INVALID as success) | bsv-sdk 0.2.1 | **Removed** from integration/ruby and examples/end2end-example/ruby — the gem is declared in both Gemfiles but never `require`d anywhere in either tree (signing is done by runar-rb's own `LocalSigner`); deleting dead weight beats chasing a 0.2 → 0.8 bump of an unused dep |

The bsv-sdk failures weren't in the original log only because the job aborted at the first step; `bundle-audit` flags them on the next run.

Verified: `bundle-audit check` passes in all 4 scanned dirs (`--update` for runar-rb, exactly as the workflow runs it); `bundle exec rspec` in packages/runar-rb: **983 examples, 0 failures**.

## Java — dependency scanning

**Root cause:** the workflow ran `gradle dependencyCheckAnalyze`, but the OWASP Dependency-Check plugin was never applied in either `build.gradle.kts` → `Task 'dependencyCheckAnalyze' not found`.

**Resolution — switched scanner instead of applying the plugin.** The repo has no `NVD_API_KEY` secret (the failing run shows it empty), and since NVD moved to its API-key model, anonymous mirroring is heavily throttled and routinely fails/times out in CI — the previous workflow comment itself called the job "best-effort" without the key. Rather than ship a flaky-by-design job:

- `dependencyLocking { lockAllConfigurations() }` enabled and `gradle.lockfile` committed in **compilers/java** and **packages/runar-java**. Gradle fails any normal build whose resolved versions drift from the lockfile, so the scanned surface can't silently rot.
- The job now downloads a pinned **osv-scanner v2.3.8** and scans both lockfiles. OSV.dev mirrors the GitHub Advisory Database's Maven ecosystem (the primary advisory source for JVM deps), works headlessly with no API key, and exits non-zero on any finding — matching the fail-on-any-advisory behaviour of the Rust/Python/Ruby jobs. Job renamed accordingly (no required status check pins the old name; the ruleset only enforces deletion protection).
- **bcprov-jdk18on 1.78 → 1.84**: 1.78 predates the GHSA-4h8f-2wvx-gg5w / CVE-2024-34447 fix (1.78.1); 1.84 is the current release.

Verified: `osv-scanner scan --lockfile …` clean for both projects; `gradle test` green in compilers/java, packages/runar-java, and examples/java (which consumes the bcprov bump via composite build).

## Repo-wide

- `bash scripts/lint-no-silent-skips.sh` — green (109 skip sites, all documented).
- No advisory required an ignore/allowlist entry; everything was fixed by a real version bump or removal of an unused dependency.