### PR TITLE
verification: widen math_byte fragment to 2-arg cat (OP_CAT)

### DIFF
--- a/runar-verification/RunarVerification.lean
+++ b/runar-verification/RunarVerification.lean
@@ -26,6 +26,7 @@ import RunarVerification.Stack.AgreesD1
 import RunarVerification.Stack.AgreesD2
 import RunarVerification.Stack.AgreesCrypto
 import RunarVerification.Stack.AgreesHashCall
+import RunarVerification.Stack.AgreesCat
 import RunarVerification.Stack.AgreesStateful
 import RunarVerification.Stack.AgreesEC
 import RunarVerification.Stack.OutputTrace

--- a/runar-verification/RunarVerification/Pipeline.lean
+++ b/runar-verification/RunarVerification/Pipeline.lean
@@ -10,6 +10,7 @@ import RunarVerification.Stack.AgreesA5
 import RunarVerification.Stack.AgreesA6
 import RunarVerification.Stack.AgreesA8
 import RunarVerification.Stack.AgreesHashCall
+import RunarVerification.Stack.AgreesCat
 import RunarVerification.Stack.AgreesStateful
 import RunarVerification.Stack.AgreesD1
 import RunarVerification.Stack.AgreesD2
@@ -8476,6 +8477,260 @@ theorem compileSafe_observational_correct_mathByte_consume
     AgreesA4.bodyEndsInAssert_false_of_noLen anfM.body tsm hShapeNoLen
   exact Stack.Eval.acceptAgrees_of_completion_of_truthy hOld (hTopTruthy hNoTA)
 
+/-! ## math_byte fragment WIDENED to the 2-arg `cat` builtin (OP_CAT)
+
+The single-arg math_byte consume fragment is widened here to admit the
+canonical two-param concatenation method `f(a, b) { d := cat(a, b) }`.
+There is no `+` on ByteString in Rúnar — byte concatenation is the `cat`
+builtin (`.call "cat" [a, b]` → `OP_CAT`).  The lowering substrate lives in
+`Stack/AgreesCat.lean`; this section carries the peephole reduction and the
+in-`Pipeline` consume theorem.
+
+`RAW = [swap, swap, OP_CAT]` (both params consumed; the d1d0 copy emits two
+swaps that cancel) and the post-peephole image collapses to `[OP_CAT]`
+(`applyDoubleSwap`), so this is the OPERATIONAL M3 regime (NOT op-list
+identity) exactly like the wave-63 update_prop image. -/
+
+/-- The 4-pass peephole pipeline collapses the cat fragment RAW
+`[swap, swap, OP_CAT]` to the single `[OP_CAT]` (the first pass'
+`applyDoubleSwap` cancels the swap pair; the remaining three passes are the
+identity on a single opcode). -/
+theorem peepholeMethodOps_catOps :
+    peepholeMethodOps AgreesCat.catOps = [StackOp.opcode "OP_CAT"] := by
+  unfold peepholeMethodOps
+  have hNoIf : Peephole.noIfOp AgreesCat.catOps := by
+    simp [AgreesCat.catOps, Peephole.noIfOp]
+  rw [Peephole.peepholePassAll_eq_flat_of_noIfOp _ hNoIf]
+  have hFlat : Peephole.peepholePassAllFlat AgreesCat.catOps
+      = [StackOp.opcode "OP_CAT"] := by
+    simp +decide [AgreesCat.catOps, Peephole.peepholePassAllFlat,
+      Peephole.applyEqualVerifyFuse, Peephole.applyCheckSigVerifyFuse,
+      Peephole.applyNumEqualVerifyFuse, Peephole.applyZeroNumEqual,
+      Peephole.applyDoubleSha256, Peephole.applyDoubleDrop, Peephole.applyDoubleOver,
+      Peephole.applyDoubleNot, Peephole.applyDoubleNegate, Peephole.applyOneSub,
+      Peephole.applyOneAdd, Peephole.applySubZero, Peephole.applyAddZero,
+      Peephole.applyPushPushMul, Peephole.applyPushPushSub, Peephole.applyPushPushAdd,
+      Peephole.applyDoubleSwap, Peephole.applyDupDrop, Peephole.applyDropAfterPush]
+  rw [hFlat]
+  have hNoIfCat : Peephole.noIfOp [StackOp.opcode "OP_CAT"] := by simp [Peephole.noIfOp]
+  rw [Peephole.peepholePostFold_eq_applyPushOne_of_noIfOp _ hNoIfCat]
+  have hPost : Peephole.applyPushOneSub
+      (Peephole.applyPushOneAdd [StackOp.opcode "OP_CAT"])
+      = [StackOp.opcode "OP_CAT"] := by
+    simp [Peephole.applyPushOneAdd, Peephole.applyPushOneSub]
+  rw [hPost, Peephole.peepholeChainFold_eq_self_of_noIfOp_pushFree _ hNoIfCat
+        (by simp [Peephole.pushFree]),
+    Peephole.peepholeRollPickFold_eq_self_of_noIfOp_flatNoop _ hNoIfCat
+        (by simp [Peephole.rollPickFoldFlatNoop, Peephole.rollPickFoldOpNoop])]
+
+/-- **cat 2-arg consume (completion-bit leg).** Discharges the omnibus
+obligation for a single-public `f(a, b) = cat(a, b)` method, given the
+two-bytes-typed entry (`a`, `b` resolve to bytes; the entry stack carries
+them as `b` over `a`).  PRIVATE leg; the headline `acceptAgrees` restatement
+is below.  4-leg transitivity:
+
+* **M2** — `AgreesCat.cat_M2` gives the body-level success iff between
+  `evalBindingsP` and `runOps catOps`.
+* **M3 (OPERATIONAL)** — unlike a single-opcode body, `peepholeMethodOps RAW
+  ≠ RAW`; `AgreesCat.runOps_catOnly_eq_catOps` proves
+  `runOps [OP_CAT] = runOps catOps` on the two-bytes entry (the swaps cancel).
+* **M4 (push round-trip)** — `[OP_CAT]` is `AreRunarEmittablePush`, fed to
+  `compileSafe_single_public_runOps_eq_push`.
+* **shape** — `peepholeProgram_single_public_shape` from `hSinglePublic` /
+  `hName`. -/
+private theorem cat_consume_completion
+    (p : ANFProgram) (anfM : ANFMethod) (bytes : ByteArray)
+    (bn a b : String) (src : Option SourceLoc)
+    (hMem : anfM ∈ p.methods) (hPublic : anfM.isPublic = true)
+    (hSafe : compileSafe p = .ok bytes)
+    (initialAnf : State) (initialStack : StackState)
+    (hSinglePublic : p.methods.filter (·.isPublic) = [anfM])
+    (hName : anfM.name ≠ "constructor")
+    (hParams : (anfM.params.map (·.name)).reverse = [b, a])
+    (hBody : anfM.body = [ANFBinding.mk bn (.call "cat" [a, b]) src])
+    (hab : a ≠ b)
+    (ba bb : ByteArray) (rest : List RunarVerification.ANF.Eval.Value)
+    (hArgA : initialAnf.resolveRef a = some (.vBytes ba))
+    (hArgB : initialAnf.resolveRef b = some (.vBytes bb))
+    (hStk : initialStack.stack = .vBytes bb :: .vBytes ba :: rest) :
+    successAgrees
+      (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf anfM.body)
+      (runParsedBytes bytes initialStack) := by
+  have hUnique :
+      ∀ m', m' ∈ p.methods → m'.isPublic = true →
+        (m'.name == anfM.name) = true → m' = anfM :=
+    unique_public_of_filter_singleton p anfM hSinglePublic
+  have hNoPreimage : Lower.bindingsUseCheckPreimage anfM.body = false := by
+    rw [hBody]; simp [Lower.bindingsUseCheckPreimage]
+  have hNoCode : Lower.bindingsUseCodePart anfM.body = false := by
+    rw [hBody]; simp [Lower.bindingsUseCodePart]
+  have hNoDeserialize : Lower.bindingsUseDeserializeState anfM.body = false := by
+    rw [hBody]; simp [Lower.bindingsUseDeserializeState]
+  have hNoTerminalAssert : Lower.bodyEndsInAssert anfM.body = false := by
+    rw [hBody]; simp [Lower.bodyEndsInAssert]
+  -- Method RAW = catOps.
+  have hRaw : Agrees.lowerMethodUserRawOps p.methods p.properties anfM = AgreesCat.catOps :=
+    AgreesCat.lowerMethodUserRawOps_cat p.methods p.properties anfM bn a b src
+      hParams hBody hab
+  -- Leg M2: ANF eval agrees with `runOps catOps`.
+  have hM2 :
+      successAgrees
+        (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf anfM.body)
+        (runOps AgreesCat.catOps initialStack) := by
+    rw [hBody]
+    exact AgreesCat.cat_M2 p.methods initialAnf initialStack bn a b src ba bb rest
+      hArgA hArgB hStk
+  -- Leg M2→method.
+  have hM2Method :
+      successAgrees
+        (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf anfM.body)
+        (runMethod (Lower.lower p) anfM.name initialStack) := by
+    have hRunEq :
+        runMethod (Lower.lower p) anfM.name initialStack
+          = runOps (Agrees.lowerMethodUserRawOps p.methods p.properties anfM) initialStack := by
+      have hP : p =
+          { contractName := p.contractName, properties := p.properties,
+            methods := p.methods } := rfl
+      rw [hP]
+      exact Agrees.runMethod_lower_public_unique_no_post_eq_userRaw
+        p.contractName p.properties p.methods anfM initialStack hMem hPublic hUnique
+        hNoPreimage hNoCode hNoTerminalAssert hNoDeserialize
+    rw [hRunEq, hRaw]; exact hM2
+  -- shape: post-peephole program is single-public with body `peepholeMethodOps RAW`.
+  obtain ⟨hPubSingleton, _hStackBody⟩ :=
+    peepholeProgram_single_public_shape p anfM hSinglePublic hName
+  have hPeepedOpsImg : (peepholedLoweredMethod p anfM).ops = [StackOp.opcode "OP_CAT"] := by
+    show peepholeMethodOps (Lower.lowerMethod p.methods p.properties anfM).ops
+      = [StackOp.opcode "OP_CAT"]
+    rw [Agrees.lowerMethod_ops_eq_userRaw_no_implicits_no_post
+          p.methods p.properties anfM hNoPreimage hNoCode hNoTerminalAssert hNoDeserialize,
+        hRaw, peepholeMethodOps_catOps]
+  have hEmitPush : Parse.AreRunarEmittablePush (peepholedLoweredMethod p anfM).ops := by
+    show Parse.areRunarEmittablePushBool (peepholedLoweredMethod p anfM).ops = true
+    rw [hPeepedOpsImg]; rfl
+  -- M4: `runParsedBytes bytes = runOps [OP_CAT]`.
+  have hM4 :
+      runParsedBytes bytes initialStack = runOps [StackOp.opcode "OP_CAT"] initialStack := by
+    have hEq :
+        runParsedBytes bytes initialStack
+          = runOps (peepholedLoweredMethod p anfM).ops initialStack :=
+      compileSafe_single_public_runOps_eq_push p bytes (peepholedLoweredMethod p anfM)
+        initialStack hSafe hPubSingleton hEmitPush
+    rw [hEq, hPeepedOpsImg]
+  -- M3 (operational): `runOps [OP_CAT] = runOps catOps` on the two-bytes entry.
+  have hM3 :
+      runOps [StackOp.opcode "OP_CAT"] initialStack = runOps AgreesCat.catOps initialStack :=
+    AgreesCat.runOps_catOnly_eq_catOps initialStack ba bb rest hStk
+  -- Compose: M2 ∘ M3 ∘ M4.
+  have hParsed :
+      successAgrees
+        (runMethod (Lower.lower p) anfM.name initialStack)
+        (runParsedBytes bytes initialStack) := by
+    rw [hM4, hM3]
+    have hMethodEq :
+        runMethod (Lower.lower p) anfM.name initialStack = runOps AgreesCat.catOps initialStack := by
+      have hRunEq :
+          runMethod (Lower.lower p) anfM.name initialStack
+            = runOps (Agrees.lowerMethodUserRawOps p.methods p.properties anfM) initialStack := by
+        have hP : p =
+            { contractName := p.contractName, properties := p.properties,
+              methods := p.methods } := rfl
+        rw [hP]
+        exact Agrees.runMethod_lower_public_unique_no_post_eq_userRaw
+          p.contractName p.properties p.methods anfM initialStack hMem hPublic hUnique
+          hNoPreimage hNoCode hNoTerminalAssert hNoDeserialize
+      rw [hRunEq, hRaw]
+    rw [hMethodEq]; exact successAgrees_refl _
+  exact successAgrees_trans _ _ _ hM2Method hParsed
+
+/-- **cat 2-arg consume (HEADLINE, acceptance bit).** Restated over
+`acceptAgrees` (truthy-top success-bit). The fragment is VALUE-terminated
+(the concatenated bytes land on top). A NONEMPTY byte string is truthy under
+the VM's `asBool?`, but the inputs are OPAQUE in-model (no nonempty-bytes
+axiom), so the truthiness fact is carried as the keyed `hTopTruthy` premise
+(FLAGGED: new hypothesis vs. the completion-era statement; discharged per
+fixture by `native_decide` on the concrete run). -/
+theorem compileSafe_observational_correct_cat_consume
+    (p : ANFProgram) (anfM : ANFMethod) (bytes : ByteArray)
+    (bn a b : String) (src : Option SourceLoc)
+    (hMem : anfM ∈ p.methods) (hPublic : anfM.isPublic = true)
+    (hSafe : compileSafe p = .ok bytes)
+    (initialAnf : State) (initialStack : StackState)
+    (hSinglePublic : p.methods.filter (·.isPublic) = [anfM])
+    (hName : anfM.name ≠ "constructor")
+    (hParams : (anfM.params.map (·.name)).reverse = [b, a])
+    (hBody : anfM.body = [ANFBinding.mk bn (.call "cat" [a, b]) src])
+    (hab : a ≠ b)
+    (ba bb : ByteArray) (rest : List RunarVerification.ANF.Eval.Value)
+    (hArgA : initialAnf.resolveRef a = some (.vBytes ba))
+    (hArgB : initialAnf.resolveRef b = some (.vBytes bb))
+    (hStk : initialStack.stack = .vBytes bb :: .vBytes ba :: rest)
+    (hTopTruthy : Lower.bodyEndsInAssert anfM.body = false →
+      ∀ s, runParsedBytes bytes initialStack = .ok s →
+        topTruthy s.stack = true) :
+    acceptAgrees
+      (RunarVerification.ANF.Eval.evalBindingsP p.methods initialAnf anfM.body)
+      (runParsedBytes bytes initialStack) := by
+  have hOld := cat_consume_completion
+    p anfM bytes bn a b src hMem hPublic hSafe initialAnf initialStack
+    hSinglePublic hName hParams hBody hab ba bb rest hArgA hArgB hStk
+  have hNoTA : Lower.bodyEndsInAssert anfM.body = false := by
+    rw [hBody]; simp [Lower.bodyEndsInAssert]
+  exact Stack.Eval.acceptAgrees_of_completion_of_truthy hOld (hTopTruthy hNoTA)
+
+/-! ### MANDATORY smoke: the cat consume theorem fires
+
+The canonical single-public cat contract `C` with public `f(a, b) =
+cat(a, b)`, fired end-to-end through `compileSafe_observational_correct_cat_consume`:
+`compileSafe` accepts it, and on a concrete two-bytes entry (`a ↦ #[01,02]`,
+`b ↦ #[03]`, the same bytes on the deployed stack as `b` over `a`) the ANF
+eval and the deployed-bytes run AGREE on their acceptance bit. -/
+
+private def catSmokeProg : ANFProgram :=
+  { contractName := "C", properties := [],
+    methods := [RunarVerification.Stack.AgreesCat.smokeMethod] }
+
+private def catSmokeAnf : State :=
+  { (default : State) with
+    bindings := [("b", .vBytes (ByteArray.mk #[3])), ("a", .vBytes (ByteArray.mk #[1, 2]))] }
+
+private def catSmokeStk : StackState :=
+  { (default : StackState) with
+    stack := [.vBytes (ByteArray.mk #[3]), .vBytes (ByteArray.mk #[1, 2])] }
+
+/-- SMOKE — `compileSafe_observational_correct_cat_consume` fires on the
+canonical cat contract.  The concatenation-result-truthiness fact is carried
+as `hTopTruthy` (the inputs are OPAQUE in-model; in reality `a ++ b` is
+nonempty when either input is, truthy under `asBool?`).  The fragment's
+REACHABILITY (compileSafe succeeds) is unconditional. -/
+theorem smoke_cat_consume_fires
+    (hTopTruthy : ∀ bytes s, compileSafe catSmokeProg = .ok bytes →
+        runParsedBytes bytes catSmokeStk = .ok s →
+        topTruthy s.stack = true) :
+    ∃ bytes, compileSafe catSmokeProg = .ok bytes ∧
+      acceptAgrees
+        (RunarVerification.ANF.Eval.evalBindingsP catSmokeProg.methods catSmokeAnf
+          RunarVerification.Stack.AgreesCat.smokeMethod.body)
+        (runParsedBytes bytes catSmokeStk) := by
+  obtain ⟨bytes, hSafe⟩ : ∃ b, compileSafe catSmokeProg = .ok b := by
+    have h : (compileSafe catSmokeProg).toOption.isSome = true := by native_decide
+    cases hc : compileSafe catSmokeProg with
+    | ok b => exact ⟨b, rfl⟩
+    | error e => rw [hc] at h; simp [Except.toOption] at h
+  refine ⟨bytes, hSafe, ?_⟩
+  have hMem : RunarVerification.Stack.AgreesCat.smokeMethod ∈ catSmokeProg.methods := by
+    simp [catSmokeProg]
+  have hPub : RunarVerification.Stack.AgreesCat.smokeMethod.isPublic = true := rfl
+  have hSP : catSmokeProg.methods.filter (·.isPublic)
+      = [RunarVerification.Stack.AgreesCat.smokeMethod] := by
+    simp [catSmokeProg, RunarVerification.Stack.AgreesCat.smokeMethod]
+  exact compileSafe_observational_correct_cat_consume catSmokeProg
+    RunarVerification.Stack.AgreesCat.smokeMethod bytes "d" "a" "b" none
+    hMem hPub hSafe catSmokeAnf catSmokeStk
+    hSP (by decide) rfl rfl (by decide)
+    (ByteArray.mk #[1, 2]) (ByteArray.mk #[3]) [] rfl rfl rfl
+    (fun _ s hRun => hTopTruthy bytes s hSafe hRun)
+
 /-- **The statefulFull DISCHARGED-PATH guard (2026-06-12 premise-shape
 repair).**  TRUE exactly when the omnibus dispatch reaches the
 `statefulFull` consume theorem: the widened classifier fires, the
@@ -8671,6 +8926,26 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms (p : ANFProgram)
         AgreesA4.structuralCallBody (Lower.computeLastUses anfM.body) []
           anfM.body (anfM.params.map (fun pp => pp.name) |>.reverse) 0 ∧
         AgreesA4.mathByteSingleArgBody anfM.body tsm initialAnf)
+    -- **math_byte-WIDENED 2-arg `cat` consume premise (keyed).**  For a body in
+    -- the canonical two-param `cat` fragment (decided by
+    -- `catConsumeShapeBool` — two distinct params `[a, b]`, body one binding
+    -- `bn := cat(a, b)`) the shape witnesses plus the two-bytes-typed entry
+    -- (`a`, `b` resolve to bytes; the entry stack carries them as `b` over `a`)
+    -- are recovered.  Keyed on the DECIDABLE classifier, it is VACUOUS for every
+    -- non-cat body (the antecedent is `false`), so the omnibus stays jointly
+    -- satisfiable; its only consumer is the conformance harness, which discharges
+    -- it per fixture from the bytes-typed entry.  Single-public-gated (like the
+    -- hash peel premises): the consequent pins the FULL entry-stack layout.
+    (hMathByteCatFrag : (p.methods.filter (·.isPublic)).length < 2 →
+      RunarVerification.Stack.AgreesCat.catConsumeShapeBool anfM = true →
+        ∃ (bn a b : String) (src : Option SourceLoc)
+          (ba bb : ByteArray) (rest : List RunarVerification.ANF.Eval.Value),
+          (anfM.params.map (·.name)).reverse = [b, a] ∧
+          anfM.body = [ANFBinding.mk bn (.call "cat" [a, b]) src] ∧
+          a ≠ b ∧
+          initialAnf.resolveRef a = some (.vBytes ba) ∧
+          initialAnf.resolveRef b = some (.vBytes bb) ∧
+          initialStack.stack = .vBytes bb :: .vBytes ba :: rest)
     -- **Wave 64 update_prop consume typed-entry premise (keyed).**  For a body
     -- in the canonical `prop ± small-const ; update_prop` consume fragment
     -- (decided by `updatePropConsumeShapeBool`) the entry tsm is the single
@@ -9091,6 +9366,7 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms (p : ANFProgram)
       have hHashCallFrag := hHashCallFrag hSpLt
       have hHashAssertFrag := hHashAssertFrag hSpLt
       have hHashChainFrag := hHashChainFrag hSpLt
+      have hMathByteCatFrag := hMathByteCatFrag hSpLt
       -- **Wave 39 consume-arith branch (replaces the retired arith axiom).**
       by_cases hArithConsume :
           anfM.name ≠ "constructor" ∧
@@ -9101,7 +9377,29 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms (p : ANFProgram)
           p hWF anfM bytes hMem hPublic hSafe initialAnf initialStack tsm hAgrees
           Γ hSinglePublic hArithConsume.1 hArithConsume.2 hUntag hTypedEntry
           (hTsmTyped hArithConsume) hCoh hValueTruthy
-      · -- **Wave 51 consume-`math_byte` branch (replaces the retired math_byte
+      · -- **math_byte-WIDENED 2-arg `cat` branch.**  The decidable
+        -- `catConsumeShapeBool` classifier pins the body to the canonical
+        -- two-param `cat(a, b)` consume fragment; the keyed `hMathByteCatFrag`
+        -- premise recovers the shape witnesses + the two-bytes-typed entry, and
+        -- the discharged consume theorem fires (value-terminated — consumes the
+        -- keyed `hValueTruthy` truthiness premise).  Bodies OUTSIDE this fragment
+        -- fall through to the single-arg math_byte / crypto_call cascade — NO new
+        -- axiom is introduced.
+        by_cases hCatShape :
+            RunarVerification.Stack.AgreesCat.catConsumeShapeBool anfM = true
+        case pos =>
+          by_cases hCatName : anfM.name ≠ "constructor"
+          · obtain ⟨bnC, aC, bC, srcC, baC, bbC, restC,
+              hCatParams, hCatBody, hCatNe, hCatArgA, hCatArgB, hCatStk⟩ :=
+              hMathByteCatFrag hCatShape
+            exact compileSafe_observational_correct_cat_consume p anfM bytes
+              bnC aC bC srcC hMem hPublic hSafe initialAnf initialStack
+              hSinglePublic hCatName hCatParams hCatBody hCatNe
+              baC bbC restC hCatArgA hCatArgB hCatStk hValueTruthy
+          · exact compileSafe_observational_correct_modulo_crypto_call_codegen
+              p hWF anfM bytes hMem hPublic hSafe initialAnf initialStack tsm hAgrees hValueTruthy
+        case neg =>
+        -- **Wave 51 consume-`math_byte` branch (replaces the retired math_byte
         -- axiom).**  The decidable NO-LEN math_byte classifier pins the body to
         -- `abs` / `bin2num` / `toByteString` chains at head slots; the keyed
         -- premise `hMathByteFrag` then supplies the copy-mode structural-call
@@ -9406,6 +9704,16 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms_via_support
         AgreesA4.structuralCallBody (Lower.computeLastUses anfM.body) []
           anfM.body (anfM.params.map (fun pp => pp.name) |>.reverse) 0 ∧
         AgreesA4.mathByteSingleArgBody anfM.body tsm initialAnf)
+    (hMathByteCatFrag : (p.methods.filter (·.isPublic)).length < 2 →
+      RunarVerification.Stack.AgreesCat.catConsumeShapeBool anfM = true →
+        ∃ (bn a b : String) (src : Option SourceLoc)
+          (ba bb : ByteArray) (rest : List RunarVerification.ANF.Eval.Value),
+          (anfM.params.map (·.name)).reverse = [b, a] ∧
+          anfM.body = [ANFBinding.mk bn (.call "cat" [a, b]) src] ∧
+          a ≠ b ∧
+          initialAnf.resolveRef a = some (.vBytes ba) ∧
+          initialAnf.resolveRef b = some (.vBytes bb) ∧
+          initialStack.stack = .vBytes bb :: .vBytes ba :: rest)
     (hUpdatePropFrag :
       Agrees.updatePropConsumeShapeBool anfM.body = true →
         ∀ (prop op : String) (c : Int),
@@ -9620,7 +9928,7 @@ theorem compileSafe_observational_correct_modulo_codegen_axioms_via_support
       (runParsedBytes bytes initialStack) :=
   compileSafe_observational_correct_modulo_codegen_axioms
     p hWF anfM bytes hMem hPublic hSafe initialAnf initialStack tsm hAgrees
-    hNoLoop Γ hUntag hTypedEntry hTsmTyped hIfValTyped hMathByteFrag hUpdatePropFrag
+    hNoLoop Γ hUntag hTypedEntry hTsmTyped hIfValTyped hMathByteFrag hMathByteCatFrag hUpdatePropFrag
     hMethodCallFrag hHashCallFrag hHashAssertFrag hHashChainFrag hStatefulFrag hStatefulFullFrag hDispatchFrag
     hDispatchMixedFrag hValueTruthy hCoh
 

--- a/runar-verification/RunarVerification/Stack/AgreesCat.lean
+++ b/runar-verification/RunarVerification/Stack/AgreesCat.lean
@@ -1,0 +1,348 @@
+import RunarVerification.ANF.Eval
+import RunarVerification.ANF.WellTyped
+import RunarVerification.Stack.Agrees
+import RunarVerification.Stack.Accept
+import RunarVerification.Stack.Sim
+
+/-! # `Stack/AgreesCat.lean` — method-level 2-arg `cat` (OP_CAT) consume substrate
+
+**Path 2 Tier 1 — math_byte fragment widened to the 2-argument `cat` builtin.**
+
+The discharged math_byte consume fragment (`mathByteSingleArgShapeNoLenBool`)
+is SINGLE-ARG only.  Concatenation is the only ByteString-`+`-shaped operation
+in Rúnar — there is no `+` on ByteString (`ANF.Eval.evalBinOp "+"` matches
+`.vBigint` only).  Byte concatenation is the `cat` builtin
+(`.call "cat" [a, b]` → `OP_CAT`).  This file carries the method-level
+substrate for peeling the canonical two-param `cat` method
+
+    f(a, b) { d := cat(a, b); return d }
+
+off the residual universal `crypto_call` fallback.
+
+## The lowering (why RAW = `[swap, swap, OP_CAT]`)
+
+With params `(a, b)` the entry user-map is `reverse [a, b] = [b, a]`, so `b`
+sits at depth 0 (top) and `a` at depth 1.  Both params are used exactly once,
+so the liveness-aware lowerer (`lowerValueP`) CONSUMES each.  `cat` is not a
+specially-cased call (`isSpecialCallFunc "cat" = false`), so it goes through
+the generic-else arm: `lowerArgsLive [a, b]` over `[b, a]` loads `a` (depth 1,
+consume → `.swap`, map → `[a, b]`) then `b` (depth 1, consume → `.swap`, map →
+`[b, a]`), then emits `OP_CAT`.  So
+
+    RAW = [.swap, .swap, .opcode "OP_CAT"]
+
+The two swaps cancel at runtime, so `runOps RAW = runOps [OP_CAT]` on the
+two-bytes-topped entry, and the post-peephole image collapses to `[OP_CAT]`
+(`applyDoubleSwap`).  The in-`Pipeline` consume theorem
+(`compileSafe_observational_correct_cat_consume`) composes these reductions.
+
+No `sorry`/`admit`, no new axioms. -/
+
+namespace RunarVerification.Stack.AgreesCat
+
+open RunarVerification.ANF RunarVerification.Stack RunarVerification.Stack.Agrees
+
+/-! ## Part 1 — the value-level `lowerValueP` reduction (generic-else, consume) -/
+
+/-- The canonical cat body: a single binding `d := cat(a, b)`. -/
+def catBody (d a b : String) (src : Option SourceLoc) : List ANFBinding :=
+  [ANFBinding.mk d (.call "cat" [a, b]) src]
+
+/-- The lowered RAW method ops of the cat fragment. -/
+def catOps : List StackOp :=
+  [.swap, .swap, .opcode "OP_CAT"]
+
+/-- `cat`'s body computes last-uses `[(b, 0), (a, 0)]`: both operands are read
+once at the single binding (index 0), in operand order `a` then `b`, so the
+last-use table threads them as `b` (most recent) then `a`. -/
+theorem computeLastUses_cat (d a b : String) (src : Option SourceLoc)
+    (hab : a ≠ b) :
+    Stack.Lower.computeLastUses (catBody d a b src) = [(b, 0), (a, 0)] := by
+  simp [catBody, Stack.Lower.computeLastUses, Stack.Lower.computeLastUses.go,
+    Stack.Lower.collectRefs, Stack.Lower.lastUsesUpdate, Stack.Lower.lastUsesLookup,
+    hab, Ne.symm hab]
+
+/-- The value-level cat reduction over the canonical entry map `[b, a]`:
+`a` (depth 1, consume → `.swap`), `b` (depth 1, consume → `.swap`), `OP_CAT`. -/
+theorem lowerValueP_call_cat_d1d0
+    (progMethods : List ANFMethod) (props : List ANFProperty) (budget : Nat)
+    (constInts : List (String × Int)) (d a b : String)
+    (hLU_a : Stack.Lower.isLastUse [(b, 0), (a, 0)] a 0 = true)
+    (hLU_b : Stack.Lower.isLastUse [(b, 0), (a, 0)] b 0 = true)
+    (hab : a ≠ b) :
+    Stack.Lower.lowerValueP progMethods props budget 0
+        [(b, 0), (a, 0)] [] [d] constInts [b, a] d (.call "cat" [a, b])
+      = ([.swap, .swap, .opcode "OP_CAT"], [d], [d]) := by
+  have hL : ∀ (smx : Stack.Lower.StackMap) (ci : Nat) (lu : List (String × Nat))
+      (oprot : List String),
+      Stack.Lower.loadRefOperand smx a [a, b] ci lu oprot
+        = Stack.Lower.loadRefLive smx a ci lu oprot :=
+    fun smx ci lu oprot => Stack.Lower.loadRefOperand_pair_left smx a b ci lu oprot hab
+  have hR : ∀ (smx : Stack.Lower.StackMap) (ci : Nat) (lu : List (String × Nat))
+      (oprot : List String),
+      Stack.Lower.loadRefOperand smx b [a, b] ci lu oprot
+        = Stack.Lower.loadRefLive smx b ci lu oprot :=
+    fun smx ci lu oprot => Stack.Lower.loadRefOperand_pair_right smx a b ci lu oprot hab
+  have hLoadA : Stack.Lower.loadRefLive [b, a] a 0 [(b, 0), (a, 0)] []
+      = ([.swap], [a, b]) := by
+    unfold Stack.Lower.loadRefLive Stack.Lower.bringToTop Stack.Lower.StackMap.depth?
+    have hfa : ([b, a] : Stack.Lower.StackMap).findIdx? (· == a) = some 1 := by
+      simp [List.findIdx?, List.findIdx?.go, Ne.symm hab]
+    rw [hfa]
+    simp [Stack.Lower.listContains, hLU_a]
+  have hLoadB : Stack.Lower.loadRefLive [a, b] b 0 [(b, 0), (a, 0)] []
+      = ([.swap], [b, a]) := by
+    unfold Stack.Lower.loadRefLive Stack.Lower.bringToTop Stack.Lower.StackMap.depth?
+    have hfb : ([a, b] : Stack.Lower.StackMap).findIdx? (· == b) = some 1 := by
+      simp [List.findIdx?, List.findIdx?.go, hab]
+    rw [hfb]
+    simp [Stack.Lower.listContains, hLU_b]
+  unfold Stack.Lower.lowerValueP
+  have hExt : Stack.Lower.isExtractor "cat" = false := by native_decide
+  simp only [hExt]
+  simp only [Stack.Lower.lowerArgsLive, hL, hR, hLoadA, hLoadB, Stack.Lower.builtinOpcode]
+  simp [Stack.Lower.StackMap.popN, Stack.Lower.StackMap.push]
+
+/-! ## Part 2 — the method-level RAW reduction -/
+
+/-- The single-binding consume hypothesis for an operand `r` read once in
+operand order at index 0: it is its own last use. -/
+theorem cat_consume_fact_left (d a b : String) (src : Option SourceLoc)
+    (hab : a ≠ b) :
+    Stack.Lower.isLastUse (Stack.Lower.computeLastUses (catBody d a b src)) a 0 = true := by
+  rw [computeLastUses_cat d a b src hab]
+  simp [Stack.Lower.isLastUse, Stack.Lower.lastUsesLookup, Ne.symm hab]
+
+/-- The right-operand consume fact. -/
+theorem cat_consume_fact_right (d a b : String) (src : Option SourceLoc)
+    (hab : a ≠ b) :
+    Stack.Lower.isLastUse (Stack.Lower.computeLastUses (catBody d a b src)) b 0 = true := by
+  rw [computeLastUses_cat d a b src hab]
+  simp [Stack.Lower.isLastUse, Stack.Lower.lastUsesLookup]
+
+/-- Method RAW for the canonical two-param `cat` method is
+`[.swap, .swap, OP_CAT]`. -/
+theorem lowerMethodUserRawOps_cat
+    (progMethods : List ANFMethod) (props : List ANFProperty) (anfM : ANFMethod)
+    (d a b : String) (src : Option SourceLoc)
+    (hParams : (anfM.params.map (·.name)).reverse = [b, a])
+    (hBody : anfM.body = catBody d a b src)
+    (hab : a ≠ b) :
+    Agrees.lowerMethodUserRawOps progMethods props anfM = catOps := by
+  unfold Agrees.lowerMethodUserRawOps
+  rw [hBody, hParams]
+  have hLU := computeLastUses_cat d a b src hab
+  have hLU_a := cat_consume_fact_left d a b src hab
+  have hLU_b := cat_consume_fact_right d a b src hab
+  rw [hLU] at hLU_a hLU_b
+  -- `lowerBindingsP` over the single binding = `lowerValueP ... ++ []`.
+  show (Stack.Lower.lowerBindingsP progMethods props Stack.Lower.defaultInlineBudget 0
+    (Stack.Lower.computeLastUses (catBody d a b src)) []
+    ((catBody d a b src).map (·.name))
+    (Stack.Lower.collectConstInts (catBody d a b src))
+    [b, a] (catBody d a b src)).1 = catOps
+  rw [hLU]
+  show (Stack.Lower.lowerBindingsP progMethods props Stack.Lower.defaultInlineBudget 0
+    [(b, 0), (a, 0)] [] [d]
+    (Stack.Lower.collectConstInts (catBody d a b src))
+    [b, a] (catBody d a b src)).1 = catOps
+  unfold catBody Stack.Lower.lowerBindingsP
+  rw [lowerValueP_call_cat_d1d0 progMethods props Stack.Lower.defaultInlineBudget
+    _ d a b hLU_a hLU_b hab]
+  simp only [Stack.Lower.lowerBindingsP, List.append_nil, catOps]
+
+/-! ## Part 3 — the runtime walks -/
+
+section Run
+open RunarVerification.Stack.Eval
+open RunarVerification.ANF.Eval (Value)
+
+/-- The deployed `[OP_CAT]` run on the canonical two-bytes-topped entry
+(`b` on top, `a` below): `OP_CAT` concatenates `a ++ b`. -/
+theorem runOps_catOnly
+    (s : StackState) (a b : ByteArray) (rest : List Value)
+    (hStk : s.stack = .vBytes b :: .vBytes a :: rest) :
+    runOps [.opcode "OP_CAT"] s
+      = .ok ({ s with stack := rest }.push (.vBytes (a ++ b))) := by
+  rw [runOps_cons_nonIf_eq _ _ _ (by intro thn els h; cases h)]
+  rw [stepNonIf_opcode, RunarVerification.Stack.Sim.runOpcode_CAT_bytesBytes s a b rest hStk]
+  simp only [runOps_nil]
+
+/-- The RAW `[swap, swap, OP_CAT]` run on the same entry: the two swaps cancel,
+so the result equals the bare-`OP_CAT` run. -/
+theorem runOps_catOps
+    (s : StackState) (a b : ByteArray) (rest : List Value)
+    (hStk : s.stack = .vBytes b :: .vBytes a :: rest) :
+    runOps catOps s
+      = .ok ({ s with stack := rest }.push (.vBytes (a ++ b))) := by
+  unfold catOps
+  rw [runOps_cons_nonIf_eq _ _ _ (by intro thn els h; cases h), stepNonIf_swap]
+  have hs1 : applySwap s = .ok { s with stack := .vBytes a :: .vBytes b :: rest } := by
+    unfold applySwap; rw [hStk]
+  rw [hs1]; simp only []
+  rw [runOps_cons_nonIf_eq _ _ _ (by intro thn els h; cases h), stepNonIf_swap]
+  have hs2 : applySwap { s with stack := .vBytes a :: .vBytes b :: rest }
+      = .ok { s with stack := .vBytes b :: .vBytes a :: rest } := by
+    unfold applySwap; rfl
+  rw [hs2]; simp only []
+  rw [runOps_cons_nonIf_eq _ _ _ (by intro thn els h; cases h), stepNonIf_opcode]
+  have hStk2 : ({ s with stack := .vBytes b :: .vBytes a :: rest } : StackState).stack
+      = .vBytes b :: .vBytes a :: rest := rfl
+  rw [RunarVerification.Stack.Sim.runOpcode_CAT_bytesBytes _ a b rest hStk2]
+  simp only [runOps_nil]
+
+/-- M3 (operational): the post-peephole image `[OP_CAT]` runs identically to
+`RAW = [swap, swap, OP_CAT]` on the canonical entry. -/
+theorem runOps_catOnly_eq_catOps
+    (s : StackState) (a b : ByteArray) (rest : List Value)
+    (hStk : s.stack = .vBytes b :: .vBytes a :: rest) :
+    runOps [.opcode "OP_CAT"] s = runOps catOps s := by
+  rw [runOps_catOnly s a b rest hStk, runOps_catOps s a b rest hStk]
+
+end Run
+
+/-! ## Part 4 — the body-level M2 walk (`evalBindingsP` ⟷ `runOps catOps`) -/
+
+section M2
+open RunarVerification.ANF.Eval (Value State evalValue evalBindings evalBindingsP)
+open RunarVerification.Stack.Eval
+
+/-- Local `cat` value-eval reduction: on `a ↦ vBytes ba`, `b ↦ vBytes bb`, the
+call computes `vBytes (ba ++ bb)`. -/
+theorem evalValue_call_cat_eq_local
+    (s : State) (x y : String) (ba bb : ByteArray)
+    (hx : s.resolveRef x = some (.vBytes ba))
+    (hy : s.resolveRef y = some (.vBytes bb)) :
+    evalValue s (.call "cat" [x, y]) = .ok (.vBytes (ba ++ bb), s) := by
+  show evalValue s (ANFValue.call "cat" [x, y]) = .ok (.vBytes (ba ++ bb), s)
+  unfold evalValue
+  simp only [List.mapM_cons, List.mapM_nil, RunarVerification.ANF.Eval.lookupRef, hx, hy,
+    bind, Except.bind, pure, Except.pure]
+  rfl
+
+/-- ANF side succeeds for the single `cat` binding. -/
+theorem evalBindingsP_single_cat_isSome
+    (progMethods : List ANFMethod) (s : State)
+    (bn x y : String) (src : Option SourceLoc) (ba bb : ByteArray)
+    (hx : s.resolveRef x = some (.vBytes ba))
+    (hy : s.resolveRef y = some (.vBytes bb)) :
+    (evalBindingsP progMethods s [ANFBinding.mk bn (.call "cat" [x, y]) src]).toOption.isSome
+      = true := by
+  have hNoMC : RunarVerification.ANF.Eval.noMethodCallBindings
+      [ANFBinding.mk bn (.call "cat" [x, y]) src] = true := by
+    simp [RunarVerification.ANF.Eval.noMethodCallBindings,
+      RunarVerification.ANF.Eval.noMethodCallValue]
+  rw [RunarVerification.ANF.Eval.evalBindingsP_eq_evalBindings_of_noMethodCall progMethods s
+        [ANFBinding.mk bn (.call "cat" [x, y]) src] hNoMC]
+  have hEval : evalBindings s [ANFBinding.mk bn (.call "cat" [x, y]) src]
+      = .ok (s.addBinding bn (.vBytes (ba ++ bb))) := by
+    unfold evalBindings
+    rw [evalValue_call_cat_eq_local s x y ba bb hx hy]
+    simp only [bind, Except.bind, evalBindings]
+  rw [hEval]; rfl
+
+/-- **M2 walk (cat).** The single-`cat`-call body's success bit agrees with the
+deployed `catOps` run on the matching two-bytes entry (`a` below `b` on top). -/
+theorem cat_M2
+    (progMethods : List ANFMethod) (anfSt : State)
+    (stkSt : StackState) (bn x y : String) (src : Option SourceLoc)
+    (ba bb : ByteArray) (rest : List Value)
+    (hx : anfSt.resolveRef x = some (.vBytes ba))
+    (hy : anfSt.resolveRef y = some (.vBytes bb))
+    (hStk : stkSt.stack = .vBytes bb :: .vBytes ba :: rest) :
+    (evalBindingsP progMethods anfSt [ANFBinding.mk bn (.call "cat" [x, y]) src]).toOption.isSome
+      ↔ (runOps catOps stkSt).toOption.isSome := by
+  have hANF := evalBindingsP_single_cat_isSome progMethods anfSt bn x y src ba bb hx hy
+  have hStack : (runOps catOps stkSt).toOption.isSome = true := by
+    rw [runOps_catOps stkSt ba bb rest hStk]; rfl
+  rw [hANF, hStack]
+
+end M2
+
+/-! ## Part 5 — the decidable fragment classifier
+
+`catConsumeShapeBool` decides the canonical two-param `cat` consume fragment: a
+method with exactly two distinct params `[a, b]` whose body is one binding
+`bn := cat(a, b)` (both params read once → consumed → RAW is `[swap, swap,
+OP_CAT]`).  The in-`Pipeline` dispatch `by_cases` on this; the witnesses are
+recovered by the keyed `hMathByteCatFrag` omnibus premise (vacuous on
+non-cat bodies). -/
+
+/-- Decidable two-param `cat` consume fragment classifier. -/
+def catConsumeShapeBool (m : ANFMethod) : Bool :=
+  match m.body with
+  | [ANFBinding.mk _ (.call func [a, b]) _] =>
+      (func == "cat") && (m.params.map (·.name) == [a, b]) && (a != b)
+  | _ => false
+
+/-- Existential extraction from the classifier: a classified method has a
+single `cat` binding over two distinct params `[a, b]`, with the reversed
+param-name list `[b, a]`. -/
+theorem catConsumeShapeBool_extract (m : ANFMethod)
+    (h : catConsumeShapeBool m = true) :
+    ∃ (bn a b : String) (src : Option SourceLoc),
+      m.body = [ANFBinding.mk bn (.call "cat" [a, b]) src] ∧
+      (m.params.map (·.name)) = [a, b] ∧
+      (m.params.map (·.name)).reverse = [b, a] ∧
+      a ≠ b := by
+  unfold catConsumeShapeBool at h
+  match hb : m.body with
+  | [ANFBinding.mk bn (.call func [a, b]) src] =>
+      rw [hb] at h
+      simp only [Bool.and_eq_true, beq_iff_eq, bne_iff_ne, ne_eq] at h
+      obtain ⟨⟨hFunc, hParams⟩, hab⟩ := h
+      subst hFunc
+      refine ⟨bn, a, b, src, rfl, hParams, ?_, hab⟩
+      rw [hParams]; rfl
+  | [] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.loadParam _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.loadProp _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.loadConst _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.binOp _ _ _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.unaryOp _ _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.call _ []) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.call _ [_]) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.call _ (_ :: _ :: _ :: _)) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.methodCall _ _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.ifVal _ _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.loop _ _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.assert _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.updateProp _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ .getStateScript _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.checkPreimage _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.deserializeState _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.addOutput _ _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.addRawOutput _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.addDataOutput _ _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.arrayLiteral _) _] => rw [hb] at h; simp at h
+  | [ANFBinding.mk _ (.rawScript _ _ _) _] => rw [hb] at h; simp at h
+  | _ :: _ :: _ => rw [hb] at h; simp at h
+
+/-! ## Part 6 — MANDATORY anti-vacuity smokes (concrete) -/
+
+/-- The canonical two-param `cat` method. -/
+def smokeMethod : ANFMethod :=
+  { name := "f"
+    params := [ANFParam.mk "a" .byteString, ANFParam.mk "b" .byteString]
+    body := [ANFBinding.mk "d" (.call "cat" ["a", "b"]) none]
+    isPublic := true }
+
+/-- SMOKE — the classifier fires on the canonical method (anti-vacuity). -/
+theorem smoke_classifier_fires : catConsumeShapeBool smokeMethod = true := by
+  decide +kernel
+
+/-- SMOKE — a single-arg call is REJECTED by the classifier (disjoint from the
+single-arg math_byte fragment). -/
+theorem smoke_classifier_rejects_singleArg :
+    catConsumeShapeBool
+      { name := "g", params := [ANFParam.mk "x" .byteString]
+        body := [ANFBinding.mk "d" (.call "toByteString" ["x"]) none]
+        isPublic := true } = false := by
+  decide +kernel
+
+/-- SMOKE — RAW reduces to `[swap, swap, OP_CAT]` for the canonical method. -/
+theorem smoke_method_raw :
+    Agrees.lowerMethodUserRawOps [] [] smokeMethod = catOps :=
+  lowerMethodUserRawOps_cat [] [] smokeMethod "d" "a" "b" none rfl rfl (by decide)
+
+end RunarVerification.Stack.AgreesCat

--- a/runar-verification/tests/OmnibusInstantiation.lean
+++ b/runar-verification/tests/OmnibusInstantiation.lean
@@ -181,6 +181,7 @@ theorem omnibus_instantiation_arith :
         rcases hpr with h | h | h <;> subst h <;> rfl))                  -- hTsmTyped (LIVE)
     (by intro bn cond thn els src h; simp [omniArithMethod] at h)        -- hIfValTyped
     (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ => vacuous (by native_decide))                                -- hMathByteCatFrag
     (vacuous (by native_decide))                                         -- hUpdatePropFrag
     (vacuous (by native_decide))                                         -- hMethodCallFrag
     (fun _ => vacuous (by native_decide))                                -- hHashCallFrag
@@ -286,6 +287,7 @@ theorem omnibus_instantiation_updateProp :
     (by intro bn cond thn els src h
         simp [omniCounterMethod, Agrees.updatePropConsumeBody] at h)     -- hIfValTyped
     (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ => vacuous (by native_decide))                                -- hMathByteCatFrag
     omniCounter_updatePropFrag                                           -- hUpdatePropFrag (LIVE)
     (vacuous (by native_decide))                                         -- hMethodCallFrag
     (fun _ => vacuous (by native_decide))                                -- hHashCallFrag
@@ -355,6 +357,7 @@ theorem omnibus_instantiation_hashLock :
         simp [AgreesHashCall.hashAssertSmokeMethod,
           AgreesHashCall.hashAssertBody] at h)                           -- hIfValTyped
     (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ => vacuous (by native_decide))                                -- hMathByteCatFrag
     (vacuous (by native_decide))                                         -- hUpdatePropFrag
     (vacuous (by native_decide))                                         -- hMethodCallFrag
     (fun _ => vacuous (by native_decide))                                -- hHashCallFrag
@@ -441,6 +444,7 @@ theorem omnibus_instantiation_stateful :
           Stack.StatefulBridge.gatedStatefulPrologueBody,
           Stack.AgreesD2.statefulPrologueBody] at h)                     -- hIfValTyped
     (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ => vacuous (by native_decide))                                -- hMathByteCatFrag
     (vacuous (by native_decide))                                         -- hUpdatePropFrag
     (vacuous (by native_decide))                                         -- hMethodCallFrag
     (fun _ => vacuous (by native_decide))                                -- hHashCallFrag
@@ -540,6 +544,7 @@ theorem omnibus_instantiation_statefulFull :
           Stack.AgreesD2.statefulPrologueBody,
           Stack.AgreesD2.statefulEpilogueBody] at h)                     -- hIfValTyped
     (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ => vacuous (by native_decide))                                -- hMathByteCatFrag
     (vacuous (by native_decide))                                         -- hUpdatePropFrag
     (vacuous (by native_decide))                                         -- hMethodCallFrag
     (fun _ => vacuous (by native_decide))                                -- hHashCallFrag
@@ -640,6 +645,7 @@ theorem omnibus_instantiation_dispatchMixed :
     (fun _ => omniMx_wt)                                                 -- hTsmTyped
     (by intro bn cond thn els src h; simp [omniMxMa] at h)               -- hIfValTyped
     (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ => vacuous (by native_decide))                                -- hMathByteCatFrag
     (vacuous (by native_decide))                                         -- hUpdatePropFrag
     (vacuous (by native_decide))                                         -- hMethodCallFrag
     (vacuousOf (by native_decide))                                       -- hHashCallFrag (multi-public)
@@ -700,6 +706,7 @@ theorem omnibus_instantiation_dispatchMixed_hashLock :
     (by intro bn cond thn els src h
         simp [omniMxUnlock, AgreesHashCall.hashAssertBody] at h)         -- hIfValTyped
     (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ => vacuous (by native_decide))                                -- hMathByteCatFrag
     (vacuous (by native_decide))                                         -- hUpdatePropFrag
     (vacuous (by native_decide))                                         -- hMethodCallFrag
     (vacuousOf (by native_decide))                                       -- hHashCallFrag (multi-public)
@@ -808,6 +815,7 @@ theorem omnibus_instantiation_p2pkh :
     (vacuousArith (by native_decide))                                    -- hTsmTyped
     (by intro bn cond thn els src h; simp [omniP2pkhUnlock] at h)        -- hIfValTyped
     (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ => vacuous (by native_decide))                                -- hMathByteCatFrag
     (vacuous (by native_decide))                                         -- hUpdatePropFrag
     (vacuous (by native_decide))                                         -- hMethodCallFrag
     (fun _ => vacuous (by native_decide))                                -- hHashCallFrag
@@ -820,12 +828,85 @@ theorem omnibus_instantiation_p2pkh :
     (fun _ => vacuousAssert (by native_decide))                          -- hValueTruthy
     omniP2pkh_coh                                                        -- hCoh
 
+/-! ## Fixture H — math_byte-WIDENED 2-arg `cat` family (`AgreesCat.smokeMethod`)
+
+`f(a, b) { d := cat(a, b) }` on concrete two-bytes entry (`a ↦ #[01,02]`,
+`b ↦ #[03]`, the deployed stack carrying them as `b` over `a`).  Value-
+terminated (the concatenation lands on top), so the truthiness premise is
+LIVE; the concatenated result `#[01,02,03]` is nonempty ⇒ truthy by
+`truthy_of_scriptAccepts` on the concrete run.  This is the only LIVE
+instantiation that drives the new `hMathByteCatFrag` consume arm of the
+omnibus dispatch end-to-end. -/
+
+def omniCatProg : ANFProgram :=
+  { contractName := "C", properties := [],
+    methods := [AgreesCat.smokeMethod] }
+
+def omniCatAB : ByteArray := ByteArray.mk #[1, 2]
+def omniCatBB : ByteArray := ByteArray.mk #[3]
+
+def omniCatAnf : State :=
+  { params := [("b", .vBytes omniCatBB), ("a", .vBytes omniCatAB)] }
+
+def omniCatStk : StackState :=
+  { stack := [.vBytes omniCatBB, .vBytes omniCatAB] }
+
+def omniCatBytes : ByteArray :=
+  Emit.emitFast (peepholeProgram (Lower.lower omniCatProg))
+
+def omniCatTsm : Agrees.TaggedStackMap :=
+  [("b", Agrees.SlotKind.param), ("a", Agrees.SlotKind.param)]
+
+theorem omniCat_coh : Agrees.tsmCoherent omniCatAnf omniCatTsm := by
+  intro s hs
+  simp only [omniCatTsm, List.mem_cons, List.not_mem_nil, or_false] at hs
+  rcases hs with h | h <;> subst h <;> rfl
+
+/-- **Omnibus instantiation — math_byte-WIDENED 2-arg `cat` family.** -/
+theorem omnibus_instantiation_cat :
+    Stack.Eval.acceptAgrees
+      (RunarVerification.ANF.Eval.evalBindingsP omniCatProg.methods omniCatAnf
+        AgreesCat.smokeMethod.body)
+      (runParsedBytes omniCatBytes omniCatStk) :=
+  compileSafe_observational_correct_modulo_codegen_axioms
+    omniCatProg
+    (by native_decide)                                                   -- hWF
+    AgreesCat.smokeMethod omniCatBytes
+    (by unfold omniCatProg; simp)                                        -- hMem
+    rfl                                                                  -- hPublic
+    (EntryDischarge.compileSafe_of_producesBool _ _ (by native_decide))  -- hSafe
+    omniCatAnf omniCatStk
+    omniCatTsm
+    ⟨⟨rfl, rfl, trivial⟩, rfl, rfl⟩                                      -- hAgrees
+    (by native_decide)                                                   -- hNoLoop
+    Typed.TypeEnv.empty                                                  -- Γ
+    (fun _ => rfl)                                                       -- hUntag (single-public)
+    (entryBigintTyped_empty _)                                           -- hTypedEntry
+    (vacuousArith (by native_decide))                                    -- hTsmTyped
+    (by intro bn cond thn els src h
+        simp [AgreesCat.smokeMethod] at h)                               -- hIfValTyped
+    (vacuous (by native_decide))                                         -- hMathByteFrag
+    (fun _ _ => ⟨"d", "a", "b", none, omniCatAB, omniCatBB, [],
+      rfl, rfl, by decide, rfl, rfl, rfl⟩)                              -- hMathByteCatFrag (LIVE)
+    (vacuous (by native_decide))                                         -- hUpdatePropFrag
+    (vacuous (by native_decide))                                         -- hMethodCallFrag
+    (fun _ => vacuous (by native_decide))                                -- hHashCallFrag
+    (fun _ => vacuous (by native_decide))                                -- hHashAssertFrag
+    (fun _ => vacuous (by native_decide))                                -- hHashChainFrag
+    (fun _ => vacuous (by native_decide))                                -- hStatefulFrag
+    (fun _ => vacuous (by native_decide))                                -- hStatefulFullFrag
+    (vacuous (by native_decide))                                         -- hDispatchFrag
+    (vacuous (by native_decide))                                         -- hDispatchMixedFrag
+    (fun _ _ => Stack.Eval.truthy_of_scriptAccepts (by native_decide))   -- hValueTruthy (LIVE)
+    omniCat_coh                                                          -- hCoh
+
 /-! ## Trust-footprint evidence (build-time) -/
 
 #print axioms omnibus_instantiation_arith
 #print axioms omnibus_instantiation_p2pkh
 #print axioms omnibus_instantiation_statefulFull
 #print axioms omnibus_instantiation_dispatchMixed_hashLock
+#print axioms omnibus_instantiation_cat
 
 end OmnibusInstantiation
 
@@ -873,6 +954,7 @@ def main : IO UInt32 := do
   IO.println "  omniDispatch   mixed dispatch consume (selector 0) synthetic (MX)"
   IO.println "  omniMxHL       mixed dispatch consume (selector 1) synthetic (MX hash-lock)"
   IO.println "  omniP2pkh      crypto_call fallback sub-omnibus    REAL basic-p2pkh golden"
+  IO.println "  omniCat        math_byte 2-arg cat consume         synthetic (cat(a,b))"
   IO.println ""
   IO.println "Each row is a zero-sorry theorem `omnibus_instantiation_*` applying"
   IO.println "`compileSafe_observational_correct_modulo_codegen_axioms` with all"


### PR DESCRIPTION
Widens the discharged math_byte consume fragment to admit the 2-argument `cat` builtin (`OP_CAT`). **Coverage widening — axiom count unchanged (70).**

## Framing
Rúnar has no `+` on ByteString (`evalBinOp "+"` is bigint-only); concatenation is the `cat` builtin (`.call "cat" [a,b]` → `OP_CAT`). This adds the canonical two-param fragment `f(a,b){ d := cat(a,b) }`, previously falling to the `crypto_call` fallback, now backed by real codegen-to-spec.

## What's proven (no new axiom, no crypto_call)
- `Stack/AgreesCat.lean` (new): `catConsumeShapeBool` classifier + extraction; `lowerMethodUserRawOps_cat` (the production RAW is `[swap, swap, OP_CAT]` — both params last-used → consume-mode `lowerArgsLive`, NOT copy-mode `[over,over,OP_CAT]`); `runOps_catOps` / `cat_M2` (ANF↔Stack walk); anti-vacuity smokes.
- `Pipeline.lean`: `peepholeMethodOps_catOps` (the 4-pass peephole collapses `[swap,swap,OP_CAT]` → `[OP_CAT]` via `applyDoubleSwap` — operational-M3 regime, like wave-63 update_prop); `compileSafe_observational_correct_cat_consume`. `#print axioms` = propext / Classical.choice / Quot.sound + the 3 crypto backends + one native_decide lowering cert — **NO codegen axiom, NO crypto_call**.
- Omnibus wired: new keyed, single-public-gated premise `hMathByteCatFrag` added to `…_modulo_codegen_axioms` and its `_via_support` sibling; dispatch arm `exact`s the consume theorem; all 8 existing instantiations supply it vacuously; new **LIVE** `omnibus_instantiation_cat` drives the arm end-to-end.

`OP_CAT` was already in `isAllowedOpcodeName` (no allowlist change needed).

## Verification (all green)
- `lake build` (full) — success (55 jobs).
- `lake exe omnibusInstantiation` — OK (new `omniCat` row green; basic-p2pkh byte-identical).
- `scripts/check-tcb-drift.sh` — `axioms = 70` (UNCHANGED).
No `sorry`/`admit`, no statement weakened.