### PR TITLE
test(examples/rust): honestly sign Rabin oracle values in example tests

### DIFF
--- a/examples/end2end-example/rust/Cargo.lock
+++ b/examples/end2end-example/rust/Cargo.lock
@@ -969,8 +969,9 @@ dependencies = [
 
 [[package]]
 name = "runar-compiler-rust"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
+ "bsv-sdk",
  "clap",
  "hex",
  "num-bigint",
@@ -987,12 +988,13 @@ dependencies = [
 name = "runar-end2end-example"
 version = "0.1.0"
 dependencies = [
+ "num-bigint",
  "runar-lang",
 ]
 
 [[package]]
 name = "runar-lang"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bs58",
  "bsv-sdk",
@@ -1012,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "runar-lang-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/end2end-example/rust/Cargo.toml
+++ b/examples/end2end-example/rust/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [dependencies]
 runar = { package = "runar-lang", path = "../../../packages/runar-rs" }
 
+[dev-dependencies]
+num-bigint = "0.4"
+
 [[test]]
 name = "price_bet"
 path = "PriceBet_test.rs"

--- a/examples/end2end-example/rust/PriceBet_test.rs
+++ b/examples/end2end-example/rust/PriceBet_test.rs
@@ -4,23 +4,24 @@ mod contract;
 use contract::*;
 use runar::prelude::*;
 
-const ORACLE_PUB_KEY: &[u8] = b"oracle_rabin_pk";
-
 fn new_price_bet() -> PriceBet {
     PriceBet {
         alice_pub_key: ALICE.pub_key.to_vec(),
         bob_pub_key: BOB.pub_key.to_vec(),
-        oracle_pub_key: ORACLE_PUB_KEY.to_vec(),
+        oracle_pub_key: oracle::pubkey_le(),
         strike_price: 50000,
     }
 }
 
-/// Sign a price using the trivial Rabin scheme: sig=0, padding=SHA256(msg) mod n.
-/// Mirrors `examples/end2end-example/go/PriceBet_test.go::signPrice`, which uses
-/// `runar.RabinSignToBytes` against the real test Rabin key.
-fn sign_price(price: i64) -> (Vec<u8>, Vec<u8>) {
+/// Honestly sign a price with the shared test Rabin key. Mirrors
+/// `examples/end2end-example/go/PriceBet_test.go::signPrice` (which uses
+/// `runar.RabinSignToBytes`) and the TS test's `rabinSign(RABIN_TEST_KEY)`.
+/// `verify_rabin_sig` performs REAL Rabin verification (with the on-chain
+/// padding bound 0 <= padding < 65536), so garbage (sig, padding) pairs no
+/// longer verify.
+fn sign_price(price: Bigint) -> (Vec<u8>, Vec<u8>) {
     let msg = num2bin(&price, 8);
-    rabin_sign_trivial(&msg, ORACLE_PUB_KEY)
+    oracle::sign(&msg)
 }
 
 #[test]
@@ -48,12 +49,26 @@ fn test_settle_bob_wins_at_strike() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "price > 0")]
 fn test_settle_zero_price_rejected() {
+    // Honestly signed so the Rabin layer passes and the failure is
+    // attributable to the `price > 0` assert, not the signature check.
     let (rabin_sig, pad) = sign_price(0);
     let alice_sig = ALICE.sign_test_message();
     let bob_sig = BOB.sign_test_message();
     new_price_bet().settle(0, &rabin_sig, &pad, &alice_sig, &bob_sig);
+}
+
+#[test]
+#[should_panic(expected = "verify_rabin_sig")]
+fn test_settle_forged_oracle_sig_rejected() {
+    // Price favors Alice but the oracle signature is garbage — the Rabin
+    // layer must reject it.
+    let alice_sig = ALICE.sign_test_message();
+    let bob_sig = BOB.sign_test_message();
+    let forged_sig: RabinSig = b"not_a_signature".to_vec();
+    let pad: ByteString = vec![0u8];
+    new_price_bet().settle(60000, &forged_sig, &pad, &alice_sig, &bob_sig);
 }
 
 #[test]
@@ -69,4 +84,68 @@ fn test_compile() {
         include_str!("PriceBet.runar.rs"),
         "PriceBet.runar.rs",
     ).unwrap();
+}
+
+/// Test-only honest Rabin oracle. Same p, q ≡ 3 (mod 4) test key as the Go
+/// (`runar.RabinTestP/Q`), Java (`OraclePriceFeedTest`), and integration-test
+/// (`integration/rust/tests/helpers/crypto.rs`) tiers. Square roots mod p are
+/// computable as a^((p+1)/4) mod p because p ≡ 3 (mod 4).
+mod oracle {
+    use num_bigint::BigUint;
+
+    const P_DEC: &str = "1361129467683753853853498429727072846227";
+    const Q_DEC: &str = "1361129467683753853853498429727082846007";
+
+    fn p() -> BigUint {
+        P_DEC.parse().unwrap()
+    }
+
+    fn q() -> BigUint {
+        Q_DEC.parse().unwrap()
+    }
+
+    /// Rabin modulus n = p * q as unsigned LE bytes (the contract's RabinPubKey).
+    pub fn pubkey_le() -> Vec<u8> {
+        (p() * q()).to_bytes_le()
+    }
+
+    /// sqrt of `a` mod prime `p` where p ≡ 3 (mod 4); None if `a` is not a
+    /// quadratic residue.
+    fn sqrt_mod(a: &BigUint, p: &BigUint) -> Option<BigUint> {
+        let a = a % p;
+        if a == BigUint::from(0u8) {
+            return Some(a);
+        }
+        let r = a.modpow(&((p + 1u8) >> 2), p);
+        if (&r * &r) % p == a {
+            Some(r)
+        } else {
+            None
+        }
+    }
+
+    /// Honest Rabin signature: returns (sig, padding) as unsigned LE bytes
+    /// with padding < 65536 such that (sig² + padding) mod n == SHA256(msg)
+    /// mod n. Finds the padding by quadratic-residue search and the root via
+    /// CRT (modular inverses by Fermat, since p and q are prime).
+    pub fn sign(msg: &[u8]) -> (Vec<u8>, Vec<u8>) {
+        let (p, q) = (p(), q());
+        let n = &p * &q;
+        let hash = runar::prelude::sha256(msg);
+        let hash_mod_n = BigUint::from_bytes_le(&hash) % &n;
+        let q_inv_p = q.modpow(&(&p - 2u8), &p);
+        let p_inv_q = p.modpow(&(&q - 2u8), &q);
+        for pad in 0u32..65536 {
+            let pad_bn = BigUint::from(pad);
+            let target = (&hash_mod_n + &n - &pad_bn) % &n;
+            let (Some(rp), Some(rq)) = (sqrt_mod(&target, &p), sqrt_mod(&target, &q)) else {
+                continue;
+            };
+            let sig = (&rp * &q * &q_inv_p + &rq * &p * &p_inv_q) % &n;
+            if (&sig * &sig + &pad_bn) % &n == hash_mod_n {
+                return (sig.to_bytes_le(), pad_bn.to_bytes_le());
+            }
+        }
+        panic!("no valid padding < 65536 found for test message");
+    }
 }

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -988,6 +988,7 @@ dependencies = [
 name = "runar-example-tests"
 version = "0.1.0"
 dependencies = [
+ "num-bigint",
  "runar-compiler-rust",
  "runar-lang",
  "serde_json",

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -9,6 +9,9 @@ runar = { package = "runar-lang", path = "../../packages/runar-rs" }
 runar-compiler-rust = { path = "../../compilers/rust" }
 serde_json = "1.0"
 
+[dev-dependencies]
+num-bigint = "0.4"
+
 [[test]]
 name = "p2pkh"
 path = "p2pkh/P2PKH_test.rs"

--- a/examples/rust/oracle-price/OraclePriceFeed_test.rs
+++ b/examples/rust/oracle-price/OraclePriceFeed_test.rs
@@ -4,44 +4,56 @@ mod contract;
 use contract::*;
 use runar::prelude::*;
 
-/// A small test Rabin modulus (a prime, so not a real Rabin key, but
-/// sufficient for verifying the contract logic with the trivial signer).
-const TEST_RABIN_PK: u64 = 997;
-
-fn rabin_pk_bytes() -> Vec<u8> {
-    TEST_RABIN_PK.to_le_bytes().to_vec()
-}
-
 fn new_oracle_feed() -> OraclePriceFeed {
     OraclePriceFeed {
-        oracle_pub_key: rabin_pk_bytes(),
+        oracle_pub_key: oracle::pubkey_le(),
         receiver: ALICE.pub_key.to_vec(),
     }
+}
+
+/// Honestly sign a price with the shared test Rabin key. `verify_rabin_sig`
+/// performs REAL Rabin verification (with the on-chain padding bound
+/// 0 <= padding < 65536), so the trivial sig=0 / padding=hash-mod-n scheme is
+/// no longer a representative way to drive the contract. Mirrors the Go
+/// (`runar.RabinSignToBytes`), Java (`OraclePriceFeedTest`), and TS
+/// (`rabinSign(RABIN_TEST_KEY)`) example tests.
+fn sign_price(price: Bigint) -> (Vec<u8>, Vec<u8>) {
+    let msg = num2bin(&price, 8);
+    oracle::sign(&msg)
 }
 
 #[test]
 fn test_settle() {
     let price: Bigint = 60000;
-    let msg = num2bin(&price, 8);
-    let (sig, pad) = rabin_sign_trivial(&msg, &rabin_pk_bytes());
+    let (sig, pad) = sign_price(price);
     new_oracle_feed().settle(price, &sig, &pad, &ALICE.sign_test_message());
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "price > 50000")]
 fn test_settle_price_too_low_fails() {
+    // Honestly signed so the Rabin layer passes and the failure is
+    // attributable to the threshold assert, not the signature check.
     let price: Bigint = 50000;
-    let msg = num2bin(&price, 8);
-    let (sig, pad) = rabin_sign_trivial(&msg, &rabin_pk_bytes());
+    let (sig, pad) = sign_price(price);
     new_oracle_feed().settle(price, &sig, &pad, &ALICE.sign_test_message());
 }
 
 #[test]
 fn test_settle_high_price() {
     let price: Bigint = 100000;
-    let msg = num2bin(&price, 8);
-    let (sig, pad) = rabin_sign_trivial(&msg, &rabin_pk_bytes());
+    let (sig, pad) = sign_price(price);
     new_oracle_feed().settle(price, &sig, &pad, &ALICE.sign_test_message());
+}
+
+#[test]
+#[should_panic(expected = "verify_rabin_sig")]
+fn test_settle_forged_oracle_sig_rejected() {
+    // Price exceeds the threshold but the oracle signature is garbage — the
+    // Rabin layer must reject it.
+    let forged_sig: RabinSig = b"not_a_signature".to_vec();
+    let pad: ByteString = vec![0u8];
+    new_oracle_feed().settle(60000, &forged_sig, &pad, &ALICE.sign_test_message());
 }
 
 #[test]
@@ -50,4 +62,68 @@ fn test_compile() {
         include_str!("OraclePriceFeed.runar.rs"),
         "OraclePriceFeed.runar.rs",
     ).unwrap();
+}
+
+/// Test-only honest Rabin oracle. Same p, q ≡ 3 (mod 4) test key as the Go
+/// (`runar.RabinTestP/Q`), Java (`OraclePriceFeedTest`), and integration-test
+/// (`integration/rust/tests/helpers/crypto.rs`) tiers. Square roots mod p are
+/// computable as a^((p+1)/4) mod p because p ≡ 3 (mod 4).
+mod oracle {
+    use num_bigint::BigUint;
+
+    const P_DEC: &str = "1361129467683753853853498429727072846227";
+    const Q_DEC: &str = "1361129467683753853853498429727082846007";
+
+    fn p() -> BigUint {
+        P_DEC.parse().unwrap()
+    }
+
+    fn q() -> BigUint {
+        Q_DEC.parse().unwrap()
+    }
+
+    /// Rabin modulus n = p * q as unsigned LE bytes (the contract's RabinPubKey).
+    pub fn pubkey_le() -> Vec<u8> {
+        (p() * q()).to_bytes_le()
+    }
+
+    /// sqrt of `a` mod prime `p` where p ≡ 3 (mod 4); None if `a` is not a
+    /// quadratic residue.
+    fn sqrt_mod(a: &BigUint, p: &BigUint) -> Option<BigUint> {
+        let a = a % p;
+        if a == BigUint::from(0u8) {
+            return Some(a);
+        }
+        let r = a.modpow(&((p + 1u8) >> 2), p);
+        if (&r * &r) % p == a {
+            Some(r)
+        } else {
+            None
+        }
+    }
+
+    /// Honest Rabin signature: returns (sig, padding) as unsigned LE bytes
+    /// with padding < 65536 such that (sig² + padding) mod n == SHA256(msg)
+    /// mod n. Finds the padding by quadratic-residue search and the root via
+    /// CRT (modular inverses by Fermat, since p and q are prime).
+    pub fn sign(msg: &[u8]) -> (Vec<u8>, Vec<u8>) {
+        let (p, q) = (p(), q());
+        let n = &p * &q;
+        let hash = runar::prelude::sha256(msg);
+        let hash_mod_n = BigUint::from_bytes_le(&hash) % &n;
+        let q_inv_p = q.modpow(&(&p - 2u8), &p);
+        let p_inv_q = p.modpow(&(&q - 2u8), &q);
+        for pad in 0u32..65536 {
+            let pad_bn = BigUint::from(pad);
+            let target = (&hash_mod_n + &n - &pad_bn) % &n;
+            let (Some(rp), Some(rq)) = (sqrt_mod(&target, &p), sqrt_mod(&target, &q)) else {
+                continue;
+            };
+            let sig = (&rp * &q * &q_inv_p + &rq * &p * &p_inv_q) % &n;
+            if (&sig * &sig + &pad_bn) % &n == hash_mod_n {
+                return (sig.to_bytes_le(), pad_bn.to_bytes_le());
+            }
+        }
+        panic!("no valid padding < 65536 found for test message");
+    }
 }


### PR DESCRIPTION
## Root cause

CI step "All end-to-end PriceBet examples" fails: `examples/end2end-example/rust` `cargo test --test price_bet` — 3 tests panic at `PriceBet.runar.rs:18:9` (`assertion failed: verify_rabin_sig(...)`).

Commit 1b43b92d (PR #57, "enforce Rabin padding bound in off-chain verifiers") upgraded `packages/runar-rs`'s `verify_rabin_sig` from a stub to REAL Rabin verification plus the on-chain padding bound `0 <= padding < 65536`. `PriceBet_test.rs` was still feeding it stub-era values: `rabin_sign_trivial` (sig=0, padding = SHA256(msg) mod n) against a garbage 15-byte ASCII modulus (`b"oracle_rabin_pk"`), so the padding is a ~120-bit value far above the bound and verification now (correctly) fails. The verifier is correct and untouched.

## Fix

Mirrors the Java fix (9549f088, PR #69) and the Go/TS example tests: sign `num2bin(price, 8)` honestly with the shared test key p,q ≡ 3 (mod 4) (`1361129467683753853853498429727072846227` / `1361129467683753853853498429727082846007` — same key as Go `RabinTestP/Q`, Java `OraclePriceFeedTest`, and `integration/rust` helpers). Padding < 65536 found by quadratic-residue search; CRT square root via `a^((p+1)/4) mod p`; modular inverses via Fermat. Test-only signer lives in each test file (`mod oracle`); `num-bigint 0.4` added as a dev-dependency to both example crates (already a dependency of `integration/rust`).

- **examples/end2end-example/rust/PriceBet_test.rs** — honest signatures for the 3 failing settle tests; zero-price negative test is now honestly signed and pinned to `#[should_panic(expected = "price > 0")]` so the failure is attributable to the threshold assert, not the signature layer; new `test_settle_forged_oracle_sig_rejected` pins garbage-sig rejection to the `verify_rabin_sig` layer.
- **examples/rust/oracle-price/OraclePriceFeed_test.rs** — was *passing*, but only because its tiny n=997 modulus slid the sig=0 trivial scheme under the 65536 padding bound — i.e. it was demonstrating exactly the forgery shape PR #57 closed. Switched to the same honest signer + shared test key; threshold negative test pinned to `price > 50000`; new forged-sig negative test.

## Sweep results

`grep -rn "verify_rabin_sig\|RabinSig\|rabin" examples/end2end-example/rust examples/rust integration/rust`:

- `examples/end2end-example/rust/PriceBet_test.rs` — broken, fixed (above).
- `examples/rust/oracle-price/OraclePriceFeed_test.rs` — natively executes `verify_rabin_sig`; passing-but-degenerate, upgraded (above).
- `integration/rust/tests/oracle_price_feed.rs` — already signs honestly via `helpers::crypto::rabin_sign` (padding search < 1000, same p,q key); no change.
- No other Rust call sites.

## Verification

- `examples/end2end-example/rust`: `cargo test` — 7/7 green (was 3 failing)
- `examples/rust`: `cargo test` — all 53 test targets green, 0 failures
- `integration/rust`: `cargo test --no-run` — compiles green
- `bash scripts/lint-no-silent-skips.sh` — green (109 skip sites, 54 inventory rows)