### PR TITLE
verification: extend CScriptNum operand coercion to comparison opcodes

### DIFF
--- a/runar-verification/RunarVerification/Stack/AgreesStateful.lean
+++ b/runar-verification/RunarVerification/Stack/AgreesStateful.lean
@@ -730,6 +730,120 @@ theorem runOpcode_LESSTHAN_intBytes
   simp only [Eval.popN, StackState.pop?, hStk]
   simp [Eval.asNum?, Eval.asInt?, hSz]
 
+/-! ### Byte-coercion fidelity smokes for the widened comparison / select ops
+
+The 2026-06-13 extension wires the consensus `asNum?` coercion into the
+comparison and numeric-select opcodes (`OP_GREATERTHAN`,
+`OP_LESSTHANOREQUAL`, `OP_GREATERTHANOREQUAL`, `OP_NUMEQUAL`,
+`OP_NUMNOTEQUAL`, `OP_MIN`, `OP_MAX`) that deployed-bytes machinery feeds
+byte-encoded literals to (the stateful varint encoder, num2bin's
+size-dispatch, clamp/pow).  These concrete smokes feed a parsed
+`vBytes` numeric push (the wire encoding `[0xfd, 0x00]` = 253, exactly
+what `push 253` parses back to) to each newly-widened opcode and confirm
+it now evaluates to the CONSENSUS result instead of type-erroring.  The
+top operand is the byte vector; the second-from-top is a typed bigint
+(`100`), mirroring the real stack shape (`OP_DUP; push 253; OP_…`). -/
+
+/-- A parsed 2-byte CScriptNum push of 253 (the `push 253` wire form). -/
+def bytes253 : ByteArray := ByteArray.mk #[0xfd, 0x00]
+
+/-- The load-bearing consensus fact, checked by the kernel evaluator: the
+parsed `push 253` byte vector decodes (via the `asNum?` ≤4-byte path) to the
+integer 253, and is ≤ 4 bytes so the coercion applies.  Every byte-coercion
+smoke below rides on this. -/
+theorem bytes253_decodes : decodeMinimalLE bytes253 = 253 ∧ bytes253.size ≤ 4 := by
+  native_decide
+
+/-- Generic reduction: a `liftIntBinNum`-wired opcode given a bigint
+second-from-top and a ≤4-byte vector top decodes the top via `asNum?` and
+applies `f`.  Mirrors `runOpcode_LESSTHAN_intBytes` but parameterised over the
+opcode's def-lemma equation `hDef`. -/
+private theorem liftIntBinNum_intBytes_reduce
+    (s : StackState) (op : String) (f : Int → Int → Value)
+    (a : Int) (bB : ByteArray) (rest : List Value)
+    (hDef : Eval.runOpcode op s = Eval.liftIntBinNum s f)
+    (hStk : s.stack = .vBytes bB :: .vBigint a :: rest)
+    (hSz : bB.size ≤ 4) :
+    Eval.runOpcode op s
+      = .ok ({ s with stack := rest }.push (f a (decodeMinimalLE bB))) := by
+  rw [hDef]
+  unfold Eval.liftIntBinNum
+  simp only [Eval.popN, StackState.pop?, hStk]
+  simp [Eval.asNum?, Eval.asInt?, hSz]
+
+/-- SMOKE — `OP_GREATERTHAN` coerces a byte-literal top operand: `100 > 253`
+is `false`, matching consensus (the bare `asInt?` would type-error). -/
+theorem smoke_GREATERTHAN_byte_coerces (s : StackState) (rest : List Value)
+    (hStk : s.stack = .vBytes bytes253 :: .vBigint 100 :: rest) :
+    Eval.runOpcode "OP_GREATERTHAN" s
+      = .ok ({ s with stack := rest }.push (.vBool false)) := by
+  have := liftIntBinNum_intBytes_reduce s "OP_GREATERTHAN"
+    (fun a b => .vBool (decide (a > b))) 100 bytes253 rest
+    (Sim.runOpcode_GREATERTHAN_def s) hStk bytes253_decodes.2
+  rw [this]; simp [bytes253_decodes.1]
+
+/-- SMOKE — `OP_LESSTHANOREQUAL` coerces a byte-literal top: `100 ≤ 253`. -/
+theorem smoke_LESSTHANOREQUAL_byte_coerces (s : StackState) (rest : List Value)
+    (hStk : s.stack = .vBytes bytes253 :: .vBigint 100 :: rest) :
+    Eval.runOpcode "OP_LESSTHANOREQUAL" s
+      = .ok ({ s with stack := rest }.push (.vBool true)) := by
+  have := liftIntBinNum_intBytes_reduce s "OP_LESSTHANOREQUAL"
+    (fun a b => .vBool (decide (a ≤ b))) 100 bytes253 rest
+    (Sim.runOpcode_LESSTHANOREQUAL_def s) hStk bytes253_decodes.2
+  rw [this]; simp [bytes253_decodes.1]
+
+/-- SMOKE — `OP_GREATERTHANOREQUAL` coerces a byte-literal top: `100 ≥ 253`. -/
+theorem smoke_GREATERTHANOREQUAL_byte_coerces (s : StackState) (rest : List Value)
+    (hStk : s.stack = .vBytes bytes253 :: .vBigint 100 :: rest) :
+    Eval.runOpcode "OP_GREATERTHANOREQUAL" s
+      = .ok ({ s with stack := rest }.push (.vBool false)) := by
+  have := liftIntBinNum_intBytes_reduce s "OP_GREATERTHANOREQUAL"
+    (fun a b => .vBool (decide (a ≥ b))) 100 bytes253 rest
+    (Sim.runOpcode_GREATERTHANOREQUAL_def s) hStk bytes253_decodes.2
+  rw [this]; simp [bytes253_decodes.1]
+
+/-- SMOKE — `OP_NUMEQUAL` coerces a byte-literal top: `253 = 253`.  This is
+the num2bin size-dispatch shape (`OP_DUP; push 254/77; OP_NUMEQUAL`). -/
+theorem smoke_NUMEQUAL_byte_coerces (s : StackState) (rest : List Value)
+    (hStk : s.stack = .vBytes bytes253 :: .vBigint 253 :: rest) :
+    Eval.runOpcode "OP_NUMEQUAL" s
+      = .ok ({ s with stack := rest }.push (.vBool true)) := by
+  have := liftIntBinNum_intBytes_reduce s "OP_NUMEQUAL"
+    (fun a b => .vBool (decide (a = b))) 253 bytes253 rest
+    (Sim.runOpcode_NUMEQUAL_def s) hStk bytes253_decodes.2
+  rw [this]; simp [bytes253_decodes.1]
+
+/-- SMOKE — `OP_NUMNOTEQUAL` coerces a byte-literal top: `100 ≠ 253`. -/
+theorem smoke_NUMNOTEQUAL_byte_coerces (s : StackState) (rest : List Value)
+    (hStk : s.stack = .vBytes bytes253 :: .vBigint 100 :: rest) :
+    Eval.runOpcode "OP_NUMNOTEQUAL" s
+      = .ok ({ s with stack := rest }.push (.vBool true)) := by
+  have := liftIntBinNum_intBytes_reduce s "OP_NUMNOTEQUAL"
+    (fun a b => .vBool (decide (a ≠ b))) 100 bytes253 rest
+    (Sim.runOpcode_NUMNOTEQUAL_def s) hStk bytes253_decodes.2
+  rw [this]; simp [bytes253_decodes.1]
+
+/-- SMOKE — `OP_MIN` coerces a byte-literal top: `min 100 253 = 100`.
+This is the clamp machinery shape (`OP_MAX … OP_MIN`). -/
+theorem smoke_MIN_byte_coerces (s : StackState) (rest : List Value)
+    (hStk : s.stack = .vBytes bytes253 :: .vBigint 100 :: rest) :
+    Eval.runOpcode "OP_MIN" s
+      = .ok ({ s with stack := rest }.push (.vBigint 100)) := by
+  have := liftIntBinNum_intBytes_reduce s "OP_MIN"
+    (fun a b => .vBigint (min a b)) 100 bytes253 rest
+    (Sim.runOpcode_MIN_def s) hStk bytes253_decodes.2
+  rw [this]; simp only [bytes253_decodes.1, show min (100 : Int) 253 = 100 from by decide]
+
+/-- SMOKE — `OP_MAX` coerces a byte-literal top: `max 100 253 = 253`. -/
+theorem smoke_MAX_byte_coerces (s : StackState) (rest : List Value)
+    (hStk : s.stack = .vBytes bytes253 :: .vBigint 100 :: rest) :
+    Eval.runOpcode "OP_MAX" s
+      = .ok ({ s with stack := rest }.push (.vBigint 253)) := by
+  have := liftIntBinNum_intBytes_reduce s "OP_MAX"
+    (fun a b => .vBigint (max a b)) 100 bytes253 rest
+    (Sim.runOpcode_MAX_def s) hStk bytes253_decodes.2
+  rw [this]; simp only [bytes253_decodes.1, show max (100 : Int) 253 = 253 from by decide]
+
 /-- Abbreviation for the accumulated state-script bytes:
 `codePart ++ OP_RETURN ++ stateVal(8-byte LE)`. -/
 def epiAcc (cpV sv8 : ByteArray) : ByteArray :=

--- a/runar-verification/RunarVerification/Stack/Eval.lean
+++ b/runar-verification/RunarVerification/Stack/Eval.lean
@@ -139,15 +139,28 @@ number); the bare `asInt?` rejects it.
 
 `asNum?` is the faithful operand coercion: byte vectors of ≤ 4 bytes
 decode via `decodeMinimalLE`; every other value falls back to `asInt?`.
-It is wired into `OP_LESSTHAN` only (the one opcode the discharged
-deployed-bytes walks currently exercise with a byte-encoded literal);
-the remaining numeric opcodes keep the strictly-typed `liftIntBin`
+It is wired into the COMPARISON and numeric-SELECT opcodes that the
+deployed-bytes machinery feeds byte-encoded literals to:
+`OP_LESSTHAN`, `OP_GREATERTHAN`, `OP_LESSTHANOREQUAL`,
+`OP_GREATERTHANOREQUAL`, `OP_NUMEQUAL`, `OP_NUMNOTEQUAL`, `OP_MIN`,
+`OP_MAX` (the varint encoder pushes 253; num2bin's size-dispatch feeds
+`push 254`/`push 77` to `OP_NUMEQUAL`; clamp/pow feed `push i` to
+`OP_MAX`/`OP_MIN`/`OP_GREATERTHAN`).  These coercions are safe because
+`asNum?` agrees with `asInt?` on `vBigint`/`vBool` operands
+(`asNum?_vBigint` / `asNum?_vBool`), so every success-direction
+lockstep theorem (which only ever runs on typed operands) is unchanged,
+and NO failure-direction theorem asserts these opcodes error on a byte
+top.
+
+The ARITHMETIC opcodes (`OP_ADD`, `OP_SUB`, `OP_MUL`, `OP_NEGATE`, and
+the shift ops) deliberately keep the strictly-typed `liftIntBin`,
 because the Wave-30 failure-lockstep theorems
-(`AgreesA3.liftIntBin_nonInt_top_isError` and friends) pin the ANF
-type-error ⟷ Stack type-error agreement for `+`/`-`/`*` on byte
-operands, and widening the coercion there would falsify them.  Extend
-opcode-by-opcode (with the matching ANF-side story) as future walks
-require. -/
+(`AgreesA3.liftIntBin_nonInt_top_isError`,
+`AgreesA3.runOpcode_binopOpcode_emittable_nonInt_top_isError` — covers
+EXACTLY `+`/`-`/`*`) pin the ANF type-error ⟷ Stack type-error
+agreement for those ops on byte operands, and widening the coercion
+there would falsify them.  Extend further opcode-by-opcode (with the
+matching ANF-side story) as future walks require. -/
 def asNum? (v : Value) : Option Int :=
   match v with
   | .vBytes b => if b.size ≤ 4 then some (decodeMinimalLE b) else none
@@ -538,18 +551,19 @@ def runOpcode (code : String) (s : StackState) : EvalResult StackState :=
   | "OP_RSHIFTNUM" => liftIntBin s (fun a b => .vBigint (a / (2 ^ b.toNat)))
   -- ---------------------------------------------------------------- comparison
   -- Consensus CScriptNum coercion (see `asNum?`): parsed numeric pushes
-  -- above OP_16 re-enter as `vBytes`; `OP_LESSTHAN` decodes them like the
-  -- real VM does (the stateful epilogue's varint encoder pushes 253).
+  -- above OP_16 re-enter as `vBytes`; the comparison + numeric-select
+  -- opcodes decode them like the real VM does (the stateful epilogue's
+  -- varint encoder pushes 253; num2bin/clamp feed byte literals here).
   | "OP_LESSTHAN"           => liftIntBinNum s (fun a b => .vBool (decide (a < b)))
-  | "OP_GREATERTHAN"        => liftIntBin s (fun a b => .vBool (decide (a > b)))
-  | "OP_LESSTHANOREQUAL"    => liftIntBin s (fun a b => .vBool (decide (a ≤ b)))
-  | "OP_GREATERTHANOREQUAL" => liftIntBin s (fun a b => .vBool (decide (a ≥ b)))
-  | "OP_NUMEQUAL"           => liftIntBin s (fun a b => .vBool (decide (a = b)))
-  | "OP_NUMNOTEQUAL"        => liftIntBin s (fun a b => .vBool (decide (a ≠ b)))
+  | "OP_GREATERTHAN"        => liftIntBinNum s (fun a b => .vBool (decide (a > b)))
+  | "OP_LESSTHANOREQUAL"    => liftIntBinNum s (fun a b => .vBool (decide (a ≤ b)))
+  | "OP_GREATERTHANOREQUAL" => liftIntBinNum s (fun a b => .vBool (decide (a ≥ b)))
+  | "OP_NUMEQUAL"           => liftIntBinNum s (fun a b => .vBool (decide (a = b)))
+  | "OP_NUMNOTEQUAL"        => liftIntBinNum s (fun a b => .vBool (decide (a ≠ b)))
   | "OP_BOOLAND"            => liftIntBin s (fun a b => .vBool (decide (a ≠ 0 ∧ b ≠ 0)))
   | "OP_BOOLOR"             => liftIntBin s (fun a b => .vBool (decide (a ≠ 0 ∨ b ≠ 0)))
-  | "OP_MIN"                => liftIntBin s (fun a b => .vBigint (min a b))
-  | "OP_MAX"                => liftIntBin s (fun a b => .vBigint (max a b))
+  | "OP_MIN"                => liftIntBinNum s (fun a b => .vBigint (min a b))
+  | "OP_MAX"                => liftIntBinNum s (fun a b => .vBigint (max a b))
   | "OP_WITHIN" =>
       match popN s 3 with
       | .error e => .error e
@@ -1312,6 +1326,19 @@ theorem liftIntBin_bigint_local
   unfold liftIntBin
   rw [popN_two_bigint_local s a b rest hStk]
   simp only [asInt?]
+
+/-- `liftIntBinNum` on a bigint top-two reduces to a push of `f a b`, exactly
+like `liftIntBin_bigint_local`.  The consensus `asNum?` coercion agrees with
+`asInt?` on `vBigint` operands (`asNum?_vBigint`), so the comparison /
+numeric-select opcodes wired through `liftIntBinNum` keep their bigint-operand
+success behaviour bit-for-bit.  In-module. -/
+theorem liftIntBinNum_bigint_local
+    (s : StackState) (f : Int → Int → Value) (a b : Int) (rest : List Value)
+    (hStk : s.stack = .vBigint b :: .vBigint a :: rest) :
+    liftIntBinNum s f = .ok ({ s with stack := rest }.push (f a b)) := by
+  unfold liftIntBinNum
+  rw [popN_two_bigint_local s a b rest hStk]
+  simp only [asNum?, asInt?]
 
 /-- `liftIntUnary` on a bigint top reduces to a push of `f a`.  In-module. -/
 theorem liftIntUnary_bigint_local

--- a/runar-verification/RunarVerification/Stack/Peephole.lean
+++ b/runar-verification/RunarVerification/Stack/Peephole.lean
@@ -362,7 +362,7 @@ tactic step (which exhausts `maxHeartbeats`).
 
 theorem runOpcode_NUMEQUAL_def (s : StackState) :
     runOpcode "OP_NUMEQUAL" s
-    = liftIntBin s (fun a b => .vBool (decide (a = b))) := rfl
+    = liftIntBinNum s (fun a b => .vBool (decide (a = b))) := rfl
 
 theorem runOpcode_VERIFY_def (s : StackState) :
     runOpcode "OP_VERIFY" s
@@ -458,9 +458,9 @@ theorem runOpcode_numEqual_int
     runOpcode "OP_NUMEQUAL" s
     = .ok (({ s with stack := rest } : StackState).push (.vBool (decide (a = b)))) := by
   rw [runOpcode_NUMEQUAL_def]
-  unfold liftIntBin
+  unfold liftIntBinNum
   rw [popN_two_cons s (.vBigint b) (.vBigint a) rest hs]
-  simp [asInt?]
+  simp [asNum?, asInt?]
 
 theorem runOpcode_NUMEQUALVERIFY_def (s : StackState) :
     runOpcode "OP_NUMEQUALVERIFY" s

--- a/runar-verification/RunarVerification/Stack/Sim.lean
+++ b/runar-verification/RunarVerification/Stack/Sim.lean
@@ -569,10 +569,10 @@ theorem runOpcode_RSHIFT_def (s : StackState) :
     = liftIntBin s (fun a b => .vBigint (a / (2 ^ b.toNat))) := rfl
 
 theorem runOpcode_MIN_def (s : StackState) :
-    runOpcode "OP_MIN" s = liftIntBin s (fun a b => .vBigint (min a b)) := rfl
+    runOpcode "OP_MIN" s = liftIntBinNum s (fun a b => .vBigint (min a b)) := rfl
 
 theorem runOpcode_MAX_def (s : StackState) :
-    runOpcode "OP_MAX" s = liftIntBin s (fun a b => .vBigint (max a b)) := rfl
+    runOpcode "OP_MAX" s = liftIntBinNum s (fun a b => .vBigint (max a b)) := rfl
 
 theorem runOpcode_WITHIN_def (s : StackState) :
     runOpcode "OP_WITHIN" s =
@@ -597,23 +597,23 @@ theorem runOpcode_LESSTHAN_def (s : StackState) :
 
 theorem runOpcode_GREATERTHAN_def (s : StackState) :
     runOpcode "OP_GREATERTHAN" s
-    = liftIntBin s (fun a b => .vBool (decide (a > b))) := rfl
+    = liftIntBinNum s (fun a b => .vBool (decide (a > b))) := rfl
 
 theorem runOpcode_LESSTHANOREQUAL_def (s : StackState) :
     runOpcode "OP_LESSTHANOREQUAL" s
-    = liftIntBin s (fun a b => .vBool (decide (a ≤ b))) := rfl
+    = liftIntBinNum s (fun a b => .vBool (decide (a ≤ b))) := rfl
 
 theorem runOpcode_GREATERTHANOREQUAL_def (s : StackState) :
     runOpcode "OP_GREATERTHANOREQUAL" s
-    = liftIntBin s (fun a b => .vBool (decide (a ≥ b))) := rfl
+    = liftIntBinNum s (fun a b => .vBool (decide (a ≥ b))) := rfl
 
 theorem runOpcode_NUMEQUAL_def (s : StackState) :
     runOpcode "OP_NUMEQUAL" s
-    = liftIntBin s (fun a b => .vBool (decide (a = b))) := rfl
+    = liftIntBinNum s (fun a b => .vBool (decide (a = b))) := rfl
 
 theorem runOpcode_NUMNOTEQUAL_def (s : StackState) :
     runOpcode "OP_NUMNOTEQUAL" s
-    = liftIntBin s (fun a b => .vBool (decide (a ≠ b))) := rfl
+    = liftIntBinNum s (fun a b => .vBool (decide (a ≠ b))) := rfl
 
 theorem runOpcode_BOOLAND_def (s : StackState) :
     runOpcode "OP_BOOLAND" s
@@ -867,18 +867,18 @@ theorem runOpcode_MIN_intInt
     (hStk : s.stack = .vBigint b :: .vBigint a :: rest) :
     runOpcode "OP_MIN" s = .ok ({ s with stack := rest }.push (.vBigint (min a b))) := by
   rw [runOpcode_MIN_def]
-  unfold liftIntBin
+  unfold liftIntBinNum
   rw [popN_two_local s _ _ rest hStk]
-  simp [asInt?]
+  simp [asNum?, asInt?]
 
 theorem runOpcode_MAX_intInt
     (s : StackState) (a b : Int) (rest : List Value)
     (hStk : s.stack = .vBigint b :: .vBigint a :: rest) :
     runOpcode "OP_MAX" s = .ok ({ s with stack := rest }.push (.vBigint (max a b))) := by
   rw [runOpcode_MAX_def]
-  unfold liftIntBin
+  unfold liftIntBinNum
   rw [popN_two_local s _ _ rest hStk]
-  simp [asInt?]
+  simp [asNum?, asInt?]
 
 theorem runOpcode_WITHIN_intIntInt
     (s : StackState) (x lo hi : Int) (rest : List Value)
@@ -905,45 +905,45 @@ theorem runOpcode_GREATERTHAN_intInt
     (hStk : s.stack = .vBigint b :: .vBigint a :: rest) :
     runOpcode "OP_GREATERTHAN" s = .ok ({ s with stack := rest }.push (.vBool (decide (a > b)))) := by
   rw [runOpcode_GREATERTHAN_def]
-  unfold liftIntBin
+  unfold liftIntBinNum
   rw [popN_two_local s _ _ rest hStk]
-  simp [asInt?]
+  simp [asNum?, asInt?]
 
 theorem runOpcode_LESSTHANOREQUAL_intInt
     (s : StackState) (a b : Int) (rest : List Value)
     (hStk : s.stack = .vBigint b :: .vBigint a :: rest) :
     runOpcode "OP_LESSTHANOREQUAL" s = .ok ({ s with stack := rest }.push (.vBool (decide (a ≤ b)))) := by
   rw [runOpcode_LESSTHANOREQUAL_def]
-  unfold liftIntBin
+  unfold liftIntBinNum
   rw [popN_two_local s _ _ rest hStk]
-  simp [asInt?]
+  simp [asNum?, asInt?]
 
 theorem runOpcode_GREATERTHANOREQUAL_intInt
     (s : StackState) (a b : Int) (rest : List Value)
     (hStk : s.stack = .vBigint b :: .vBigint a :: rest) :
     runOpcode "OP_GREATERTHANOREQUAL" s = .ok ({ s with stack := rest }.push (.vBool (decide (a ≥ b)))) := by
   rw [runOpcode_GREATERTHANOREQUAL_def]
-  unfold liftIntBin
+  unfold liftIntBinNum
   rw [popN_two_local s _ _ rest hStk]
-  simp [asInt?]
+  simp [asNum?, asInt?]
 
 theorem runOpcode_NUMEQUAL_intInt
     (s : StackState) (a b : Int) (rest : List Value)
     (hStk : s.stack = .vBigint b :: .vBigint a :: rest) :
     runOpcode "OP_NUMEQUAL" s = .ok ({ s with stack := rest }.push (.vBool (decide (a = b)))) := by
   rw [runOpcode_NUMEQUAL_def]
-  unfold liftIntBin
+  unfold liftIntBinNum
   rw [popN_two_local s _ _ rest hStk]
-  simp [asInt?]
+  simp [asNum?, asInt?]
 
 theorem runOpcode_NUMNOTEQUAL_intInt
     (s : StackState) (a b : Int) (rest : List Value)
     (hStk : s.stack = .vBigint b :: .vBigint a :: rest) :
     runOpcode "OP_NUMNOTEQUAL" s = .ok ({ s with stack := rest }.push (.vBool (decide (a ≠ b)))) := by
   rw [runOpcode_NUMNOTEQUAL_def]
-  unfold liftIntBin
+  unfold liftIntBinNum
   rw [popN_two_local s _ _ rest hStk]
-  simp [asInt?]
+  simp [asNum?, asInt?]
 
 theorem runOpcode_BOOLAND_intInt
     (s : StackState) (a b : Int) (rest : List Value)


### PR DESCRIPTION
Extends the consensus CScriptNum operand coercion (`Eval.asNum?` / `liftIntBinNum`) from `OP_LESSTHAN`-only to the comparison/select opcodes that deployed-bytes machinery feeds byte-encoded literals to. **Fidelity widening — axiom count unchanged (70).**

## Extended (7 + LESSTHAN)
`OP_GREATERTHAN`, `OP_LESSTHANOREQUAL`, `OP_GREATERTHANOREQUAL`, `OP_NUMEQUAL`, `OP_NUMNOTEQUAL`, `OP_MIN`, `OP_MAX`. Real consumers: varint encoder (`push 253`), num2bin size-dispatch (`push 254`/`77` → `OP_NUMEQUAL`, Lower.lean:1779-1802), clamp/pow (`OP_MAX`/`OP_MIN`/`OP_GREATERTHAN`, Lower.lean:3138-3168). These now decode parsed `vBytes` numeric pushes (≤4 bytes) like consensus instead of type-erroring.

## Boundary held (kept strict)
`OP_ADD`/`OP_SUB`/`OP_MUL`/`OP_NEGATE` + shifts — the Wave-30 failure-lockstep theorems (`AgreesA3.liftIntBin_nonInt_top_isError`, `runOpcode_binopOpcode_emittable_nonInt_top_isError`, which covers exactly `+`/`-`/`*`) pin ANF-type-error ⟷ Stack-type-error; coercing them would falsify those theorems. `OP_WITHIN`/`OP_NUMEQUALVERIFY` left strict (bespoke shape, no consumer pressure).

## Why safe
`asNum? ≡ asInt?` on `vBigint`/`vBool` operands (`asNum?_vBigint`/`asNum?_vBool` are `rfl`), so every success-direction lockstep proof is unaffected; only `runOpcode_X_def` rfl-plumbing in Sim.lean/Peephole.lean was repaired (via `liftIntBinNum_bigint` reduction). Grep-confirmed + build-confirmed: no failure-direction theorem asserts any of the 7 errors on a byte top, so none broke. No theorem statement was weakened.

## Verification (all green)
- `lake build` (full) — success.
- `lake exe omnibusInstantiation` — OK (basic-p2pkh byte-identical).
- `scripts/check-tcb-drift.sh` — `axioms = 70` (UNCHANGED).
- 7 new byte-coercion fidelity smokes (AgreesStateful.lean), one per widened opcode. No `sorry`/`admit`.