### PR TITLE
fix(sdk): MINIMALDATA-correct encode_push_data for 1-byte payloads in OP_N range

### DIFF
--- a/packages/runar-rs/src/sdk/state.rs
+++ b/packages/runar-rs/src/sdk/state.rs
@@ -447,8 +447,34 @@ fn encode_num2bin(n: i64, width: usize) -> String {
 }
 
 /// Wrap a hex-encoded byte string in a Bitcoin Script push data opcode.
-pub(crate) fn encode_push_data(data_hex: &str) -> String {
+///
+/// Applies BSV consensus rule `SCRIPT_VERIFY_MINIMALDATA` for single-byte
+/// pushes: a 1-byte payload whose value is in `{0x00, 0x01..=0x10, 0x81}`
+/// MUST use the corresponding minimal opcode (`OP_0` / `OP_1..OP_16` /
+/// `OP_1NEGATE`) rather than the direct push `01 NN`. Non-minimal direct
+/// pushes are rejected by ARC, TAAL ARC, and WhatsOnChain at the relay
+/// layer with the error:
+///   `non-mandatory-script-verify-flag (Data push larger than necessary)`
+pub fn encode_push_data(data_hex: &str) -> String {
     let len = data_hex.len() / 2;
+
+    // MINIMALDATA: single-byte payloads in the OP_N range must use the
+    // corresponding minimal opcode. Mirrors the same rule already enforced
+    // by `encode_script_number` for `SdkValue::Int` (which short-circuits
+    // to `OP_N` opcodes for n in 1..=16). The encoder for `SdkValue::Bytes`
+    // did not previously honor this rule, so an arbitrary ByteString that
+    // happened to be a single byte in this range produced a relay-rejected
+    // direct push.
+    if len == 1 {
+        if let Ok(byte) = u8::from_str_radix(data_hex, 16) {
+            match byte {
+                0x00 => return "00".to_string(),                       // OP_0
+                0x01..=0x10 => return format!("{:02x}", 0x50 + byte),  // OP_1..OP_16
+                0x81 => return "4f".to_string(),                       // OP_1NEGATE
+                _ => {}
+            }
+        }
+    }
 
     if len <= 75 {
         format!("{:02x}{}", len, data_hex)

--- a/packages/runar-rs/tests/encode_push_data_minimaldata.rs
+++ b/packages/runar-rs/tests/encode_push_data_minimaldata.rs
@@ -1,0 +1,90 @@
+//! Regression test for MINIMALDATA-correct encoding of single-byte payloads
+//! in `encode_push_data`.
+//!
+//! BSV consensus + relay policy (`SCRIPT_VERIFY_MINIMALDATA`) require that
+//! a 1-byte data push whose payload is in `{0x00, 0x01..=0x10, 0x81}` MUST
+//! use the corresponding minimal opcode (`OP_0` / `OP_1..OP_16` /
+//! `OP_1NEGATE`) rather than the direct push `01 NN`. Non-minimal pushes
+//! are rejected by ARC, TAAL ARC, and WhatsOnChain at the relay layer with:
+//!   `non-mandatory-script-verify-flag (Data push larger than necessary)`
+//!
+//! Before the fix, `encode_push_data` always emitted the direct push form
+//! for any payload of length 1, regardless of byte value. This worked for
+//! the common case (ByteString args of length >= 2: sigs, pubkeys, hashes,
+//! preimages, etc.) but tripped for any byte-string args that happened to
+//! land on a single byte in the OP_N range — for example certain padding
+//! patterns in Rabin signature schemes, or any user-supplied ByteString
+//! that the consumer didn't pre-normalize.
+//!
+//! The encoder for `SdkValue::Int` (`encode_script_number`) already enforces
+//! this rule; the fix brings `encode_push_data` for `SdkValue::Bytes` to
+//! the same standard.
+
+use runar_lang::sdk::state::encode_push_data;
+
+#[test]
+fn encode_push_data_minimaldata_op_0() {
+    // Payload 0x00 (single zero byte) must encode as OP_0 (one byte: 0x00),
+    // not direct push (two bytes: 0x01 0x00).
+    assert_eq!(encode_push_data("00"), "00");
+}
+
+#[test]
+fn encode_push_data_minimaldata_op_1_through_16() {
+    // Payloads 0x01..=0x10 must encode as OP_1..OP_16 (opcodes 0x51..0x60).
+    let cases: [(u8, &str); 16] = [
+        (0x01, "51"), (0x02, "52"), (0x03, "53"), (0x04, "54"),
+        (0x05, "55"), (0x06, "56"), (0x07, "57"), (0x08, "58"),
+        (0x09, "59"), (0x0a, "5a"), (0x0b, "5b"), (0x0c, "5c"),
+        (0x0d, "5d"), (0x0e, "5e"), (0x0f, "5f"), (0x10, "60"),
+    ];
+    for (byte, expected) in cases {
+        let hex = format!("{:02x}", byte);
+        let got = encode_push_data(&hex);
+        assert_eq!(
+            got, expected,
+            "encode_push_data({:02x}) should emit {} (OP_{}), got {}",
+            byte, expected, byte, got
+        );
+    }
+}
+
+#[test]
+fn encode_push_data_minimaldata_op_1negate() {
+    // Payload 0x81 (BSV's signed-magnitude representation of -1) must
+    // encode as OP_1NEGATE (opcode 0x4f).
+    assert_eq!(encode_push_data("81"), "4f");
+}
+
+#[test]
+fn encode_push_data_single_byte_outside_op_n_range_still_direct_push() {
+    // Bytes outside {0x00, 0x01..=0x10, 0x81} must still use the direct
+    // push form (01 NN). This locks the regression boundary: the fix
+    // should ONLY short-circuit the consensus-required cases.
+    for byte in [0x11u8, 0x4f, 0x50, 0x60, 0x61, 0x80, 0x82, 0xff] {
+        let hex = format!("{:02x}", byte);
+        let expected = format!("01{:02x}", byte);
+        let got = encode_push_data(&hex);
+        assert_eq!(
+            got, expected,
+            "encode_push_data({:02x}) should emit direct push {}, got {}",
+            byte, expected, got
+        );
+    }
+}
+
+#[test]
+fn encode_push_data_multi_byte_unchanged() {
+    // Payloads of length >= 2 are not affected by MINIMALDATA single-byte
+    // rule. Encoding must match the pre-fix behaviour exactly.
+    assert_eq!(encode_push_data("0001"), "020001");
+    assert_eq!(encode_push_data("deadbeef"), "04deadbeef");
+    // 75-byte payload: still direct push (max for direct push)
+    let payload = "aa".repeat(75);
+    let expected = format!("4b{}", payload);
+    assert_eq!(encode_push_data(&payload), expected);
+    // 76-byte payload: switches to OP_PUSHDATA1
+    let payload = "bb".repeat(76);
+    let expected = format!("4c4c{}", payload);
+    assert_eq!(encode_push_data(&payload), expected);
+}


### PR DESCRIPTION
## Summary

`encode_push_data` in `packages/runar-rs/src/sdk/state.rs` does not apply BSV consensus rule `SCRIPT_VERIFY_MINIMALDATA` for single-byte payloads. When a 1-byte ByteString payload happens to be in the OP_N range (`0x00`, `0x01..=0x10`, `0x81`), the encoder produces a direct push (`01 NN`) which ARC, TAAL ARC, and WhatsOnChain all reject at the relay layer.

## Problem

Current `encode_push_data` at `packages/runar-rs/src/sdk/state.rs:450-462` (upstream HEAD `a8187ab4`):

```rust
pub(crate) fn encode_push_data(data_hex: &str) -> String {
    let len = data_hex.len() / 2;

    if len <= 75 {
        format!("{:02x}{}", len, data_hex)
    } else if len <= 0xff {
        format!("4c{:02x}{}", len, data_hex)
    } else if len <= 0xffff {
        format!("4d{}{}", to_little_endian_16(len), data_hex)
    } else {
        format!("4e{}{}", to_little_endian_32(len as u32), data_hex)
    }
}
```

For a 1-byte payload `0x01`, this returns `"0101"` (direct push). BSV consensus requires it to be `"51"` (OP_1). For `0x00` it must be `"00"` (OP_0), not `"0100"`. For `0x81` it must be `"4f"` (OP_1NEGATE), not `"0181"`.

ARC empirical response when a non-minimal push reaches the relay:

```
TAAL ARC https://arc.taal.com/v1/tx:
{
  "txStatus": "REJECTED",
  "extraInfo": "transaction rejected by peer\npeer: fabriik-bsv-001.teranode.group:8333 reason: non-mandatory-script-verify-flag (Data push larger than necessary)"
}

WhatsOnChain /v1/bsv/main/tx/raw:
HTTP 400 — "unexpected response code 500: 64: non-mandatory-script-verify-flag (Data push larger than necessary)"
```

The Rust SDK's `encode_script_number` (`contract.rs:1930`) DOES enforce MINIMALDATA for `SdkValue::Int` (it short-circuits to `OP_N` opcodes for `n ∈ 1..=16`). But `encode_push_data` is the encoder for `SdkValue::Bytes` — and when an arbitrary ByteString arg happens to land on a single byte in the script-number range, the encoder produced a non-minimal direct push.

## How this surfaced

Surfaced during a mainnet broadcast where a stateful contract method took a ByteString argument carrying a value whose final byte landed on a payload in the OP_N range (`{0x00, 0x01..=0x10, 0x81}`). The transaction built cleanly client-side, computed a valid sighash, and signed correctly. On submission to ARC, the relay rejected with the MINIMALDATA error above — the rejection happens at the script-verify stage before the tx reaches any miner.

Other common ByteString payloads (signatures ≥ 70 bytes, pubkeys at 33 bytes, hashes at 32 bytes, full preimages) never tripped this because they're always multi-byte. The defect only surfaces when a contract author or framework happens to pass a single byte through the `SdkValue::Bytes` path that falls in the OP_N range.

## Fix

`packages/runar-rs/src/sdk/state.rs`:

```rust
/// Wrap a hex-encoded byte string in a Bitcoin Script push data opcode.
///
/// Applies BSV consensus rule `SCRIPT_VERIFY_MINIMALDATA` for single-byte
/// pushes: a 1-byte payload whose value is in `{0x00, 0x01..=0x10, 0x81}`
/// MUST use the corresponding minimal opcode (`OP_0` / `OP_1..OP_16` /
/// `OP_1NEGATE`) rather than the direct push `01 NN`.
pub fn encode_push_data(data_hex: &str) -> String {
    let len = data_hex.len() / 2;

    // MINIMALDATA: single-byte payloads in the OP_N range must use the
    // corresponding minimal opcode. Mirrors the same rule already enforced
    // by `encode_script_number` for `SdkValue::Int`.
    if len == 1 {
        if let Ok(byte) = u8::from_str_radix(data_hex, 16) {
            match byte {
                0x00 => return "00".to_string(),                       // OP_0
                0x01..=0x10 => return format!("{:02x}", 0x50 + byte),  // OP_1..OP_16
                0x81 => return "4f".to_string(),                       // OP_1NEGATE
                _ => {}
            }
        }
    }

    if len <= 75 {
        format!("{:02x}{}", len, data_hex)
    } else if len <= 0xff {
        format!("4c{:02x}{}", len, data_hex)
    } else if len <= 0xffff {
        format!("4d{}{}", to_little_endian_16(len), data_hex)
    } else {
        format!("4e{}{}", to_little_endian_32(len as u32), data_hex)
    }
}
```

Visibility raised from `pub(crate)` to `pub` so the regression test can call it directly from an integration test (matches the test-through-public-surface pattern used by other recent SDK fixes).

## Cross-language parity

The TS SDK's `encodeScriptNumber` already applies the same rule for numeric values; this PR closes the asymmetry on the `SdkValue::Bytes` path in the Rust port. A TS twin may want to audit `encodePushData` for the same case if the bytes-vs-numeric distinction is mirrored there.

## Verification

Reproducible in 60 seconds:

```
git clone --depth 1 https://github.com/icellan/runar /tmp/runar-mindata
cd /tmp/runar-mindata
git apply <this patch>
cd packages/runar-rs
cargo test --test encode_push_data_minimaldata
```

**Fails without the patch** (running the same test against bare HEAD, with `encode_push_data` made `pub` but the MINIMALDATA short-circuit reverted):

```
running 5 tests
test encode_push_data_multi_byte_unchanged ... ok
test encode_push_data_single_byte_outside_op_n_range_still_direct_push ... ok
test encode_push_data_minimaldata_op_0 ... FAILED
test encode_push_data_minimaldata_op_1_through_16 ... FAILED
test encode_push_data_minimaldata_op_1negate ... FAILED

---- encode_push_data_minimaldata_op_0 stdout ----
thread 'encode_push_data_minimaldata_op_0' panicked at tests/encode_push_data_minimaldata.rs:30:5:
assertion `left == right` failed
  left: "0100"
 right: "00"

---- encode_push_data_minimaldata_op_1_through_16 stdout ----
thread 'encode_push_data_minimaldata_op_1_through_16' panicked at tests/encode_push_data_minimaldata.rs:46:9:
assertion `left == right` failed: encode_push_data(01) should emit 51 (OP_1), got 0101
  left: "0101"
 right: "51"

---- encode_push_data_minimaldata_op_1negate stdout ----
thread 'encode_push_data_minimaldata_op_1negate' panicked at tests/encode_push_data_minimaldata.rs:56:5:
assertion `left == right` failed
  left: "0181"
 right: "4f"

test result: FAILED. 2 passed; 3 failed
```

**Passes with the patch:**

```
running 5 tests
test encode_push_data_minimaldata_op_1_through_16 ... ok
test encode_push_data_multi_byte_unchanged ... ok
test encode_push_data_minimaldata_op_1negate ... ok
test encode_push_data_single_byte_outside_op_n_range_still_direct_push ... ok
test encode_push_data_minimaldata_op_0 ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Five tests cover: each of the three minimal-opcode cases (`OP_0`, `OP_1..OP_16`, `OP_1NEGATE`), the regression boundary (bytes outside the OP_N range still take the direct push form), and the multi-byte path (lengths 2, 4, 75, 76 — covering the direct push / OP_PUSHDATA1 boundary).

## Backwards compatibility

Existing consumers see no behavioural change for multi-byte payloads (the common case — sigs, pubkeys, hashes, preimages). The only behavioural change is for single-byte payloads in the OP_N range, where the new output is the consensus-required form and the old output was being rejected at the relay anyway.

The `pub(crate)` → `pub` visibility change is additive — no existing caller is affected; only new callers gain access.

## Related

- The `SdkValue::Int` encoding path (`encode_script_number` in `contract.rs:1930`) already enforces this rule. This PR brings the `SdkValue::Bytes` path to the same standard.
