### PR TITLE
test(end2end/java): honest Rabin signing in PriceBetTest (last red Integration step)

### DIFF
--- a/examples/end2end-example/java/src/test/java/runar/end2end/PriceBetTest.java
+++ b/examples/end2end-example/java/src/test/java/runar/end2end/PriceBetTest.java
@@ -40,15 +40,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class PriceBetTest {
 
-    // Mirrors the demo Rabin modulus used by the Python / Ruby end-to-end
-    // tests; mock crypto inside ContractSimulator returns true regardless
-    // of value, so the exact bytes don't matter — but using the same
-    // 130-bit n keeps the tests visually consistent across languages.
-    private static final RabinPubKey ORACLE_PK = new RabinPubKey(
-        new BigInteger("950b36f00000000000000000000000002863620200000000000000000000000010", 16)
-    );
-    private static final RabinSig    ORACLE_SIG = new RabinSig(BigInteger.ONE);
-    private static final ByteString  ORACLE_PADDING = ByteString.fromHex("00");
+    // Rabin test primes, both ≡ 3 (mod 4) so square roots are computable via
+    // a^((p+1)/4) mod p. Same shared cross-tier test key as
+    // runar.lang.runtime.RabinPaddingBoundTest and the examples/java
+    // OraclePriceFeedTest. MockCrypto.verifyRabinSig performs REAL Rabin
+    // verification (with the on-chain padding bound), so the oracle
+    // signature must be honestly produced — garbage (sig, padding) pairs
+    // no longer verify.
+    private static final BigInteger P = new BigInteger("1361129467683753853853498429727072846227");
+    private static final BigInteger Q = new BigInteger("1361129467683753853853498429727082846007");
+    private static final BigInteger N = P.multiply(Q);
+
+    private static final RabinPubKey ORACLE_PK = new RabinPubKey(N);
 
     private static final PubKey ALICE = PubKey.fromHex(
         "0202020202020202020202020202020202020202020202020202020202020202aa"
@@ -77,8 +80,10 @@ class PriceBetTest {
     void settleAlicewinsWhenPriceExceedsStrike() {
         PriceBet bet = makeBet();
         ContractSimulator sim = ContractSimulator.stateless(bet);
+        BigInteger[] sigAndPad = sign(priceMsg(60_000));
         sim.call("settle",
-            Bigint.of(60_000), ORACLE_SIG, ORACLE_PADDING,
+            Bigint.of(60_000), new RabinSig(sigAndPad[0]),
+            new ByteString(unsignedToLE(sigAndPad[1])),
             ALICE_SIG, BOB_SIG
         );
     }
@@ -87,8 +92,10 @@ class PriceBetTest {
     void settleBobWinsWhenPriceBelowStrike() {
         PriceBet bet = makeBet();
         ContractSimulator sim = ContractSimulator.stateless(bet);
+        BigInteger[] sigAndPad = sign(priceMsg(30_000));
         sim.call("settle",
-            Bigint.of(30_000), ORACLE_SIG, ORACLE_PADDING,
+            Bigint.of(30_000), new RabinSig(sigAndPad[0]),
+            new ByteString(unsignedToLE(sigAndPad[1])),
             ALICE_SIG, BOB_SIG
         );
     }
@@ -98,8 +105,10 @@ class PriceBetTest {
         // price == strike → bob wins (the contract's else branch).
         PriceBet bet = makeBet();
         ContractSimulator sim = ContractSimulator.stateless(bet);
+        BigInteger[] sigAndPad = sign(priceMsg(50_000));
         sim.call("settle",
-            STRIKE, ORACLE_SIG, ORACLE_PADDING,
+            STRIKE, new RabinSig(sigAndPad[0]),
+            new ByteString(unsignedToLE(sigAndPad[1])),
             ALICE_SIG, BOB_SIG
         );
     }
@@ -108,9 +117,29 @@ class PriceBetTest {
     void settleRejectsZeroPrice() {
         PriceBet bet = makeBet();
         ContractSimulator sim = ContractSimulator.stateless(bet);
+        // Honestly signed zero price so the failure is attributable to the
+        // price > 0 assert, not the signature layer.
+        BigInteger[] sigAndPad = sign(priceMsg(0));
         assertThrows(AssertionError.class, () ->
             sim.call("settle",
-                Bigint.of(0), ORACLE_SIG, ORACLE_PADDING,
+                Bigint.of(0), new RabinSig(sigAndPad[0]),
+                new ByteString(unsignedToLE(sigAndPad[1])),
+                ALICE_SIG, BOB_SIG
+            )
+        );
+    }
+
+    @Test
+    void settleRejectsForgedOracleSignature() {
+        // Price exceeds the strike but the oracle signature is garbage —
+        // the Rabin layer must reject it (regression for the stub-era
+        // mock values this test previously relied on).
+        PriceBet bet = makeBet();
+        ContractSimulator sim = ContractSimulator.stateless(bet);
+        assertThrows(AssertionError.class, () ->
+            sim.call("settle",
+                Bigint.of(60_000), new RabinSig(BigInteger.ONE),
+                ByteString.fromHex("00"),
                 ALICE_SIG, BOB_SIG
             )
         );
@@ -131,5 +160,82 @@ class PriceBetTest {
         Path source = Paths.get(System.getProperty("user.dir"))
             .resolve("src/main/java/runar/end2end/PriceBet.runar.java");
         CompileCheck.run(source);
+    }
+
+    // --- honest signer (test-only; mirrors examples/java OraclePriceFeedTest) ---
+
+    /** The message the contract verifies: num2bin(price, 8) — 8-byte little-endian. */
+    private static byte[] priceMsg(long price) {
+        byte[] msg = new byte[8];
+        for (int i = 0; i < 8; i++) {
+            msg[i] = (byte) (price >>> (8 * i));
+        }
+        return msg;
+    }
+
+    /** Returns {sig, padding} with padding < 65536 such that (sig^2 + padding) mod n == H(msg) mod n. */
+    private static BigInteger[] sign(byte[] msg) {
+        BigInteger hashBN = leToUnsigned(sha256(msg));
+        BigInteger hashModN = hashBN.mod(N);
+
+        for (long pad = 0; pad < 65536; pad++) {
+            BigInteger padBig = BigInteger.valueOf(pad);
+            BigInteger target = hashModN.subtract(padBig).mod(N);
+            BigInteger root = sqrtModPQ(target);
+            if (root != null) {
+                BigInteger check = root.multiply(root).add(padBig).mod(N);
+                if (check.equals(hashModN)) {
+                    return new BigInteger[]{root, padBig};
+                }
+            }
+        }
+        throw new IllegalStateException("no valid padding < 65536 found for test message");
+    }
+
+    /** sqrt of a mod n=p*q via CRT, or null if not a quadratic residue. */
+    private static BigInteger sqrtModPQ(BigInteger a) {
+        BigInteger rp = sqrtMod3(a, P);
+        if (rp == null) return null;
+        BigInteger rq = sqrtMod3(a, Q);
+        if (rq == null) return null;
+        BigInteger qInvP = Q.modInverse(P);
+        BigInteger pInvQ = P.modInverse(Q);
+        BigInteger t1 = rp.multiply(Q).multiply(qInvP);
+        BigInteger t2 = rq.multiply(P).multiply(pInvQ);
+        return t1.add(t2).mod(N);
+    }
+
+    /** sqrt of a mod prime p where p ≡ 3 (mod 4); null if a is not a QR. */
+    private static BigInteger sqrtMod3(BigInteger a, BigInteger p) {
+        a = a.mod(p);
+        if (a.signum() == 0) return BigInteger.ZERO;
+        BigInteger r = a.modPow(p.add(BigInteger.ONE).shiftRight(2), p);
+        return r.multiply(r).mod(p).equals(a) ? r : null;
+    }
+
+    private static byte[] sha256(byte[] data) {
+        try {
+            return java.security.MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Unsigned little-endian bytes to BigInteger. */
+    private static BigInteger leToUnsigned(byte[] le) {
+        byte[] be = new byte[le.length];
+        for (int i = 0; i < le.length; i++) be[le.length - 1 - i] = le[i];
+        return new BigInteger(1, be);
+    }
+
+    /** BigInteger to minimal unsigned little-endian bytes. */
+    private static byte[] unsignedToLE(BigInteger n) {
+        if (n.signum() == 0) return new byte[]{0};
+        byte[] be = n.toByteArray();           // big-endian, may have leading 0x00 sign byte
+        int start = (be.length > 1 && be[0] == 0) ? 1 : 0;
+        int len = be.length - start;
+        byte[] le = new byte[len];
+        for (int i = 0; i < len; i++) le[i] = be[be.length - 1 - i];
+        return le;
     }
 }


### PR DESCRIPTION
Integration's `All end-to-end PriceBet examples` step fails on the **Java** leg: 3 settle tests in `examples/end2end-example/java/PriceBetTest` still used stub-era garbage Rabin values (`sig=1`, `padding=0x00`, junk modulus) against the now-real `MockCrypto.verifyRabinSig` (1b43b92d / #57). Third and (per repo-wide sweep) final such call site, after `examples/java` (#69) and the Rust tiers (#81).

Same recipe: honest signing over `num2bin(price, 8)` with the shared cross-tier test key; zero-price negative honestly signed for clean failure attribution; the old garbage values become a forged-signature regression test.

Sweep evidence: `grep -rln 'RabinSig|verifyRabinSig'` across examples/, end2end, and integration — all remaining call sites are honest signers (`integration/java` already uses `RabinHelpers`).

Verified: `examples/end2end-example/java` 8 tests / 0 failures (was 7/3).