### PR TITLE
verification: widen hash-chain fragment to (sha256,sha256) via OP_HASH256 fusion

### DIFF
--- a/runar-verification/RunarVerification/Pipeline.lean
+++ b/runar-verification/RunarVerification/Pipeline.lean
@@ -6208,6 +6208,46 @@ theorem peepholeMethodOps_hashChain_hash160_hash160 :
     (by simp +decide [AgreesHashCall.hashChainOps,
       Peephole.rollPickFoldFlatNoop, Peephole.rollPickFoldOpNoop])
 
+/-- **Peephole FUSION image on `[OP_SHA256, OP_SHA256]`.**  Unlike the three
+peephole-stable pairs, the `(sha256, sha256)` chain ops do NOT survive: the
+flat pass's `applyDoubleSha256` rewrites `[OP_SHA256, OP_SHA256]` to the single
+`[OP_HASH256]`, on which the three remaining passes are the identity (same
+single-opcode reduction as `peepholeMethodOps_single_opcode`).  Sound — the VM
+identity `hash256 = sha256 ∘ sha256` (`Stack.HashOps.hash256_eq_double_sha256`)
+links the two images at runtime. -/
+theorem peepholeMethodOps_hashChain_sha256_sha256 :
+    peepholeMethodOps (AgreesHashCall.hashChainOps "OP_SHA256" "OP_SHA256")
+      = [StackOp.opcode "OP_HASH256"] := by
+  unfold peepholeMethodOps
+  have hNoIf : Peephole.noIfOp (AgreesHashCall.hashChainOps "OP_SHA256" "OP_SHA256") := by
+    simp [AgreesHashCall.hashChainOps, Peephole.noIfOp]
+  rw [Peephole.peepholePassAll_eq_flat_of_noIfOp _ hNoIf]
+  -- The flat pass FUSES the double-sha256 to a single OP_HASH256.
+  have hFlat : Peephole.peepholePassAllFlat
+      (AgreesHashCall.hashChainOps "OP_SHA256" "OP_SHA256")
+      = [StackOp.opcode "OP_HASH256"] := by
+    simp +decide [AgreesHashCall.hashChainOps, Peephole.peepholePassAllFlat,
+      Peephole.applyEqualVerifyFuse, Peephole.applyCheckSigVerifyFuse,
+      Peephole.applyNumEqualVerifyFuse, Peephole.applyZeroNumEqual,
+      Peephole.applyDoubleSha256, Peephole.applyDoubleDrop, Peephole.applyDoubleOver,
+      Peephole.applyDoubleNot, Peephole.applyDoubleNegate, Peephole.applyOneSub,
+      Peephole.applyOneAdd, Peephole.applySubZero, Peephole.applyAddZero,
+      Peephole.applyPushPushMul, Peephole.applyPushPushSub, Peephole.applyPushPushAdd,
+      Peephole.applyDoubleSwap, Peephole.applyDupDrop, Peephole.applyDropAfterPush]
+  rw [hFlat]
+  -- The remaining three passes are the identity on the single OP_HASH256.
+  have hNoIf256 : Peephole.noIfOp [StackOp.opcode "OP_HASH256"] := by
+    simp [Peephole.noIfOp]
+  rw [Peephole.peepholePostFold_eq_applyPushOne_of_noIfOp _ hNoIf256]
+  have hPost : Peephole.applyPushOneSub
+      (Peephole.applyPushOneAdd [StackOp.opcode "OP_HASH256"])
+      = [StackOp.opcode "OP_HASH256"] := by
+    simp [Peephole.applyPushOneAdd, Peephole.applyPushOneSub]
+  rw [hPost, Peephole.peepholeChainFold_eq_self_of_noIfOp_pushFree _ hNoIf256
+        (by simp [Peephole.pushFree]),
+    Peephole.peepholeRollPickFold_eq_self_of_noIfOp_flatNoop _ hNoIf256
+        (by simp [Peephole.rollPickFoldFlatNoop, Peephole.rollPickFoldOpNoop])]
+
 /-- **2-chain consume core (func-agnostic).**  Composes the always-completing
 ANF and Stack walks with the method-level lowering reduction, the peephole
 identity, and the push round-trip M4.  VALUE-terminated, so the acceptance
@@ -6296,10 +6336,113 @@ theorem hashChain_consume_core
     rw [hBody]; simp [AgreesHashCall.hashChainBody, Lower.bodyEndsInAssert]
   exact Stack.Eval.acceptAgrees_of_completion_of_truthy hCompletion (hTopTruthy hNoTA)
 
+/-- **2-chain consume core — FUSING `(sha256, sha256)` pair.**  Sibling of
+`hashChain_consume_core` for the one pair whose lowered ops do NOT survive the
+peephole: `lowerMethod` still emits `hashChainOps "OP_SHA256" "OP_SHA256"`
+(pre-peephole, shared), but the peephole stage FUSES it to `[OP_HASH256]`
+(`peepholeMethodOps_hashChain_sha256_sha256`).  The M4 round-trip and M2 walk
+are therefore over `[OP_HASH256]`, whose digest `hash256 arg = sha256 (sha256
+arg)` matches the ANF body's `d2`.  VALUE-terminated. -/
+theorem hashChain_consume_sha256d_core
+    (p : ANFProgram) (anfM : ANFMethod) (bytes : ByteArray)
+    (d1 d2 arg : String) (ty : ANFType)
+    (s1 s2 : Option SourceLoc)
+    (hMem : anfM ∈ p.methods) (hPublic : anfM.isPublic = true)
+    (hSafe : compileSafe p = .ok bytes)
+    (initialAnf : State) (initialStack : StackState)
+    (hSinglePublic : p.methods.filter (·.isPublic) = [anfM])
+    (hName : anfM.name ≠ "constructor")
+    (hParams : anfM.params = [ANFParam.mk arg ty])
+    (hBody : anfM.body = AgreesHashCall.hashChainBody d1 d2 arg "sha256" "sha256" s1 s2)
+    (hNe : d1 ≠ arg)
+    (argBytes : ByteArray) (rest : List RunarVerification.ANF.Eval.Value)
+    (hArg : initialAnf.resolveRef arg = some (.vBytes argBytes))
+    (hStk : initialStack.stack = .vBytes argBytes :: rest)
+    (hLen : argBytes.size ≤ 520)
+    (hCallWit1 : Lower.lowerValueP p.methods p.properties Lower.defaultInlineBudget 0
+        [(d1, 1), (arg, 0)] [] [d1, d2]
+        (Lower.collectConstInts
+          (AgreesHashCall.hashChainBody d1 d2 arg "sha256" "sha256" s1 s2))
+        [arg] d1 (.call "sha256" [arg])
+      = ([StackOp.opcode "OP_SHA256"], [d1], [d1, d2]))
+    (hCallWit2 : Lower.lowerValueP p.methods p.properties Lower.defaultInlineBudget 1
+        [(d1, 1), (arg, 0)] [] [d1, d2]
+        (Lower.collectConstInts
+          (AgreesHashCall.hashChainBody d1 d2 arg "sha256" "sha256" s1 s2))
+        [d1] d2 (.call "sha256" [d1])
+      = ([StackOp.opcode "OP_SHA256"], [d2], [d1, d2]))
+    (hTopTruthy : Lower.bodyEndsInAssert anfM.body = false →
+      ∀ s, runParsedBytes bytes initialStack = .ok s →
+        topTruthy s.stack = true) :
+    acceptAgrees
+      (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf anfM.body)
+      (runParsedBytes bytes initialStack) := by
+  have hFuncs : AgreesHashCall.hashChainFuncsOk "sha256" "sha256" = true := by decide
+  have hD1Self : (initialAnf.addBinding d1
+      (.vBytes (RunarVerification.ANF.Eval.Crypto.sha256 argBytes))).resolveRef d1
+      = some (.vBytes (RunarVerification.ANF.Eval.Crypto.sha256 argBytes)) :=
+    RunarVerification.ANF.WellTyped.resolveRef_addBinding_self initialAnf d1 _
+  -- ANF: both sha256 calls complete; the body's d2 = sha256 (sha256 argBytes).
+  have hCall1 : RunarVerification.ANF.Eval.evalValue initialAnf (.call "sha256" [arg])
+      = .ok (.vBytes (RunarVerification.ANF.Eval.Crypto.sha256 argBytes), initialAnf) :=
+    AgreesHashCall.evalValue_call_sha256_eq_local initialAnf arg argBytes hArg
+  have hCall2 : RunarVerification.ANF.Eval.evalValue
+      (initialAnf.addBinding d1
+        (.vBytes (RunarVerification.ANF.Eval.Crypto.sha256 argBytes))) (.call "sha256" [d1])
+      = .ok (.vBytes (RunarVerification.ANF.Eval.Crypto.sha256
+          (RunarVerification.ANF.Eval.Crypto.sha256 argBytes)),
+        initialAnf.addBinding d1
+          (.vBytes (RunarVerification.ANF.Eval.Crypto.sha256 argBytes))) :=
+    AgreesHashCall.evalValue_call_sha256_eq_local _ d1 _ hD1Self
+  have hANF : (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf
+      anfM.body).toOption.isSome = true := by
+    rw [hBody]
+    exact AgreesHashCall.evalBindingsP_hashChain_isSome p.methods initialAnf
+      d1 d2 arg "sha256" "sha256" s1 s2 _ _ hCall1 hCall2
+  -- Lowering (pre-peephole, shared) reduces to the bare 2-opcode double-sha256.
+  have hOps : (Lower.lowerMethod p.methods p.properties anfM).ops
+      = AgreesHashCall.hashChainOps "OP_SHA256" "OP_SHA256" :=
+    AgreesHashCall.lowerMethod_ops_hashChain p.methods p.properties anfM
+      d1 d2 arg "sha256" "sha256" "OP_SHA256" "OP_SHA256" ty s1 s2 hParams hBody hPublic
+      hNe hFuncs hCallWit1 hCallWit2
+  obtain ⟨hPubSingleton, _hStackBody⟩ :=
+    peepholeProgram_single_public_shape p anfM hSinglePublic hName
+  -- Peephole FUSES the lowered ops to a single OP_HASH256.
+  have hPeeped : (peepholedLoweredMethod p anfM).ops = [StackOp.opcode "OP_HASH256"] := by
+    show peepholeMethodOps (Lower.lowerMethod p.methods p.properties anfM).ops = _
+    rw [hOps]
+    exact peepholeMethodOps_hashChain_sha256_sha256
+  -- M4: parsed bytes run as the fused [OP_HASH256].
+  have hM4 : runParsedBytes bytes initialStack
+      = runOps [StackOp.opcode "OP_HASH256"] initialStack := by
+    have hEmitPush : Parse.AreRunarEmittablePush (peepholedLoweredMethod p anfM).ops := by
+      show Parse.areRunarEmittablePushBool (peepholedLoweredMethod p anfM).ops = true
+      rw [hPeeped]; decide
+    have hEq := compileSafe_single_public_runOps_eq_push p bytes
+      (peepholedLoweredMethod p anfM) initialStack hSafe hPubSingleton hEmitPush
+    rw [hEq, hPeeped]
+  -- M2: the fused op produces hash256 argBytes = sha256 (sha256 argBytes).
+  have hStackRun : runOps [StackOp.opcode "OP_HASH256"] initialStack
+      = .ok { initialStack with
+          stack := .vBytes (RunarVerification.ANF.Eval.Crypto.sha256
+            (RunarVerification.ANF.Eval.Crypto.sha256 argBytes)) :: rest } :=
+    Stack.HashOps.runOps_hash256Ops_eq_composition initialStack argBytes rest hStk hLen
+  have hCompletion :
+      (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf
+        anfM.body).toOption.isSome
+      ↔ (runParsedBytes bytes initialStack).toOption.isSome := by
+    rw [hANF, hM4, hStackRun]
+    simp [Except.toOption]
+  have hNoTA : Lower.bodyEndsInAssert anfM.body = false := by
+    rw [hBody]; simp [AgreesHashCall.hashChainBody, Lower.bodyEndsInAssert]
+  exact Stack.Eval.acceptAgrees_of_completion_of_truthy hCompletion (hTopTruthy hNoTA)
+
 /-- **2-chain consume (HEADLINE, acceptance bit).**  One theorem over the
-three admissible pairs (`hashChainFuncsOk`); the digest truthiness is carried
+four admissible pairs (`hashChainFuncsOk`); the digest truthiness is carried
 by the keyed `hTopTruthy` premise (the body is VALUE-terminated and the hash
-backends are opaque — same regime as the bare single-call theorems). -/
+backends are opaque — same regime as the bare single-call theorems).  Three
+pairs are peephole-stable; `(sha256, sha256)` FUSES to `[OP_HASH256]` and is
+discharged by `hashChain_consume_sha256d_core`. -/
 theorem hashChain_consume
     (p : ANFProgram) (anfM : ANFMethod) (bytes : ByteArray)
     (d1 d2 arg f1 f2 : String) (ty : ANFType) (s1 s2 : Option SourceLoc)
@@ -6323,14 +6466,15 @@ theorem hashChain_consume
       (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf anfM.body)
       (runParsedBytes bytes initialStack) := by
   have hF : (f1 = "sha256" ∧ f2 = "hash160") ∨ (f1 = "hash160" ∧ f2 = "sha256")
-      ∨ (f1 = "hash160" ∧ f2 = "hash160") := by
+      ∨ (f1 = "hash160" ∧ f2 = "hash160") ∨ (f1 = "sha256" ∧ f2 = "sha256") := by
     have h := hFuncs
     simp only [AgreesHashCall.hashChainFuncsOk, Bool.or_eq_true,
       Bool.and_eq_true, beq_iff_eq] at h
-    rcases h with (h | h) | h
+    rcases h with ((h | h) | h) | h
     · exact Or.inl h
     · exact Or.inr (Or.inl h)
-    · exact Or.inr (Or.inr h)
+    · exact Or.inr (Or.inr (Or.inl h))
+    · exact Or.inr (Or.inr (Or.inr h))
   have hD1Self : (initialAnf.addBinding d1
       (.vBytes (RunarVerification.ANF.Eval.Crypto.sha256 argBytes))).resolveRef d1
       = some (.vBytes (RunarVerification.ANF.Eval.Crypto.sha256 argBytes)) :=
@@ -6339,7 +6483,8 @@ theorem hashChain_consume
       (.vBytes (RunarVerification.ANF.Eval.Crypto.hash160 argBytes))).resolveRef d1
       = some (.vBytes (RunarVerification.ANF.Eval.Crypto.hash160 argBytes)) :=
     RunarVerification.ANF.WellTyped.resolveRef_addBinding_self initialAnf d1 _
-  rcases hF with ⟨hF1, hF2⟩ | ⟨hF1, hF2⟩ | ⟨hF1, hF2⟩ <;> subst hF1 <;> subst hF2
+  rcases hF with ⟨hF1, hF2⟩ | ⟨hF1, hF2⟩ | ⟨hF1, hF2⟩ | ⟨hF1, hF2⟩ <;>
+    subst hF1 <;> subst hF2
   · -- (sha256, hash160)
     exact hashChain_consume_core p anfM bytes d1 d2 arg "sha256" "hash160"
       "OP_SHA256" "OP_HASH160" ty s1 s2 hMem hPublic hSafe initialAnf initialStack
@@ -6409,6 +6554,21 @@ theorem hashChain_consume
           (AgreesHashCall.hashChainBody d1 d2 arg "hash160" "hash160" s1 s2))
         d2 d1 [] (AgreesHashCall.hashChain_d1_consume_fact d1 arg))
       hTopTruthy
+  · -- (sha256, sha256) — FUSES to [OP_HASH256]; sibling fused core.
+    exact hashChain_consume_sha256d_core p anfM bytes d1 d2 arg ty s1 s2
+      hMem hPublic hSafe initialAnf initialStack hSinglePublic hName hParams hBody hNe
+      argBytes rest hArg hStk hLen
+      (AgreesHashCall.lowerValueP_call_sha256_consume_d0_full p.methods p.properties
+        Lower.defaultInlineBudget 0 [(d1, 1), (arg, 0)] [d1, d2]
+        (Lower.collectConstInts
+          (AgreesHashCall.hashChainBody d1 d2 arg "sha256" "sha256" s1 s2))
+        d1 arg [] (AgreesHashCall.hashChain_arg_consume_fact d1 arg hNe))
+      (AgreesHashCall.lowerValueP_call_sha256_consume_d0_full p.methods p.properties
+        Lower.defaultInlineBudget 1 [(d1, 1), (arg, 0)] [d1, d2]
+        (Lower.collectConstInts
+          (AgreesHashCall.hashChainBody d1 d2 arg "sha256" "sha256" s1 s2))
+        d2 d1 [] (AgreesHashCall.hashChain_d1_consume_fact d1 arg))
+      hTopTruthy
 
 /-! ### MANDATORY smoke: the 2-chain consume theorem fires
 
@@ -6449,6 +6609,40 @@ theorem smoke_hashChain_consume_fires
     AgreesHashCall.hashChainSmokeMethod bytes "d1" "d2" "x" "sha256" "hash160"
     .byteString none none
     (by simp [hashChainSmokeProg]) rfl hSafe
+    hashChainSmokeAnf hashChainSmokeStk rfl (by decide) rfl rfl (by decide)
+    (by decide) (ByteArray.mk #[1, 2, 3]) [] rfl rfl (by decide)
+    (fun _ s hRun => hTopTruthy bytes s hSafe hRun)
+
+/-- The FUSING `(sha256, sha256)` 2-chain method `h(x){d1:=sha256(x); d2:=sha256(d1)}`. -/
+private def hashChainSha256dSmokeMethod : ANFMethod :=
+  { AgreesHashCall.hashChainSmokeMethod with
+    body := AgreesHashCall.hashChainBody "d1" "d2" "x" "sha256" "sha256" none none }
+
+private def hashChainSha256dSmokeProg : ANFProgram :=
+  { contractName := "HCD", properties := [], methods := [hashChainSha256dSmokeMethod] }
+
+/-- SMOKE — `hashChain_consume` fires on the FUSING sha256→sha256 chain (the
+new `(sha256, sha256)` coverage; the peephole fuses to `[OP_HASH256]`). -/
+theorem smoke_hashChain_consume_fires_sha256d
+    (hTopTruthy : ∀ bytes s, compileSafe hashChainSha256dSmokeProg = .ok bytes →
+        runParsedBytes bytes hashChainSmokeStk = .ok s →
+        topTruthy s.stack = true) :
+    ∃ bytes, compileSafe hashChainSha256dSmokeProg = .ok bytes ∧
+      acceptAgrees
+        (RunarVerification.ANF.Eval.evalBindingsP hashChainSha256dSmokeProg.methods
+          hashChainSmokeAnf hashChainSha256dSmokeMethod.body)
+        (runParsedBytes bytes hashChainSmokeStk) := by
+  obtain ⟨bytes, hSafe⟩ : ∃ b, compileSafe hashChainSha256dSmokeProg = .ok b := by
+    have h : (compileSafe hashChainSha256dSmokeProg).toOption.isSome = true := by
+      native_decide
+    cases hc : compileSafe hashChainSha256dSmokeProg with
+    | ok b => exact ⟨b, rfl⟩
+    | error e => rw [hc] at h; simp [Except.toOption] at h
+  refine ⟨bytes, hSafe, ?_⟩
+  exact hashChain_consume hashChainSha256dSmokeProg
+    hashChainSha256dSmokeMethod bytes "d1" "d2" "x" "sha256" "sha256"
+    .byteString none none
+    (by simp [hashChainSha256dSmokeProg]) rfl hSafe
     hashChainSmokeAnf hashChainSmokeStk rfl (by decide) rfl rfl (by decide)
     (by decide) (ByteArray.mk #[1, 2, 3]) [] rfl rfl (by decide)
     (fun _ s hRun => hTopTruthy bytes s hSafe hRun)

--- a/runar-verification/RunarVerification/Script/Parse.lean
+++ b/runar-verification/RunarVerification/Script/Parse.lean
@@ -667,6 +667,11 @@ def isAllowedOpcodeName (name : String) : Bool :=
     || name = "OP_ADD" || name = "OP_SUB" || name = "OP_MUL"
     || name = "OP_EQUAL" || name = "OP_EQUALVERIFY"
     || name = "OP_HASH160" || name = "OP_SHA256"
+    -- OP_HASH256 (byte 0xaa): emitted by the peephole's `applyDoubleSha256`
+    -- fusion (`[OP_SHA256, OP_SHA256] → [OP_HASH256]`).  Round-trips cleanly —
+    -- `parseStackOp1? 0xaa = some (.opcode "OP_HASH256")` (0xaa is neither a
+    -- short-form byte nor an if-frame byte), so it is safe to allowlist.
+    || name = "OP_HASH256"
     || name = "OP_CHECKSIG" || name = "OP_CHECKSIGVERIFY"
     || name = "OP_CAT" || name = "OP_SPLIT"
     -- Wave 49: math_byte single-arg popping opcodes. These three round-trip
@@ -1295,6 +1300,10 @@ theorem parseStackOpFuel_OP_SHA256 (fuel : Nat) (rest : List UInt8) :
     parseStackOpFuel (fuel + 1) (emitStackOpL (.opcode "OP_SHA256") ++ rest)
       = .ok (.opcode "OP_SHA256", rest) := rfl
 
+theorem parseStackOpFuel_OP_HASH256 (fuel : Nat) (rest : List UInt8) :
+    parseStackOpFuel (fuel + 1) (emitStackOpL (.opcode "OP_HASH256") ++ rest)
+      = .ok (.opcode "OP_HASH256", rest) := rfl
+
 theorem parseStackOpFuel_OP_CHECKSIG (fuel : Nat) (rest : List UInt8) :
     parseStackOpFuel (fuel + 1) (emitStackOpL (.opcode "OP_CHECKSIG") ++ rest)
       = .ok (.opcode "OP_CHECKSIG", rest) := rfl
@@ -1414,6 +1423,7 @@ theorem parseStackOpFuel_opcode_allowed (fuel : Nat) (rest : List UInt8)
   obtain h1 | h1 := h1
   obtain h1 | h1 := h1
   obtain h1 | h1 := h1
+  obtain h1 | h1 := h1
   all_goals (subst h1; first
     | exact parseStackOpFuel_OP_VERIFY fuel rest
     | exact parseStackOpFuel_OP_NEGATE fuel rest
@@ -1425,6 +1435,7 @@ theorem parseStackOpFuel_opcode_allowed (fuel : Nat) (rest : List UInt8)
     | exact parseStackOpFuel_OP_EQUALVERIFY fuel rest
     | exact parseStackOpFuel_OP_HASH160 fuel rest
     | exact parseStackOpFuel_OP_SHA256 fuel rest
+    | exact parseStackOpFuel_OP_HASH256 fuel rest
     | exact parseStackOpFuel_OP_CHECKSIG fuel rest
     | exact parseStackOpFuel_OP_CHECKSIGVERIFY fuel rest
     | exact parseStackOpFuel_OP_CAT fuel rest
@@ -1557,6 +1568,7 @@ theorem emitStackOpL_cons_of_RunarEmittable (op : StackOp)
       obtain hN | hN := hN
       obtain hN | hN := hN
       obtain hN | hN := hN
+      obtain hN | hN := hN
       all_goals (subst hN; first
         | exact ⟨0x69, [], rfl⟩  -- VERIFY
         | exact ⟨0x8f, [], rfl⟩  -- NEGATE
@@ -1568,6 +1580,7 @@ theorem emitStackOpL_cons_of_RunarEmittable (op : StackOp)
         | exact ⟨0x88, [], rfl⟩  -- EQUALVERIFY
         | exact ⟨0xa9, [], rfl⟩  -- HASH160
         | exact ⟨0xa8, [], rfl⟩  -- SHA256
+        | exact ⟨0xaa, [], rfl⟩  -- HASH256 (2026-06-13 fusion image)
         | exact ⟨0xac, [], rfl⟩  -- CHECKSIG
         | exact ⟨0xad, [], rfl⟩  -- CHECKSIGVERIFY
         | exact ⟨0x7e, [], rfl⟩  -- CAT
@@ -1839,6 +1852,7 @@ theorem emitStackOp_toList_of_RunarEmittable (op : StackOp)
       unfold isAllowedOpcodeName at hAllow
       simp only [Bool.or_eq_true, decide_eq_true_eq] at hAllow
       obtain hN | hN := hAllow
+      obtain hN | hN := hN
       obtain hN | hN := hN
       obtain hN | hN := hN
       obtain hN | hN := hN
@@ -2248,6 +2262,7 @@ private theorem head_of_emitStackOpL_not_else_or_endif
       unfold isAllowedOpcodeName at hAllow
       simp only [Bool.or_eq_true, decide_eq_true_eq] at hAllow
       obtain hN | hN := hAllow
+      obtain hN | hN := hN
       obtain hN | hN := hN
       obtain hN | hN := hN
       obtain hN | hN := hN

--- a/runar-verification/RunarVerification/Stack/AgreesHashCall.lean
+++ b/runar-verification/RunarVerification/Stack/AgreesHashCall.lean
@@ -819,11 +819,13 @@ Each intermediate is consumed in place (depth-0 last-use), so the method
 lowers to the bare 2-opcode list `[op1, op2]` — no elision (the body is
 VALUE-terminated), no NIPs (the `bodyEndsInAssert` gate is false).
 
-SCOPE (probed 2026-06-11): the pair `(sha256, sha256)` is EXCLUDED — the
-peephole `applyDoubleSha256` fuses `[OP_SHA256, OP_SHA256]` to `[OP_HASH256]`
-(sound — `hash256 = sha256 ∘ sha256` — but a different M3/M4 image; covering
-it via the `runOps_hash256Ops_eq_composition` transport is deferred).  The
-remaining three pairs are peephole-stable. -/
+SCOPE (2026-06-13, widened): all FOUR ordered hash pairs are covered.  Three
+are peephole-STABLE (`hashChainOps` survives unchanged).  The pair
+`(sha256, sha256)` is peephole-FUSING — `applyDoubleSha256` rewrites
+`[OP_SHA256, OP_SHA256]` to `[OP_HASH256]` — and is sound via
+`hash256 = sha256 ∘ sha256` (`runOps_hash256Ops_eq_composition`); its M3/M4
+image is `[OP_HASH256]`, discharged in `Pipeline.hashChain_consume_sha256d_core`
+(`OP_HASH256` is allowlisted for the round-trip in `Script.Parse`). -/
 
 /-- The 2-chain body shape. -/
 def hashChainBody (d1 d2 arg f1 f2 : String) (s1 s2 : Option SourceLoc) :
@@ -835,12 +837,22 @@ def hashChainBody (d1 d2 arg f1 f2 : String) (s1 s2 : Option SourceLoc) :
 def hashChainOps (op1 op2 : String) : List StackOp :=
   [.opcode op1, .opcode op2]
 
-/-- The admissible (peephole-stable) function pairs.  `(sha256, sha256)` is
-deliberately ABSENT — see the Part 9 header. -/
+/-- The admissible function pairs.  Three pairs are peephole-STABLE
+(`hashChainOps` survives the peephole unchanged); `(sha256, sha256)` is also
+admitted but is peephole-FUSING — the pair `[OP_SHA256, OP_SHA256]` fuses to
+`[OP_HASH256]` (sound: `hash256 = sha256 ∘ sha256`).  See the Part 9 header
+and `hashChainFuses` for the discriminator. -/
 def hashChainFuncsOk (f1 f2 : String) : Bool :=
   (f1 == "sha256" && f2 == "hash160")
     || (f1 == "hash160" && f2 == "sha256")
     || (f1 == "hash160" && f2 == "hash160")
+    || (f1 == "sha256" && f2 == "sha256")
+
+/-- Discriminates the peephole-FUSING pair `(sha256, sha256)` from the three
+peephole-stable pairs.  The fusing pair lowers to `[OP_SHA256, OP_SHA256]`,
+which the peephole `applyDoubleSha256` rewrites to `[OP_HASH256]`. -/
+def hashChainFuses (f1 f2 : String) : Bool :=
+  f1 == "sha256" && f2 == "sha256"
 
 /-- The concrete last-use table of the 2-chain body. -/
 theorem computeLastUses_hashChain
@@ -915,14 +927,15 @@ theorem lowerMethod_ops_hashChain
       = ([StackOp.opcode op2], [d2], [d1, d2])) :
     (Lower.lowerMethod progMethods props anfM).ops = hashChainOps op1 op2 := by
   have hF : (f1 = "sha256" ∧ f2 = "hash160") ∨ (f1 = "hash160" ∧ f2 = "sha256")
-      ∨ (f1 = "hash160" ∧ f2 = "hash160") := by
+      ∨ (f1 = "hash160" ∧ f2 = "hash160") ∨ (f1 = "sha256" ∧ f2 = "sha256") := by
     have h := hFuncs
     simp only [hashChainFuncsOk, Bool.or_eq_true, Bool.and_eq_true,
       beq_iff_eq] at h
-    rcases h with (h | h) | h
+    rcases h with ((h | h) | h) | h
     · exact Or.inl h
     · exact Or.inr (Or.inl h)
-    · exact Or.inr (Or.inr h)
+    · exact Or.inr (Or.inr (Or.inl h))
+    · exact Or.inr (Or.inr (Or.inr h))
   unfold Lower.lowerMethod
   rw [hParams, hBody, hPub]
   simp only [List.map_cons, List.map_nil, List.reverse_cons, List.reverse_nil,
@@ -932,8 +945,8 @@ theorem lowerMethod_ops_hashChain
     simp [hashChainBody, Lower.bindingsUseCheckPreimage]
   have hUsesCode : Lower.bindingsUseCodePart
       (hashChainBody d1 d2 arg f1 f2 s1 s2) = false := by
-    rcases hF with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ <;> subst h1 <;> subst h2 <;>
-      simp [hashChainBody, Lower.bindingsUseCodePart]
+    rcases hF with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ <;> subst h1 <;>
+      subst h2 <;> simp [hashChainBody, Lower.bindingsUseCodePart]
   have hEndsAssert : Lower.bodyEndsInAssert
       (hashChainBody d1 d2 arg f1 f2 s1 s2) = false := by
     simp [hashChainBody, Lower.bodyEndsInAssert]
@@ -1072,11 +1085,12 @@ theorem smoke_hashChain_classifier_fires :
     hashAssertConsumeShapeBool hashChainSmokeMethod = false := by
   refine ⟨?_, ?_, ?_⟩ <;> decide +kernel
 
-/-- SMOKE — the excluded fusing pair `(sha256, sha256)` is NOT classified. -/
-theorem smoke_hashChain_excludes_double_sha256 :
+/-- SMOKE — the fusing pair `(sha256, sha256)` IS now classified (2026-06-13
+widening; its method ops fuse `[OP_SHA256, OP_SHA256] → [OP_HASH256]`). -/
+theorem smoke_hashChain_includes_double_sha256 :
     hashChainConsumeShapeBool
       { hashChainSmokeMethod with
-        body := hashChainBody "d1" "d2" "x" "sha256" "sha256" none none } = false := by
+        body := hashChainBody "d1" "d2" "x" "sha256" "sha256" none none } = true := by
   decide +kernel
 
 /-- SMOKE — the canonical chain's method ops reduce to the bare 2-opcode list. -/


### PR DESCRIPTION
Closes the `(sha256, sha256)` exclusion in the W2 two-chain hash fragment (`d1 := f1(arg); d2 := f2(d1)`). The fragment now covers all four ordered hash pairs. **Coverage widening — axiom count unchanged (70).**

## What this adds
Programs of shape `h(x){ d1 := sha256(x); d2 := sha256(d1) }` previously fell to the universal `crypto_call` fallback. They are now backed by a real codegen-to-spec discharge.

The one real difference from the three stable pairs: the peephole **fuses** `[OP_SHA256, OP_SHA256] → [OP_HASH256]`, so this pair has a distinct M3/M4 image.
- `peepholeMethodOps_hashChain_sha256_sha256` (Pipeline.lean) — fused M3 image `[OP_HASH256]` via `applyDoubleSha256`.
- `hashChain_consume_sha256d_core` — M4 parse round-trip + M2 runtime walk over `[OP_HASH256]`, matching the ANF `d2 = sha256(sha256 arg)` via `runOps_hash256Ops_eq_composition` (`hash256 = sha256 ∘ sha256`).
- `hashChainFuncsOk` + `hashChainConsumeShapeBool` admit the pair; `hashChain_consume` gains a 4th branch; smoke `smoke_hashChain_consume_fires_sha256d` fires it.
- `Script/Parse.lean`: `OP_HASH256` (byte `0xaa`) added to `isAllowedOpcodeName` — the fused image had to round-trip through the emittable-push allowlist; `OP_HASH256` was simply missing. `parseStackOpFuel_OP_HASH256` is `rfl`.

## Verification (all green)
- `lake build` (full) — success.
- `lake exe omnibusInstantiation` — OK.
- `scripts/check-tcb-drift.sh` — `axioms = 70` (UNCHANGED), opaques/stubs/partials 0.

No `sorry`/`admit`, no new axiom, no classifier weakened.