### PR TITLE
feat: verification descriptors + requireBaked option + companion-verifier example

### DIFF
--- a/docs/cross-covenant-pattern.md
+++ b/docs/cross-covenant-pattern.md
@@ -90,6 +90,16 @@ const stateRoot = substr(referencedOutput, stateRootOffset, 32n);
 See `examples/ts/cross-covenant/CrossCovenantRef.runar.ts` for a complete
 working example with tests.
 
+For the stronger form — verifying attributes of a *specific companion input*
+of the current transaction by parsing its parent tx (hash-bound to the
+spending tx via the BIP-143 preimage), with contract identity proven by a
+slot-excised *template* hash instead of an exact script hash — see the
+"Verified Companion Inputs" example pair in
+`examples/ts/companion-verifier/` (`AttributedToken.runar.ts` +
+`CompanionVerifier.runar.ts`). It addresses the third limitation above:
+the parent tx binds a specific UTXO, not just a script shape, and
+per-instance attribute values survive the identity check.
+
 ## Use in BSV-EVM
 
 The bridge covenant uses this pattern to read the state covenant's latest

--- a/examples/ts/companion-verifier/AttributedToken.runar.ts
+++ b/examples/ts/companion-verifier/AttributedToken.runar.ts
@@ -1,0 +1,133 @@
+import { StatefulSmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+/**
+ * AttributedToken -- a token whose immutable ATTRIBUTES are baked into the
+ * code part of its locking script, so a later covenant can verify them by
+ * inspecting the token's parent transaction in Bitcoin Script.
+ *
+ * This is the token half of the "Verified Companion Inputs" example pair
+ * (see CompanionVerifier.runar.ts for the verifier half): cross-contract
+ * composition where one covenant input verifies attributes of ANOTHER input
+ * in the same spending transaction -- no oracle, no indexer, no coordinator.
+ *
+ * Design rules that make the attributes verifiable:
+ *
+ *  - **Attributes travel in the code part.** `attestor`, `category`, and
+ *    `batchId` are readonly and baked at deploy; every child produced by a
+ *    split inherits them byte-for-byte because the children reuse the same
+ *    code part.
+ *  - **An attribute only exists on-chain if the contract references it.**
+ *    Unreferenced readonly props are eliminated by the compiler. `revoke`
+ *    references `attestor` (checkSig) and `category` (enum floor assert)
+ *    precisely so both become constructorSlots a downstream verifier can
+ *    extract. This is the load-bearing rule of the whole pattern.
+ *  - **Amount is divisible; attribution is not.** `split` conserves `amount`
+ *    across children; the attribute slots are indivisible provenance.
+ *
+ * ATTRIBUTE SLOT ENCODING (fixed-layout template requirement):
+ *  - `attestor` is a 33-byte pubkey push -- a fixed-width 33-byte slot.
+ *  - `category` is constrained to 1..16 so it always bakes as a SINGLE OP_N
+ *    opcode byte (0x51..0x60). 0 would bake as OP_0 (indistinguishable from
+ *    an unbaked placeholder); 17+ bakes as a 2-byte push, shifting every
+ *    offset after the slot. Fixed-width slots keep the verifier's offsets
+ *    compile-time constants.
+ *
+ * The verifier derives those offsets mechanically from the artifact's
+ * verification descriptors (`resolveSlotLayout` / `computeTemplateHash` in
+ * runar-sdk) -- see the test file for the derivation.
+ *
+ * State model (UTXO): mutable state (owner, amount, status) rides in an
+ * OP_RETURN tail; spending with the same code part = transfer/split.
+ * Status: 1 = Active, 3 = Retired (consumed), 4 = Revoked (attestor recall).
+ */
+class AttributedToken extends StatefulSmartContract {
+  /** Current holder. Mutable -- updated on transfer/split. */
+  owner: PubKey;
+  /** Divisible quantity. Mutable -- divided on split, conserved across children. */
+  amount: bigint;
+  /** Lifecycle status: 1 = Active, 3 = Retired, 4 = Revoked. Mutable. */
+  status: bigint;
+
+  /** ATTRIBUTE SLOT #1: who attested/minted this token. Readonly, baked into
+   *  the code part -- the field a downstream CompanionVerifier extracts and
+   *  checks against its allowlist. */
+  readonly attestor: PubKey;
+  /** ATTRIBUTE SLOT #2: category enum (1..16 ONLY -- see encoding note above).
+   *  Readonly, baked as a single OP_N opcode byte. */
+  readonly category: bigint;
+  /** Batch identity -- hash of genesis metadata. Readonly, inherited by all children. */
+  readonly batchId: ByteString;
+
+  constructor(
+    owner: PubKey,
+    amount: bigint,
+    status: bigint,
+    attestor: PubKey,
+    category: bigint,
+    batchId: ByteString,
+  ) {
+    super(owner, amount, status, attestor, category, batchId);
+    this.owner = owner;
+    this.amount = amount;
+    this.status = status;
+    this.attestor = attestor;
+    this.category = category;
+    this.batchId = batchId;
+  }
+
+  /** Full transfer: 1 UTXO -> 1 UTXO. Whole amount to a new owner. */
+  public transfer(sig: Sig, to: PubKey, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(this.status === 1n);
+    assert(outputSatoshis >= 1n);
+
+    this.addOutput(outputSatoshis, to, this.amount, this.status);
+  }
+
+  /**
+   * Split: 1 UTXO -> 2 UTXOs. Recipient gets `splitAmount`, owner keeps the
+   * remainder. Amount is conserved; attestor/category/batchId are inherited
+   * automatically because both children reuse this same code part.
+   */
+  public split(sig: Sig, to: PubKey, splitAmount: bigint, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(this.status === 1n);
+    assert(outputSatoshis >= 1n);
+    assert(splitAmount > 0n);
+    assert(splitAmount < this.amount);
+
+    this.addOutput(outputSatoshis, to, splitAmount, this.status);
+    this.addOutput(outputSatoshis, this.owner, this.amount - splitAmount, this.status);
+  }
+
+  /** Retire: mark the token consumed. Active -> Retired. Amount and owner
+   *  preserved as the permanent record. */
+  public retire(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(this.status === 1n);
+    assert(outputSatoshis >= 1n);
+
+    this.addOutput(outputSatoshis, this.owner, this.amount, 3n);
+  }
+
+  /**
+   * Revoke: attestor-only error correction. Active -> Revoked (status 4).
+   *
+   * Beyond its business meaning, this method is what forces BOTH attribute
+   * slots on-chain: `checkSig(sig, this.attestor)` bakes the attestor pubkey
+   * as a constructorSlot, and the `category` floor assert bakes the category
+   * opcode. Attributes you can verify in Script exist only because the
+   * contract itself commits to them.
+   */
+  public revoke(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.attestor));
+    // On-chain anchor for `category` + enum floor (0 would bake as an OP_0
+    // placeholder-lookalike -- see the encoding note on the property).
+    assert(this.category >= 1n);
+    assert(this.status === 1n);
+    assert(outputSatoshis >= 1n);
+
+    this.addOutput(outputSatoshis, this.owner, this.amount, 4n);
+  }
+}

--- a/examples/ts/companion-verifier/CompanionVerifier.runar.ts
+++ b/examples/ts/companion-verifier/CompanionVerifier.runar.ts
@@ -1,0 +1,208 @@
+import {
+  StatefulSmartContract, assert, checkSig, hash256, substr, len, cat, bin2num,
+  extractHashPrevouts, extractOutpoint, extractOutputHash,
+} from 'runar-lang';
+import type { PubKey, Sig, ByteString, Sha256 } from 'runar-lang';
+
+/**
+ * CompanionVerifier -- the "Verified Companion Inputs" pattern: a Bitcoin
+ * Script covenant that verifies ATTRIBUTES of a companion input by parsing
+ * that input's parent transaction, bound to the spending transaction via the
+ * BIP-143 preimage. No oracle, no indexer, no coordinator.
+ *
+ * This demonstrates cross-contract composition one step beyond
+ * `examples/ts/cross-covenant/` (which verifies externally supplied output
+ * data against a known script hash): here the external data is a FULL parent
+ * transaction, cryptographically bound to a real input of THIS spend, and
+ * the companion's contract identity is proven by template hash rather than
+ * exact script hash -- so the check survives per-instance attribute values.
+ *
+ * The normative steps (each numbered in the method body):
+ *  1. PREVOUTS BINDING -- `allPrevouts` (unlock data) is bound to THIS tx:
+ *     hash256(allPrevouts) === hashPrevouts(preimage).
+ *  2. POSITIONAL CONVENTION -- this covenant is input 0; the companion is
+ *     input 1; the companion UTXO is output 0 of its parent tx.
+ *  3. PARENT BINDING -- the supplied parent tx is bound by hash:
+ *     hash256(parentTx) === txid in the companion's outpoint. Outpoint txids
+ *     are in INTERNAL byte order -- the same order hash256 produces -- so the
+ *     comparison is like-for-like, NO byte reversal (the classic footgun).
+ *  4. STRUCTURAL WALK -- deterministic parse of the parent's bytes (bounded
+ *     multi-input skip, 1..3 inputs) to output 0's locking script.
+ *  5. TEMPLATE IDENTITY -- hash256 of that script with the attribute slots
+ *     EXCISED must equal the known template hash. This proves the companion
+ *     IS an instance of the expected contract and defeats attribute-planting
+ *     counterfeits.
+ *  6. ATTRIBUTE EXTRACTION + PREDICATE -- substr the fixed-width slots; apply
+ *     the predicate (here: allowlist membership + category equality + state
+ *     threshold; any predicate over the extracted bytes works).
+ *  7. OUTPUT BINDING -- hash256(expectedOutputs) === hashOutputs(preimage), so
+ *     ALL covenants in the tx agree on one output set (terminal form).
+ *
+ * SECURITY NOTE on excised slots: the template hash is a SHAPE commitment.
+ * Every excised slot is attacker-controlled bytes until the covenant
+ * value-checks it -- which is why step 6 checks BOTH slots (allowlist for
+ * the attestor, exact OP_N compare for the category). Never excise a slot
+ * you do not also value-check.
+ *
+ * SIGN-BYTE DISCIPLINE: every bin2num on parsed bytes is padded with a
+ * trailing zero byte (`cat(bytes, PAD00)`) so values whose top bit is set can
+ * never read negative. This is the bug class the pattern must codify.
+ *
+ * The baked layout constants (attestorOffset / categoryOffset / codePostLen /
+ * expectedTemplateHash) come from the companion artifact's verification
+ * descriptors: `resolveSlotLayout` + `computeTemplateHash` in runar-sdk.
+ * See the test file for the derivation.
+ */
+class CompanionVerifier extends StatefulSmartContract {
+  /** Operator of this verifier. Mutable state. */
+  owner: PubKey;
+  /** Count of companions verified. Mutable state. */
+  companionsVerified: bigint;
+
+  /** Byte offset of attribute slot #1 (33-byte attestor pubkey) inside the
+   *  companion's locking script (from its constructorSlots). */
+  readonly attestorOffset: bigint;
+  /** Byte offset of attribute slot #2 (single OP_N category opcode; the enum
+   *  is constrained to 1..16 so the slot is always exactly 1 byte). Must be
+   *  > attestorOffset + 33. */
+  readonly categoryOffset: bigint;
+  /** Length of the companion code part AFTER the category slot ends
+   *  (codeLen - categoryOffset - 1). */
+  readonly codePostLen: bigint;
+  /** hash256 of the companion code part with BOTH attribute slots excised
+   *  (33-byte attestor + 1-byte category) -- the template identity. */
+  readonly expectedTemplateHash: Sha256;
+  /** Attribute predicate data: approved attestors (allowlist of 2). */
+  readonly allowedAttestor1: PubKey;
+  readonly allowedAttestor2: PubKey;
+  /** Attribute predicate data: minimum companion amount accepted. */
+  readonly minAmount: bigint;
+  /** Attribute predicate data: required category enum value (1..16). The
+   *  companion's baked opcode must equal OP_N for this N (byte = 0x50 + N). */
+  readonly requiredCategory: bigint;
+
+  /** Zero pad for sign-safe bin2num on parsed little-endian fields. */
+  readonly pad00: ByteString = "00" as ByteString;
+
+  constructor(
+    owner: PubKey,
+    companionsVerified: bigint,
+    attestorOffset: bigint,
+    categoryOffset: bigint,
+    codePostLen: bigint,
+    expectedTemplateHash: Sha256,
+    allowedAttestor1: PubKey,
+    allowedAttestor2: PubKey,
+    minAmount: bigint,
+    requiredCategory: bigint,
+  ) {
+    super(owner, companionsVerified, attestorOffset, categoryOffset, codePostLen, expectedTemplateHash, allowedAttestor1, allowedAttestor2, minAmount, requiredCategory);
+    this.owner = owner;
+    this.companionsVerified = companionsVerified;
+    this.attestorOffset = attestorOffset;
+    this.categoryOffset = categoryOffset;
+    this.codePostLen = codePostLen;
+    this.expectedTemplateHash = expectedTemplateHash;
+    this.allowedAttestor1 = allowedAttestor1;
+    this.allowedAttestor2 = allowedAttestor2;
+    this.minAmount = minAmount;
+    this.requiredCategory = requiredCategory;
+  }
+
+  /**
+   * Verify the companion input (input 1) against this verifier's attribute
+   * predicate, by parsing the companion's parent transaction in Script.
+   *
+   * TERMINAL method: this UTXO is fully spent; no continuation. The spending
+   * tx's outputs are bound via extractOutputHash, and the companion input's
+   * own covenant (e.g. AttributedToken.retire) independently enforces ITS
+   * continuation -- so both covenant inputs agree on the same output set.
+   *
+   * @param sig               - owner's signature
+   * @param allPrevouts       - concatenated 36-byte outpoints of ALL inputs of THIS tx
+   * @param companionParentTx - full serialized parent transaction of the companion input
+   * @param expectedOutputs   - serialized outputs of THIS tx (value8|varint|script per output)
+   */
+  public verifyCompanion(sig: Sig, allPrevouts: ByteString, companionParentTx: ByteString, expectedOutputs: ByteString) {
+    assert(checkSig(sig, this.owner));
+
+    // -- 1. Bind allPrevouts to the real spending tx. --
+    assert(hash256(allPrevouts) === extractHashPrevouts(this.txPreimage));
+    assert(len(allPrevouts) >= 72n); // at least: this input + the companion input
+
+    // -- 2. Positional convention: I am input 0; the companion is input 1. --
+    const myOutpoint = extractOutpoint(this.txPreimage);
+    assert(substr(allPrevouts, 0n, 36n) === myOutpoint);
+    const companionOutpoint = substr(allPrevouts, 36n, 36n);
+    const companionTxid = substr(companionOutpoint, 0n, 32n);
+    // vout must be 0 (sign-safe read of 4-byte LE)
+    const companionVout = bin2num(cat(substr(companionOutpoint, 32n, 4n), this.pad00));
+    assert(companionVout === 0n);
+
+    // -- 3. Bind the supplied parent tx by hash. Internal byte order both sides; no reversal. --
+    assert(hash256(companionParentTx) === companionTxid);
+
+    // -- 4. Walk to output 0's locking script. --
+    // version(4) | inCount(varint) | inputs... | outCount(varint) | outputs... | locktime(4)
+    // Bounded multi-input walk (1..3 inputs -- the general profile). inCount is
+    // a 1-byte varint by construction: >3 rejects, and a 0xfd/0xfe/0xff marker
+    // byte reads as 253/254/255 which also rejects.
+    const inCount = bin2num(cat(substr(companionParentTx, 4n, 1n), this.pad00));
+    assert(inCount >= 1n);
+    assert(inCount <= 3n);
+    // each input: outpoint(36) + scriptLen varint (1-byte only, sign-safe;
+    // P2PKH unlock ~107B) + script + sequence(4)
+    let off = 5n;
+    for (let i = 0n; i < 3n; i++) {
+      if (i < inCount) {
+        const sl = bin2num(cat(substr(companionParentTx, off + 36n, 1n), this.pad00));
+        assert(sl < 253n);
+        off = off + 36n + 1n + sl + 4n;
+      }
+    }
+    // outputs section starts at off
+    const outCount = bin2num(cat(substr(companionParentTx, off, 1n), this.pad00));
+    assert(outCount >= 1n);
+    // output 0 = value(8) + scriptLen(varint) + script. Companion scripts are
+    // >252B -> the varint MUST be 0xfd + LE16 (also rejects short scripts like P2PKH).
+    const marker = bin2num(cat(substr(companionParentTx, off + 9n, 1n), this.pad00));
+    assert(marker === 253n);
+    const scriptLen = bin2num(cat(substr(companionParentTx, off + 10n, 2n), this.pad00));
+    const scriptStart = off + 12n;
+    assert(len(companionParentTx) >= scriptStart + scriptLen);
+    const companionScript = substr(companionParentTx, scriptStart, scriptLen);
+
+    // -- 5. Template identity: the companion IS an instance of the expected
+    //       contract. BOTH attribute slots are excised (33-byte attestor +
+    //       1-byte category opcode), leaving a fixed-layout template.
+    const codePre = substr(companionScript, 0n, this.attestorOffset);
+    const codeMid = substr(companionScript, this.attestorOffset + 33n, this.categoryOffset - this.attestorOffset - 33n);
+    const codePost = substr(companionScript, this.categoryOffset + 1n, this.codePostLen);
+    assert(hash256(cat(cat(codePre, codeMid), codePost)) === this.expectedTemplateHash);
+
+    // -- 6. Attribute extraction + predicate. --
+    // 6a. Attestor allowlist membership (the worked predicate).
+    const attestor = substr(companionScript, this.attestorOffset, 33n);
+    assert(attestor === this.allowedAttestor1 || attestor === this.allowedAttestor2);
+
+    // 6b. Category enum: the baked slot is the single opcode OP_N (byte
+    //     0x50 + N). Read the raw opcode byte sign-safely and require it to
+    //     encode exactly requiredCategory (1..16). NOTE: this slot is excised
+    //     from the template, so WITHOUT this check an attacker could plant
+    //     any byte here -- the sign-safe read also defeats bytes >= 0x80.
+    const catOp = bin2num(cat(substr(companionScript, this.categoryOffset, 1n), this.pad00));
+    assert(catOp === this.requiredCategory + 80n);
+
+    // 6c. Predicates over the companion's STATE region (fixed 8-byte LE
+    //     fields at the script tail: [.. owner(33) | amount(8) | status(8)]).
+    //     Sign-safe reads: an 8-byte LE value with its top bit set (e.g.
+    //     2^63) would read NEGATIVE unpadded -- the pad00 cat prevents it.
+    const companionAmount = bin2num(cat(substr(companionScript, scriptLen - 16n, 8n), this.pad00));
+    const companionStatus = bin2num(cat(substr(companionScript, scriptLen - 8n, 8n), this.pad00));
+    assert(companionStatus === 1n); // must be Active (not Retired/Revoked)
+    assert(companionAmount >= this.minAmount);
+
+    // -- 7. Terminal output binding: the spending tx's outputs are exactly the supplied set. --
+    assert(hash256(expectedOutputs) === extractOutputHash(this.txPreimage));
+  }
+}

--- a/examples/ts/companion-verifier/CompanionVerifier.test.ts
+++ b/examples/ts/companion-verifier/CompanionVerifier.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Verified Companion Inputs — cross-contract composition example.
+ *
+ * A CompanionVerifier covenant (input 0) verifies attributes of an
+ * AttributedToken companion (input 1) by parsing the companion's parent
+ * transaction in Script, bound to the spending tx via the BIP-143 preimage.
+ *
+ * The fixtures exercise the REAL compiled token: the companion locking
+ * script inside each parent tx is produced by `RunarContract` from the
+ * compiled AttributedToken artifact, and the verifier's layout constants
+ * (slot offsets + excised-template hash) are derived mechanically from the
+ * artifact's verification descriptors via `resolveSlotLayout` /
+ * `computeTemplateHash` — no hand-counted byte offsets.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+import { TestContract, ALICE, BOB, CHARLIE, DAVE, EVE, signTestMessage } from 'runar-testing';
+import { compile } from 'runar-compiler';
+import { RunarContract, resolveSlotLayout, computeTemplateHash } from 'runar-sdk';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const tokenSource = readFileSync(join(__dirname, 'AttributedToken.runar.ts'), 'utf8');
+const verifierSource = readFileSync(join(__dirname, 'CompanionVerifier.runar.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Compile the token and derive the verifier's layout constants from the
+// artifact's verification descriptors
+// ---------------------------------------------------------------------------
+
+const tokenCompile = compile(tokenSource, { fileName: 'AttributedToken.runar.ts' });
+if (!tokenCompile.artifact) {
+  throw new Error('AttributedToken compile failed: ' + JSON.stringify(tokenCompile.diagnostics));
+}
+const tokenArtifact = tokenCompile.artifact;
+
+const ATTESTOR = CHARLIE.pubKey.toLowerCase(); // allowlisted attestor #1
+const ATTESTOR2 = DAVE.pubKey.toLowerCase(); // allowlisted attestor #2
+const ROGUE = EVE.pubKey.toLowerCase(); // NOT on the allowlist
+const CATEGORY_A = 1n; // the required category enum
+const CATEGORY_B = 2n; // a different (rejected) category
+
+/** ctor args: [owner, amount, status, attestor, category, batchId] */
+const tokenArgs = (attestor: string, amount = 10n, status = 1n, category = CATEGORY_A): unknown[] =>
+  [BOB.pubKey, amount, status, attestor, category, 'deadbeef'];
+
+// The descriptor-driven derivation: resolveSlotLayout returns the concrete
+// byte offsets of the attestor (33-byte push) and category (single OP_N
+// opcode) slots in the deployed code part; computeTemplateHash returns the
+// hash256 of the code part with both slot VALUES excised. These replace the
+// hand-rolled indexOf / two-bake-diff derivation entirely.
+const layout = resolveSlotLayout(tokenArtifact, tokenArgs(ATTESTOR));
+const attestorSlot = layout.slots.find((s) => s.name === 'attestor')!;
+const categorySlot = layout.slots.find((s) => s.name === 'category')!;
+
+const ATTESTOR_OFFSET = BigInt(attestorSlot.valueByteOffset);
+const CATEGORY_OFFSET = BigInt(categorySlot.valueByteOffset);
+const CODE_POST_LEN = BigInt(layout.codeByteLength) - CATEGORY_OFFSET - 1n;
+const TEMPLATE_HASH = computeTemplateHash(tokenArtifact, tokenArgs(ATTESTOR));
+
+/** Full locking script (code part + OP_RETURN state tail) of a token UTXO. */
+function tokenFullScript(attestor: string, amount = 10n, status = 1n, category = CATEGORY_A): string {
+  const c = new RunarContract(tokenArtifact, tokenArgs(attestor, amount, status, category));
+  return (c.getLockingScript() as string).toLowerCase();
+}
+
+const TOKEN_SCRIPT = tokenFullScript(ATTESTOR);
+
+// ---------------------------------------------------------------------------
+// Parent-tx fixture builders (structurally real serialized transactions)
+// ---------------------------------------------------------------------------
+
+const hash256hex = (hex: string) => {
+  const f = createHash('sha256').update(Buffer.from(hex, 'hex')).digest();
+  return createHash('sha256').update(f).digest('hex');
+};
+const u32le = (n: number) => { const b = Buffer.alloc(4); b.writeUInt32LE(n); return b.toString('hex'); };
+const u64le = (n: bigint) => { const b = Buffer.alloc(8); b.writeBigUInt64LE(n); return b.toString('hex'); };
+const varint = (n: number) => {
+  if (n < 0xfd) return Buffer.from([n]).toString('hex');
+  const b = Buffer.alloc(2); b.writeUInt16LE(n);
+  return 'fd' + b.toString('hex');
+};
+
+/** Build a structurally real parent tx: version | inputs | outputs | locktime. */
+function buildParentTx(outputScript: string = TOKEN_SCRIPT, inputCount = 1): string {
+  let tx = u32le(1) + varint(inputCount);
+  for (let i = 0; i < inputCount; i++) {
+    tx += (i + 11).toString(16).padStart(2, '0').repeat(32) + u32le(0) + varint(107) + 'ab'.repeat(107) + 'ffffffff';
+  }
+  tx += varint(1) + u64le(1000n) + varint(outputScript.length / 2) + outputScript + u32le(0);
+  return tx;
+}
+
+const MY_OUTPOINT = 'cc'.repeat(32) + u32le(0);
+const OWNER_SIG = signTestMessage(ALICE.privKey);
+const SATS = 1000n;
+
+function makeVerifier(overrides: Record<string, unknown> = {}) {
+  return TestContract.fromSource(verifierSource, {
+    owner: ALICE.pubKey,
+    companionsVerified: 0n,
+    attestorOffset: ATTESTOR_OFFSET,
+    categoryOffset: CATEGORY_OFFSET,
+    codePostLen: CODE_POST_LEN,
+    expectedTemplateHash: TEMPLATE_HASH,
+    allowedAttestor1: ATTESTOR,
+    allowedAttestor2: ATTESTOR2,
+    minAmount: 5n,
+    requiredCategory: CATEGORY_A,
+    ...overrides,
+  }, 'CompanionVerifier.runar.ts');
+}
+
+/**
+ * Drive one verifyCompanion call. The mock preimage is wired so that
+ * hashPrevouts / outpoint / outputHash reflect a spending tx whose input 0
+ * is this verifier and whose input 1 is output 0 of `parentTx`.
+ */
+function verify(
+  verifier: ReturnType<typeof makeVerifier>,
+  parentTx: string,
+  opts: { tamperParent?: boolean; vout?: number; tamperPrevouts?: boolean } = {},
+) {
+  const companionOutpoint = hash256hex(parentTx) + u32le(opts.vout ?? 0);
+  const allPrevouts = MY_OUTPOINT + companionOutpoint;
+  const expectedOutputs = 'e803000000000000' + '19' + '76a914' + '22'.repeat(20) + '88ac';
+  verifier.setMockPreimageBytes({
+    hashPrevouts: Buffer.from(hash256hex(allPrevouts), 'hex'),
+    outpoint: Buffer.from(MY_OUTPOINT, 'hex'),
+    outputHash: Buffer.from(hash256hex(expectedOutputs), 'hex'),
+  });
+  // A single flipped nibble breaks hash256(parentTx) === outpoint txid.
+  const suppliedParent = opts.tamperParent
+    ? parentTx.slice(0, 9) + (parentTx[9] === '0' ? '1' : '0') + parentTx.slice(10)
+    : parentTx;
+  // Prevouts that do NOT hash to the preimage's hashPrevouts.
+  const suppliedPrevouts = opts.tamperPrevouts
+    ? 'ff'.repeat(allPrevouts.length / 2)
+    : allPrevouts;
+  return verifier.call('verifyCompanion', {
+    sig: OWNER_SIG,
+    allPrevouts: suppliedPrevouts,
+    companionParentTx: suppliedParent,
+    expectedOutputs,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// AttributedToken — the companion token's own behavior
+// ---------------------------------------------------------------------------
+
+describe('AttributedToken', () => {
+  function makeToken(amount = 100n) {
+    return TestContract.fromSource(tokenSource, {
+      owner: ALICE.pubKey,
+      amount,
+      status: 1n,
+      attestor: ATTESTOR,
+      category: CATEGORY_A,
+      batchId: 'deadbeef',
+    }, 'AttributedToken.runar.ts');
+  }
+
+  it('transfer moves the whole amount to the recipient', () => {
+    const r = makeToken().call('transfer', { sig: OWNER_SIG, to: BOB.pubKey, outputSatoshis: SATS });
+    expect(r.success).toBe(true);
+    expect(r.outputs).toHaveLength(1);
+    expect(r.outputs[0]!.owner).toBe(BOB.pubKey);
+    expect(r.outputs[0]!.amount).toBe(100n);
+  });
+
+  it('split conserves amount across both children', () => {
+    const r = makeToken().call('split', { sig: OWNER_SIG, to: BOB.pubKey, splitAmount: 30n, outputSatoshis: SATS });
+    expect(r.success).toBe(true);
+    expect(r.outputs).toHaveLength(2);
+    expect(r.outputs[0]!.amount).toBe(30n);
+    expect(r.outputs[1]!.amount).toBe(70n);
+    expect(r.outputs[0]!.owner).toBe(BOB.pubKey);
+    expect(r.outputs[1]!.owner).toBe(ALICE.pubKey);
+  });
+
+  it('split rejects taking the full amount (must leave a remainder)', () => {
+    const r = makeToken().call('split', { sig: OWNER_SIG, to: BOB.pubKey, splitAmount: 100n, outputSatoshis: SATS });
+    expect(r.success).toBe(false);
+  });
+
+  it('both attribute slots are baked as constructorSlots (the load-bearing rule)', () => {
+    // `batchId` is readonly but unreferenced by any method — the compiler
+    // eliminates it, so it is NOT verifiable on-chain. Only referenced
+    // attributes become slots.
+    expect(tokenArtifact.constructorSlots).toHaveLength(2);
+    expect(attestorSlot.encoding).toBe('data-push');
+    expect(attestorSlot.valueByteLength).toBe(33);
+    expect(categorySlot.encoding).toBe('op-n');
+    expect(categorySlot.byteLength).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CompanionVerifier — accept + adversarial battery
+// ---------------------------------------------------------------------------
+
+describe('CompanionVerifier', () => {
+  describe('accepts', () => {
+    it('a valid companion (allowlisted attestor, right category, active, amount ok)', () => {
+      const r = verify(makeVerifier(), buildParentTx());
+      expect(r.error).toBeUndefined();
+      expect(r.success).toBe(true);
+    });
+
+    it('a companion whose parent has multiple inputs (bounded-walk profile)', () => {
+      const r = verify(makeVerifier(), buildParentTx(TOKEN_SCRIPT, 2));
+      expect(r.success).toBe(true);
+    });
+
+    it('a companion attested by the second allowlisted attestor', () => {
+      const r = verify(makeVerifier(), buildParentTx(tokenFullScript(ATTESTOR2)));
+      expect(r.success).toBe(true);
+    });
+  });
+
+  describe('rejects (attribute predicate)', () => {
+    it('a rogue attestor not on the allowlist', () => {
+      const r = verify(makeVerifier(), buildParentTx(tokenFullScript(ROGUE)));
+      expect(r.success).toBe(false);
+    });
+
+    it('a wrong category (attribute slot #2, OP_N extraction)', () => {
+      const r = verify(makeVerifier(), buildParentTx(tokenFullScript(ATTESTOR, 10n, 1n, CATEGORY_B)));
+      expect(r.success).toBe(false);
+    });
+
+    it('a companion below the minimum amount (state-region predicate)', () => {
+      const r = verify(makeVerifier({ minAmount: 50n }), buildParentTx());
+      expect(r.success).toBe(false);
+    });
+
+    it('a retired companion (status must be Active)', () => {
+      const r = verify(makeVerifier(), buildParentTx(tokenFullScript(ATTESTOR, 10n, 3n)));
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe('rejects (counterfeits and tampering)', () => {
+    it('a counterfeit script planting an allowlisted key at the attestor offset (template identity)', () => {
+      // Same length class, allowlisted attestor bytes at the right offset —
+      // but every other byte differs, so the excised-template hash mismatches.
+      const fake =
+        'ee'.repeat(Number(ATTESTOR_OFFSET)) + ATTESTOR + 'ee'.repeat(Number(CODE_POST_LEN) + 50);
+      const r = verify(makeVerifier(), buildParentTx(fake));
+      expect(r.success).toBe(false);
+    });
+
+    it('a tampered parent tx (one flipped nibble -> txid mismatch; parent binding)', () => {
+      const r = verify(makeVerifier(), buildParentTx(), { tamperParent: true });
+      expect(r.success).toBe(false);
+    });
+
+    it('allPrevouts that do not hash to the preimage hashPrevouts (prevouts binding)', () => {
+      const r = verify(makeVerifier(), buildParentTx(), { tamperPrevouts: true });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe('rejects (structural walk bounds)', () => {
+    it('a companion outpoint pointing at vout 1 (positional convention)', () => {
+      const r = verify(makeVerifier(), buildParentTx(), { vout: 1 });
+      expect(r.success).toBe(false);
+    });
+
+    it('a parent tx with more than 3 inputs (walk bound)', () => {
+      const r = verify(makeVerifier(), buildParentTx(TOKEN_SCRIPT, 4));
+      expect(r.success).toBe(false);
+    });
+
+    it('a short (P2PKH-sized) output 0 script (varint marker must be 0xfd)', () => {
+      const p2pkh = '76a914' + '33'.repeat(20) + '88ac';
+      const r = verify(makeVerifier(), buildParentTx(p2pkh));
+      expect(r.success).toBe(false);
+    });
+  });
+});

--- a/packages/decompiler/__tests__/constructor-placeholders.test.ts
+++ b/packages/decompiler/__tests__/constructor-placeholders.test.ts
@@ -38,6 +38,10 @@ function compileSource(source: string, fileName = 'Probe.runar.ts') {
   return r;
 }
 
+// Slot `name` is source metadata, not byte-derivable — recovered sources
+// declare synthetic propN names, so round-trip comparisons ignore it.
+const stripName = ({ name: _name, ...rest }: { name?: string }) => rest;
+
 describe('symexec — constructor placeholder recovery', () => {
   it('without constructorSlots, OP_0 placeholders are treated as literal 0n', () => {
     // Same probe as the next case; here we OMIT constructorSlots. The
@@ -74,7 +78,9 @@ describe('symexec — constructor placeholder recovery', () => {
       }
     `;
     const r = compileSource(source);
-    expect(r.artifact!.constructorSlots).toEqual([{ paramIndex: 0, byteOffset: 0 }]);
+    expect(r.artifact!.constructorSlots).toEqual([
+      { paramIndex: 0, byteOffset: 0, name: 'threshold', type: 'bigint', valueEncoding: 'scriptnum' },
+    ]);
 
     const dec = decompile(hexToBytes(r.scriptHex!), {
       constructorSlots: r.artifact!.constructorSlots,
@@ -86,11 +92,15 @@ describe('symexec — constructor placeholder recovery', () => {
     expect(dec.source).toContain('readonly prop0:');
     expect(dec.source).toContain('this.prop0');
 
-    // Re-compile and confirm byte-identity AND slot alignment.
+    // Re-compile and confirm byte-identity AND slot alignment. Slot `name`
+    // is source metadata (the recovered source declares synthetic propN
+    // names), so only the byte-level fields must round-trip.
     const recompiled = compile(dec.source, { fileName: '_Recovered.runar.ts' });
     expect(recompiled.success).toBe(true);
     expect(recompiled.scriptHex).toBe(r.scriptHex);
-    expect(recompiled.artifact!.constructorSlots).toEqual(r.artifact!.constructorSlots);
+    expect(recompiled.artifact!.constructorSlots!.map(stripName)).toEqual(
+      r.artifact!.constructorSlots!.map(stripName),
+    );
   });
 
   it('recovers two placeholders at independent byte offsets via the full symexec pipeline', () => {
@@ -121,8 +131,8 @@ describe('symexec — constructor placeholder recovery', () => {
     `;
     const r = compileSource(source);
     expect(r.artifact!.constructorSlots).toEqual([
-      { paramIndex: 0, byteOffset: 1 },
-      { paramIndex: 1, byteOffset: 4 },
+      { paramIndex: 0, byteOffset: 1, name: 'lo', type: 'bigint', valueEncoding: 'scriptnum' },
+      { paramIndex: 1, byteOffset: 4, name: 'hi', type: 'bigint', valueEncoding: 'scriptnum' },
     ]);
 
     const dec = decompile(hexToBytes(r.scriptHex!), {
@@ -139,7 +149,9 @@ describe('symexec — constructor placeholder recovery', () => {
     const recompiled = compile(dec.source, { fileName: '_Recovered.runar.ts' });
     expect(recompiled.success).toBe(true);
     expect(recompiled.scriptHex).toBe(r.scriptHex);
-    expect(recompiled.artifact!.constructorSlots).toEqual(r.artifact!.constructorSlots);
+    expect(recompiled.artifact!.constructorSlots!.map(stripName)).toEqual(
+      r.artifact!.constructorSlots!.map(stripName),
+    );
   });
 
   it('contract with no placeholders does not synthesize spurious properties', () => {

--- a/packages/decompiler/__tests__/symexec-multimethod.test.ts
+++ b/packages/decompiler/__tests__/symexec-multimethod.test.ts
@@ -159,7 +159,11 @@ describe('symexec — multi-method dispatch', () => {
     const recompiled = compile(dec.source, { fileName: '_Recovered.runar.ts' });
     expect(recompiled.success).toBe(true);
     expect(recompiled.scriptHex).toBe(r.scriptHex);
-    expect(recompiled.artifact!.constructorSlots).toEqual(slots);
+    // Compare slots ignoring `name`: the enriched name is source metadata,
+    // not byte-derivable — the recovered source declares synthetic propN
+    // names, so only the byte-level fields must round-trip.
+    const stripName = ({ name: _name, ...rest }: { name?: string }) => rest;
+    expect(recompiled.artifact!.constructorSlots!.map(stripName)).toEqual(slots.map(stripName));
   });
 
   it('one-method-fails aborts the whole recovery to raw_script (no partial recovery)', () => {

--- a/packages/runar-compiler/src/__tests__/assembler.test.ts
+++ b/packages/runar-compiler/src/__tests__/assembler.test.ts
@@ -288,13 +288,36 @@ describe('Assembler', () => {
   // 7. Constructor slots and codeSeparator
   // -------------------------------------------------------------------------
   describe('constructor slots and codeSeparator', () => {
-    it('includes constructorSlots when provided', () => {
+    it('includes constructorSlots when provided (enriched with descriptor metadata)', () => {
       const slots = [
         { paramIndex: 0, byteOffset: 5 },
         { paramIndex: 1, byteOffset: 40 },
       ];
       const artifact = assemble(P2PKH_SOURCE, { constructorSlots: slots });
-      expect(artifact.constructorSlots).toEqual(slots);
+      // Raw emitter data is preserved...
+      expect(artifact.constructorSlots).toMatchObject(slots);
+      // ...and enriched with verification-descriptor metadata from the ABI.
+      // P2PKH has one ctor param (pk: PubKey) — slot 0 resolves, slot 1 has
+      // no matching param and stays bare.
+      expect(artifact.constructorSlots![0]).toMatchObject({
+        name: 'pk',
+        type: 'PubKey',
+        valueEncoding: 'data',
+        fixedValueByteLength: 33,
+        fixedPushHeaderBytes: 1,
+      });
+      expect(artifact.constructorSlots![1]).toEqual({ paramIndex: 1, byteOffset: 40 });
+      // A templateDigest recipe accompanies the slots.
+      expect(artifact.templateDigest).toEqual({
+        algorithm: 'hash256-excised-slots',
+        pieces: [
+          { kind: 'code' },
+          { kind: 'slot', slot: 'pk', byteOffset: 5 },
+          { kind: 'code' },
+          { kind: 'slot', byteOffset: 40 },
+          { kind: 'code' },
+        ],
+      });
     });
 
     it('omits constructorSlots when empty', () => {

--- a/packages/runar-compiler/src/__tests__/constructor-args-validation.test.ts
+++ b/packages/runar-compiler/src/__tests__/constructor-args-validation.test.ts
@@ -1,0 +1,123 @@
+/**
+ * constructorArgs shape validation — `compile(opts.constructorArgs)` must
+ * reject inputs that would silently bake nothing and emit placeholder
+ * scripts that fail opaquely at runtime:
+ *
+ *  (a) positional arrays (natural guess, but keys match no property names)
+ *  (b) keys that don't match any contract property (typos)
+ *  (c) referenced readonly properties left unbaked after applying the args
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from '../index.js';
+
+// ---------------------------------------------------------------------------
+// Contract sources
+// ---------------------------------------------------------------------------
+
+const HASH_LOCK_SOURCE = `
+class HashLock extends SmartContract {
+  readonly hashValue: Sha256;
+
+  constructor(hashValue: Sha256) {
+    super(hashValue);
+    this.hashValue = hashValue;
+  }
+
+  public unlock(preimage: ByteString) {
+    assert(sha256(preimage) === this.hashValue);
+  }
+}
+`;
+
+const TWO_PROP_SOURCE = `
+class TwoProp extends SmartContract {
+  readonly target: bigint;
+  readonly unused: bigint;
+
+  constructor(target: bigint, unused: bigint) {
+    super(target, unused);
+    this.target = target;
+    this.unused = unused;
+  }
+
+  public check(x: bigint) {
+    assert(x === this.target);
+  }
+}
+`;
+
+const HASH = 'aa'.repeat(32);
+
+function errorMessages(result: ReturnType<typeof compile>): string {
+  return result.diagnostics
+    .filter((d) => d.severity === 'error')
+    .map((d) => d.message)
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('constructorArgs validation', () => {
+  it('rejects a positional array with a diagnostic error', () => {
+    const result = compile(HASH_LOCK_SOURCE, {
+      // Positional array — the shape RunarContract/TestSmartContract take,
+      // but NOT what compile() takes. Previously baked nothing silently.
+      constructorArgs: [HASH] as unknown as Record<string, string>,
+    });
+
+    expect(result.success).toBe(false);
+    expect(errorMessages(result)).toMatch(/positional array/i);
+  });
+
+  it('rejects keys that match no contract property', () => {
+    const result = compile(HASH_LOCK_SOURCE, {
+      constructorArgs: { hashVal: HASH }, // typo: hashValue
+    });
+
+    expect(result.success).toBe(false);
+    const msgs = errorMessages(result);
+    expect(msgs).toContain("'hashVal'");
+    expect(msgs).toContain('hashValue');
+  });
+
+  it('rejects when a referenced readonly property remains unbaked', () => {
+    const result = compile(TWO_PROP_SOURCE, {
+      // 'target' is referenced by check() but not provided.
+      constructorArgs: { unused: 1n },
+    });
+
+    expect(result.success).toBe(false);
+    expect(errorMessages(result)).toMatch(/'target'.*placeholder/s);
+  });
+
+  it('accepts an unreferenced readonly property left unbaked', () => {
+    // 'unused' is never referenced by a method — DCE eliminates it, so
+    // leaving it unbaked is fine.
+    const result = compile(TWO_PROP_SOURCE, {
+      constructorArgs: { target: 42n },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.scriptHex).toBeDefined();
+  });
+
+  it('accepts a complete named record (baked script, no slots)', () => {
+    const result = compile(HASH_LOCK_SOURCE, {
+      constructorArgs: { hashValue: HASH },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.artifact!.script).toContain(HASH);
+    const slots = result.artifact!.constructorSlots;
+    expect(slots === undefined || slots.length === 0).toBe(true);
+  });
+
+  it('still compiles placeholder artifacts when no constructorArgs given', () => {
+    const result = compile(HASH_LOCK_SOURCE);
+    expect(result.success).toBe(true);
+    expect(result.artifact!.constructorSlots!.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/runar-compiler/src/__tests__/cross-compiler.test.ts
+++ b/packages/runar-compiler/src/__tests__/cross-compiler.test.ts
@@ -746,6 +746,19 @@ describe.skipIf(!hasRust || !rustBinaryPath)('Cross-compiler: TS IR -> Rust Scri
 // Test compilation of all example contracts through TS + Go pipeline
 // ---------------------------------------------------------------------------
 
+// Examples that currently compile on the TS tier ONLY, keyed by example
+// directory name with a required justification (mirrors ZIG_PORT_PENDING in
+// zig-parser-examples.test.ts — tracked explicitly, never silently dropped).
+const TS_ONLY_EXAMPLES = new Map<string, string>([
+  // The TS stack lowerer keeps outer-scope refs (method params / pre-loop
+  // consts) alive across unrolled loops (fix in 05-stack-lower.ts); the Go
+  // and Rust lowerers still reject such programs with "value 'inCount' not
+  // found on stack". CompanionVerifier's bounded multi-input walk depends
+  // on that fix. Remove this entry when the loop-scope fix is ported to
+  // the other tiers.
+  ['companion-verifier', 'Go/Rust stack lowering lacks the outer-scope-refs-across-unrolled-loops fix'],
+]);
+
 function findExampleContracts(targetTier?: string): { name: string; source: string }[] {
   const examplesDir = join(__dirname, '..', '..', '..', '..', 'examples', 'ts');
   const contracts: { name: string; source: string }[] = [];
@@ -789,6 +802,9 @@ function findExampleContracts(targetTier?: string): { name: string; source: stri
           if (targetTier) {
             const allowlist = fixtureAllowlists.get(dir.name);
             if (allowlist && !allowlist.includes(targetTier)) continue;
+            // TS-only examples without a conformance fixture (see
+            // TS_ONLY_EXAMPLES above for the tracked justifications).
+            if (targetTier !== 'ts' && TS_ONLY_EXAMPLES.has(dir.name)) continue;
           }
           const source = readFileSync(join(dirPath, file), 'utf-8');
           contracts.push({ name: file.replace('.runar.ts', ''), source });

--- a/packages/runar-compiler/src/__tests__/loop-outer-refs.test.ts
+++ b/packages/runar-compiler/src/__tests__/loop-outer-refs.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Stack lowering across unrolled for-loops — outer-scope refs (method
+ * params, pre-loop consts) must survive loop unrolling:
+ *
+ *  (a) a const defined before a loop and referenced inside it (including
+ *      only inside a nested if-branch) failed compilation with
+ *      "Value 'X' not found on stack" — the first iteration consumed it;
+ *  (b) worse, a method PARAM referenced after an unrolled loop whose body
+ *      also references it was silently lowered to an empty push (OP_0):
+ *      compilation succeeded, the env-based interpreter passed, but the
+ *      emitted Script failed at runtime (silent interpreter<->Script
+ *      divergence).
+ *
+ * The fix: lowerLoop collects outer refs deeply (nested branches included)
+ * and protects them in non-final iterations, and in the final iteration
+ * whenever the enclosing scope still references them after the loop. The
+ * old silent OP_0 fallbacks are now hard errors.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile, compileFromANF } from '../index.js';
+import type { ANFProgram } from '../ir/index.js';
+
+// ---------------------------------------------------------------------------
+// Sources
+// ---------------------------------------------------------------------------
+
+/** V003 repro: multi-input tx walk — param `data` used inside AND after the loop. */
+const LOOP_WALK_SOURCE = `
+import { SmartContract, assert, substr, cat, bin2num } from 'runar-lang';
+import type { ByteString } from 'runar-lang';
+
+class LoopWalk extends SmartContract {
+  readonly pad00: ByteString = "00" as ByteString;
+
+  constructor() {
+    super();
+  }
+
+  public walk(data: ByteString) {
+    let off = 5n;
+    for (let i = 0n; i < 3n; i++) {
+      if (i < bin2num(cat(substr(data, 4n, 1n), this.pad00))) {
+        const sl = bin2num(cat(substr(data, off + 36n, 1n), this.pad00));
+        assert(sl < 253n);
+        off = off + 36n + 1n + sl + 4n;
+      }
+    }
+    const tail = bin2num(cat(substr(data, off, 1n), this.pad00));
+    assert(tail === 7n);
+  }
+}
+`;
+
+/** Symptom (a): const defined before the loop, referenced inside it. */
+const CONST_BEFORE_LOOP_SOURCE = `
+import { SmartContract, assert, substr, cat, bin2num } from 'runar-lang';
+import type { ByteString } from 'runar-lang';
+
+class ConstLoop extends SmartContract {
+  readonly pad00: ByteString = "00" as ByteString;
+
+  constructor() {
+    super();
+  }
+
+  public probe(data: ByteString) {
+    const base = 5n;
+    let acc = 0n;
+    for (let i = 0n; i < 3n; i++) {
+      const b = bin2num(cat(substr(data, base + i, 1n), this.pad00));
+      acc = acc + b;
+    }
+    assert(acc === 6n);
+  }
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('stack lowering: outer refs across unrolled loops', () => {
+  it('param referenced after a loop is not lowered to an empty push', () => {
+    const result = compile(LOOP_WALK_SOURCE, { fileName: 'LoopWalk.runar.ts' });
+    expect(result.success).toBe(true);
+
+    // The post-loop code (after the last OP_ENDIF) reads `data` via
+    // substr(data, off, 1n). With the bug, `data` was emitted as OP_0
+    // right after the final OP_ENDIF; fixed code brings the real param up.
+    const asm = result.scriptAsm!;
+    const postLoop = asm.slice(asm.lastIndexOf('OP_ENDIF'));
+    expect(postLoop).not.toContain('OP_0');
+  });
+
+  it('const defined before a loop and referenced inside compiles', () => {
+    const result = compile(CONST_BEFORE_LOOP_SOURCE, {
+      fileName: 'ConstLoop.runar.ts',
+    });
+    // Previously: "Value 'base' not found on stack (...)"
+    expect(result.success).toBe(true);
+    expect(result.scriptHex).toBeDefined();
+  });
+
+  it('a load_param that cannot be satisfied is a loud error, not OP_0', () => {
+    // Hand-written ANF referencing a parameter the method does not have —
+    // the old code silently emitted OP_0 here.
+    const program: ANFProgram = {
+      contractName: 'Broken',
+      properties: [],
+      methods: [
+        {
+          name: 'run',
+          isPublic: true,
+          params: [{ name: 'x', type: 'bigint' }],
+          body: [
+            { name: 't0', value: { kind: 'load_param', name: 'ghost' } },
+            { name: 't1', value: { kind: 'assert', value: 't0' } },
+          ],
+        },
+      ],
+    };
+
+    expect(() => compileFromANF(program)).toThrow(
+      /Refusing to emit a silent OP_0/,
+    );
+  });
+});

--- a/packages/runar-compiler/src/__tests__/require-baked.test.ts
+++ b/packages/runar-compiler/src/__tests__/require-baked.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `requireBaked` compile option — kills the silent-elimination footgun.
+ *
+ * A readonly property no method references is dropped from the compiled
+ * script entirely; its value then exists nowhere on-chain and cannot be
+ * verified by any downstream contract. `requireBaked: ['prop']` turns that
+ * silent elimination into a compile error, in both template mode (no
+ * constructorArgs — SDK bakes at deploy) and baked mode (constructorArgs
+ * provided at compile time).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from '../index.js';
+
+const SOURCE = `
+import { StatefulSmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class EacShaped extends StatefulSmartContract {
+  owner: PubKey;
+  quantityWh: bigint;
+
+  readonly issuer: PubKey;
+  readonly source: bigint;
+  /** Never referenced — the compiler eliminates it. */
+  readonly tokenId: ByteString;
+
+  constructor(owner: PubKey, quantityWh: bigint, issuer: PubKey, source: bigint, tokenId: ByteString) {
+    super(owner, quantityWh, issuer, source, tokenId);
+    this.owner = owner;
+    this.quantityWh = quantityWh;
+    this.issuer = issuer;
+    this.source = source;
+    this.tokenId = tokenId;
+  }
+
+  public withdraw(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.issuer));
+    assert(this.source >= 1n);
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.quantityWh);
+  }
+}
+`;
+
+const OWNER = '02' + '11'.repeat(32);
+const ISSUER = '03' + 'ab'.repeat(32);
+
+describe('requireBaked (template mode)', () => {
+  it('passes for referenced readonly props (they become constructor slots)', () => {
+    const result = compile(SOURCE, {
+      fileName: 'EacShaped.runar.ts',
+      requireBaked: ['issuer', 'source'],
+    });
+    expect(result.success, JSON.stringify(result.diagnostics)).toBe(true);
+    const slotNames = result.artifact!.constructorSlots!.map(s => s.name);
+    expect(slotNames).toContain('issuer');
+    expect(slotNames).toContain('source');
+  });
+
+  it('FAILS for an eliminated (unreferenced) readonly prop — the iteration-003 footgun', () => {
+    const result = compile(SOURCE, {
+      fileName: 'EacShaped.runar.ts',
+      requireBaked: ['tokenId'],
+    });
+    expect(result.success).toBe(false);
+    expect(result.artifact).toBeUndefined();
+    const msgs = result.diagnostics.map(d => d.message).join('\n');
+    expect(msgs).toMatch(/tokenId.*not referenced by any method body/s);
+    expect(msgs).toMatch(/ELIMINATES/);
+  });
+
+  it('FAILS for an unknown property name', () => {
+    const result = compile(SOURCE, {
+      fileName: 'EacShaped.runar.ts',
+      requireBaked: ['isuer'], // typo
+    });
+    expect(result.success).toBe(false);
+    expect(result.diagnostics.map(d => d.message).join('\n'))
+      .toMatch(/'isuer' is not a property/);
+  });
+
+  it('FAILS for a mutable state field (state tail, not a code slot)', () => {
+    const result = compile(SOURCE, {
+      fileName: 'EacShaped.runar.ts',
+      requireBaked: ['quantityWh'],
+    });
+    expect(result.success).toBe(false);
+    expect(result.diagnostics.map(d => d.message).join('\n'))
+      .toMatch(/'quantityWh' is mutable state/);
+  });
+});
+
+describe('requireBaked (baked mode — constructorArgs at compile time)', () => {
+  const constructorArgs = {
+    owner: OWNER,
+    quantityWh: 10n,
+    issuer: ISSUER,
+    source: 1n,
+    tokenId: 'deadbeef',
+  };
+
+  it('passes for referenced props baked via constructorArgs', () => {
+    const result = compile(SOURCE, {
+      fileName: 'EacShaped.runar.ts',
+      constructorArgs,
+      requireBaked: ['issuer', 'source'],
+    });
+    expect(result.success, JSON.stringify(result.diagnostics)).toBe(true);
+    // The baked issuer bytes are really in the script.
+    expect(result.artifact!.script).toContain(ISSUER);
+  });
+
+  it('FAILS for an eliminated prop even when a value was supplied for it', () => {
+    const result = compile(SOURCE, {
+      fileName: 'EacShaped.runar.ts',
+      constructorArgs,
+      requireBaked: ['tokenId'],
+    });
+    expect(result.success).toBe(false);
+    expect(result.diagnostics.map(d => d.message).join('\n'))
+      .toMatch(/tokenId.*not referenced by any method body/s);
+  });
+});
+
+describe('requireBaked is opt-in', () => {
+  it('omitting the option changes nothing (eliminated prop still compiles)', () => {
+    const result = compile(SOURCE, { fileName: 'EacShaped.runar.ts' });
+    expect(result.success).toBe(true);
+    expect(result.artifact!.constructorSlots!.find(s => s.name === 'tokenId')).toBeUndefined();
+  });
+});

--- a/packages/runar-compiler/src/__tests__/verification-descriptors.test.ts
+++ b/packages/runar-compiler/src/__tests__/verification-descriptors.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Verification descriptors in the compiled artifact:
+ *  - constructorSlots enriched with name/type/valueEncoding + fixed sizes
+ *  - stateFields annotated with byte layout (encoding/byteOffset/byteLength/tailOffset)
+ *  - templateDigest recipe for the slot-excised template hash
+ *
+ * The contract shape mirrors the EAC pattern that motivated the feature: a
+ * stateful token whose readonly provenance fields (issuer PubKey + source
+ * enum) are baked into the code part BECAUSE a method references them —
+ * unreferenced readonly props are eliminated and get no slot.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from '../index.js';
+import { validateArtifact, canonicalJsonStringify } from 'runar-ir-schema';
+
+const EAC_SHAPED_SOURCE = `
+import { StatefulSmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class EacShaped extends StatefulSmartContract {
+  owner: PubKey;
+  quantityWh: bigint;
+  status: bigint;
+
+  readonly issuer: PubKey;
+  readonly source: bigint;
+  /** Never referenced by a method — must be ELIMINATED (no slot). */
+  readonly tokenId: ByteString;
+
+  constructor(
+    owner: PubKey,
+    quantityWh: bigint,
+    status: bigint,
+    issuer: PubKey,
+    source: bigint,
+    tokenId: ByteString,
+  ) {
+    super(owner, quantityWh, status, issuer, source, tokenId);
+    this.owner = owner;
+    this.quantityWh = quantityWh;
+    this.status = status;
+    this.issuer = issuer;
+    this.source = source;
+    this.tokenId = tokenId;
+  }
+
+  public retire(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(this.status === 1n);
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.quantityWh, 3n);
+  }
+
+  public withdraw(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.issuer));
+    assert(this.source >= 1n);
+    assert(this.status === 1n);
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.quantityWh, 4n);
+  }
+}
+`;
+
+function compileEacShaped() {
+  const result = compile(EAC_SHAPED_SOURCE, { fileName: 'EacShaped.runar.ts' });
+  if (!result.artifact) {
+    throw new Error('compile failed: ' + JSON.stringify(result.diagnostics));
+  }
+  return result.artifact;
+}
+
+describe('constructorSlots verification descriptors', () => {
+  const artifact = compileEacShaped();
+  const slots = artifact.constructorSlots ?? [];
+
+  it('emits enriched slots for referenced readonly props (issuer + source)', () => {
+    const issuer = slots.find(s => s.name === 'issuer');
+    expect(issuer).toBeDefined();
+    expect(issuer).toMatchObject({
+      paramIndex: 3,
+      type: 'PubKey',
+      valueEncoding: 'data',
+      fixedValueByteLength: 33,
+      fixedPushHeaderBytes: 1,
+    });
+
+    const source = slots.find(s => s.name === 'source');
+    expect(source).toBeDefined();
+    expect(source).toMatchObject({
+      paramIndex: 4,
+      type: 'bigint',
+      valueEncoding: 'scriptnum',
+    });
+    // scriptnum slots have NO fixed width — the baked length depends on the
+    // value (1..16 = single OP_N byte, >= 17 = multi-byte push).
+    expect(source!.fixedValueByteLength).toBeUndefined();
+    expect(source!.fixedPushHeaderBytes).toBeUndefined();
+  });
+
+  it('emits NO slot for an eliminated (unreferenced) readonly prop', () => {
+    expect(slots.find(s => s.name === 'tokenId')).toBeUndefined();
+    expect(slots.find(s => s.paramIndex === 5)).toBeUndefined();
+  });
+
+  it('slot names/types match abi.constructor.params[paramIndex]', () => {
+    for (const slot of slots) {
+      const param = artifact.abi.constructor.params[slot.paramIndex]!;
+      expect(slot.name).toBe(param.name);
+      expect(slot.type).toBe(param.type);
+    }
+  });
+});
+
+describe('stateFields byte-layout annotation', () => {
+  const artifact = compileEacShaped();
+
+  it('annotates owner/quantityWh/status with serializeState layout', () => {
+    const fields = artifact.stateFields!;
+    expect(fields.map(f => f.name)).toEqual(['owner', 'quantityWh', 'status']);
+
+    // owner: PubKey — 33 raw bytes at the start of the state tail
+    expect(fields[0]).toMatchObject({
+      encoding: 'raw', byteOffset: 0, byteLength: 33, tailOffset: -49,
+    });
+    // quantityWh: bigint — 8 bytes LE sign-magnitude (NUM2BIN 8)
+    expect(fields[1]).toMatchObject({
+      encoding: 'num2bin-le8', byteOffset: 33, byteLength: 8, tailOffset: -16,
+    });
+    // status: bigint — final 8 bytes of the script
+    expect(fields[2]).toMatchObject({
+      encoding: 'num2bin-le8', byteOffset: 41, byteLength: 8, tailOffset: -8,
+    });
+  });
+});
+
+describe('templateDigest recipe', () => {
+  const artifact = compileEacShaped();
+
+  it('emits alternating code/slot pieces in script order', () => {
+    const digest = artifact.templateDigest!;
+    expect(digest.algorithm).toBe('hash256-excised-slots');
+
+    const slotPieces = digest.pieces.filter(p => p.kind === 'slot');
+    const codePieces = digest.pieces.filter(p => p.kind === 'code');
+    // code piece before, between, and after each slot
+    expect(codePieces.length).toBe(slotPieces.length + 1);
+    expect(digest.pieces[0]!.kind).toBe('code');
+    expect(digest.pieces[digest.pieces.length - 1]!.kind).toBe('code');
+
+    // slot pieces in ascending template byte offset, named
+    const offsets = slotPieces.map(p => p.byteOffset!);
+    expect([...offsets].sort((a, b) => a - b)).toEqual(offsets);
+    expect(new Set(slotPieces.map(p => p.slot))).toEqual(new Set(['issuer', 'source']));
+  });
+});
+
+describe('artifact schema accepts the descriptor fields', () => {
+  it('validateArtifact passes on an artifact carrying all new fields', () => {
+    const artifact = compileEacShaped();
+    expect(artifact.templateDigest).toBeDefined();
+    // Round-trip through canonical JSON (bigints → plain integers) — the
+    // on-disk shape the schema validator sees. Same pattern as
+    // artifact-schema.test.ts. `anf` is stripped: the ANF sub-schema has a
+    // PRE-EXISTING gap for this contract's add_output shape that is
+    // unrelated to the descriptor fields under test here.
+    const { anf: _anf, ...rest } = artifact;
+    const plain = JSON.parse(canonicalJsonStringify(rest));
+    const result = validateArtifact(plain);
+    expect(result.valid, JSON.stringify((result as { errors?: unknown }).errors)).toBe(true);
+  });
+});
+
+describe('stateless contracts are unaffected', () => {
+  it('a slotless contract gets no templateDigest', () => {
+    const result = compile(`
+import { SmartContract, assert } from 'runar-lang';
+class AlwaysTrue extends SmartContract {
+  readonly threshold: bigint;
+  constructor(threshold: bigint) { super(threshold); this.threshold = threshold; }
+  public unlock(x: bigint) { assert(x === 1n); }
+}
+`, { fileName: 'AlwaysTrue.runar.ts' });
+    expect(result.artifact, JSON.stringify(result.diagnostics)).toBeDefined();
+    // threshold is never referenced by a method — eliminated, no slots.
+    expect(result.artifact!.constructorSlots).toBeUndefined();
+    expect(result.artifact!.templateDigest).toBeUndefined();
+  });
+});

--- a/packages/runar-compiler/src/__tests__/zig-parser-examples.test.ts
+++ b/packages/runar-compiler/src/__tests__/zig-parser-examples.test.ts
@@ -46,6 +46,14 @@ const ZIG_PORT_PENDING: readonly string[] = [
   // tiers and is verified via the .runar.ts conformance fixture compiled by
   // every tier; it needs no per-format example port.
   'nested-if-multi-reassign/StackTrackerRepro.runar.zig',
+  // TS-only until the non-TS tiers receive the outer-scope-refs-across-
+  // unrolled-loops stack-lowering fix (the TS fix landed in
+  // 05-stack-lower.ts): CompanionVerifier's bounded multi-input walk
+  // references `inCount`/`off` inside an unrolled loop, which the Go/Rust
+  // stack lowerers still reject with "value 'inCount' not found on stack".
+  // Port these alongside that fix.
+  'companion-verifier/AttributedToken.runar.zig',
+  'companion-verifier/CompanionVerifier.runar.zig',
 ];
 
 describe('Zig parser: example inventory', () => {

--- a/packages/runar-compiler/src/artifact/assembler.ts
+++ b/packages/runar-compiler/src/artifact/assembler.ts
@@ -16,6 +16,7 @@ import type {
   ANFProgram,
 } from '../ir/index.js';
 import { computeSideEffectSummary, continuationShape } from '../passes/side-effect-summary.js';
+import { annotateStateFieldLayout, STATE_FIELD_WIDTHS } from 'runar-ir-schema';
 
 // ---------------------------------------------------------------------------
 // Artifact types (mirroring runar-ir-schema/artifact.ts)
@@ -101,16 +102,65 @@ export interface StateField {
     length: number;
     syntheticNames: string[];
   };
+
+  // -- Byte-layout descriptors (additive; mirror the SDK's serializeState) --
+
+  /** Wire encoding of the serialized field in the OP_RETURN state tail. */
+  encoding?: 'num2bin-le8' | 'bool1' | 'raw' | 'pushdata';
+  /** Byte offset from the byte AFTER the OP_RETURN separator. Omitted when
+   *  any preceding field is variable-length. */
+  byteOffset?: number;
+  /** Serialized length in bytes. Omitted for variable-length fields. */
+  byteLength?: number;
+  /** NEGATIVE byte offset from the END of the locking script. Omitted when
+   *  this or any following field is variable-length. */
+  tailOffset?: number;
 }
 
+/**
+ * One deploy-baked constructor slot: a 1-byte OP_0 placeholder in the
+ * template script. The optional verification-descriptor fields carry
+ * value-INDEPENDENT metadata (name/type/encoding); the SDK's
+ * `resolveSlotLayout(artifact, constructorArgs)` resolves concrete deployed
+ * offsets/lengths for given args.
+ */
 export interface ConstructorSlot {
   paramIndex: number;
   byteOffset: number;
+  /** Constructor parameter name (matches `abi.constructor.params[paramIndex].name`). */
+  name?: string;
+  /** ABI type of the parameter (e.g. `PubKey`, `bigint`, `ByteString`). */
+  type?: string;
+  /** How the deploy-time value is encoded when spliced into the slot. */
+  valueEncoding?: 'data' | 'scriptnum' | 'bool';
+  /** For fixed-size data types only: baked value length in bytes. */
+  fixedValueByteLength?: number;
+  /** For fixed-size data types only: push-header bytes preceding the value. */
+  fixedPushHeaderBytes?: number;
 }
 
 export interface CodeSepIndexSlot {
   byteOffset: number;
   codeSepIndex: number;
+}
+
+/** One piece of the slot-excised template identity. */
+export interface TemplateDigestPiece {
+  kind: 'code' | 'slot';
+  /** For kind 'slot': the excised slot's constructor param name. */
+  slot?: string;
+  /** For kind 'slot': the slot's TEMPLATE byte offset. */
+  byteOffset?: number;
+}
+
+/**
+ * Recipe for recomputing the contract's slot-excised template hash:
+ * hash256 over the resolved code part with every constructor slot's VALUE
+ * bytes removed (push headers stay in the hashed template).
+ */
+export interface TemplateDigest {
+  algorithm: 'hash256-excised-slots';
+  pieces: TemplateDigestPiece[];
 }
 
 /**
@@ -168,8 +218,12 @@ export interface RunarArtifact {
   /** State field descriptors (present only for stateful contracts) */
   stateFields?: StateField[];
 
-  /** Byte offsets of constructor parameter placeholders in the script */
+  /** Byte offsets of constructor parameter placeholders in the script,
+   *  enriched with verification-descriptor metadata (name/type/encoding). */
   constructorSlots?: ConstructorSlot[];
+
+  /** Recipe for recomputing the slot-excised template identity hash. */
+  templateDigest?: TemplateDigest;
 
   /** Byte offsets of codeSepIndex placeholders in the script */
   codeSepIndexSlots?: CodeSepIndexSlot[];
@@ -609,6 +663,69 @@ function extractStateFields(properties: PropertyNode[], anfProgram?: ANFProgram)
 }
 
 // ---------------------------------------------------------------------------
+// Verification-descriptor enrichment
+// ---------------------------------------------------------------------------
+
+/** Classify how a constructor arg of the given ABI type is encoded when
+ *  spliced into its slot (see ConstructorSlot.valueEncoding). */
+function slotValueEncoding(type: string): 'data' | 'scriptnum' | 'bool' {
+  if (type === 'int' || type === 'bigint') return 'scriptnum';
+  if (type === 'bool' || type === 'boolean') return 'bool';
+  return 'data';
+}
+
+/**
+ * Enrich raw emitter constructor slots with value-INDEPENDENT verification
+ * metadata: param name/type, value encoding, and — for fixed-size data
+ * types (PubKey, Sha256, ...) — the exact value length and push-header
+ * length. Widths come from the shared `STATE_FIELD_WIDTHS` table (the same
+ * table the state serializer uses), so slot and state descriptors cannot
+ * drift apart.
+ */
+function enrichConstructorSlots(
+  slots: ConstructorSlot[],
+  abi: ABI,
+): ConstructorSlot[] {
+  return slots.map(slot => {
+    const out: ConstructorSlot = { paramIndex: slot.paramIndex, byteOffset: slot.byteOffset };
+    const param = abi.constructor.params[slot.paramIndex];
+    if (!param) return out;
+    out.name = param.name;
+    out.type = param.type;
+    out.valueEncoding = slotValueEncoding(param.type);
+    if (out.valueEncoding === 'data') {
+      const width = STATE_FIELD_WIDTHS[param.type];
+      if (width && width.encoding === 'raw') {
+        out.fixedValueByteLength = width.size;
+        out.fixedPushHeaderBytes = 1; // direct push: all fixed types are <= 75 bytes
+      }
+    }
+    return out;
+  });
+}
+
+/**
+ * Build the slot-excised template digest recipe: alternating code/slot
+ * pieces in script order (slots deduped by template byte offset — the same
+ * placeholder cannot be excised twice).
+ */
+function buildTemplateDigest(slots: ConstructorSlot[]): TemplateDigest {
+  const seen = new Set<number>();
+  const ordered = [...slots]
+    .sort((a, b) => a.byteOffset - b.byteOffset)
+    .filter(s => (seen.has(s.byteOffset) ? false : (seen.add(s.byteOffset), true)));
+
+  const pieces: TemplateDigestPiece[] = [{ kind: 'code' }];
+  for (const s of ordered) {
+    const piece: TemplateDigestPiece = { kind: 'slot', byteOffset: s.byteOffset };
+    if (s.name !== undefined) piece.slot = s.name;
+    pieces.push(piece);
+    pieces.push({ kind: 'code' });
+  }
+  return { algorithm: 'hash256-excised-slots', pieces };
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -640,7 +757,12 @@ export function assembleArtifact(
       m.usesCodePart = true;
     }
   }
-  const stateFields = extractStateFields(contract.properties, anfProgram);
+  // Annotate state fields with their byte layout (encoding/byteOffset/
+  // byteLength/tailOffset) so verifiers can locate state values in a
+  // companion input's locking script without re-deriving the layout.
+  const stateFields = annotateStateFieldLayout(
+    extractStateFields(contract.properties, anfProgram),
+  ) as StateField[];
   const compilerVersion = options?.compilerVersion ?? DEFAULT_COMPILER_VERSION;
 
   const artifact: RunarArtifact = {
@@ -677,9 +799,11 @@ export function assembleArtifact(
     artifact.anf = anfProgram;
   }
 
-  // Constructor slots (only if there are placeholder byte offsets)
+  // Constructor slots (only if there are placeholder byte offsets), enriched
+  // with verification-descriptor metadata + the template digest recipe.
   if (options?.constructorSlots && options.constructorSlots.length > 0) {
-    artifact.constructorSlots = options.constructorSlots;
+    artifact.constructorSlots = enrichConstructorSlots(options.constructorSlots, abi);
+    artifact.templateDigest = buildTemplateDigest(artifact.constructorSlots);
   }
 
   // CodeSepIndex slots (only if there are placeholder byte offsets)

--- a/packages/runar-compiler/src/index.ts
+++ b/packages/runar-compiler/src/index.ts
@@ -94,6 +94,20 @@ export interface CompileOptions {
   /** Bake property values into the locking script (replaces placeholders). */
   constructorArgs?: Record<string, bigint | boolean | string>;
 
+  /**
+   * Names of readonly properties that MUST be verifiable on-chain — i.e.
+   * survive compilation baked into the locking script (as deploy-time
+   * constructor slots, or as compile-time-baked values).
+   *
+   * A readonly property that no method references is ELIMINATED from the
+   * compiled script entirely — silently. Its value then exists nowhere in
+   * the deployed UTXO, so no downstream contract or verifier can extract
+   * it: provenance you can check in Script only exists if the contract
+   * itself commits to it. Listing such a property here turns that silent
+   * elimination into a compile error.
+   */
+  requireBaked?: string[];
+
   /** If true, skip the ANF constant folding pass. Default: false (folding enabled). */
   disableConstantFolding?: boolean;
 
@@ -359,6 +373,24 @@ export function compile(source: string, options?: CompileOptions): CompileResult
     }
   }
 
+  // requireBaked guard: turn silent elimination of a must-be-verifiable
+  // readonly property into a compile error. Runs on the pre-fold ANF so
+  // `load_prop` references are still intact in both template and baked modes.
+  if (opts.requireBaked && opts.requireBaked.length > 0) {
+    const requireBakedErrors = validateRequireBaked(anf, opts.requireBaked);
+    if (requireBakedErrors.length > 0) {
+      for (const msg of requireBakedErrors) {
+        diagnostics.push({ message: msg, severity: 'error' } as CompilerDiagnostic);
+      }
+      return {
+        anf: null,
+        contract: parseResult.contract,
+        diagnostics,
+        success: false,
+      };
+    }
+  }
+
   // Pass 4.25: Constant folding (on by default)
   if (!opts.disableConstantFolding) {
     onProgress?.('Constant folding', 45);
@@ -390,6 +422,28 @@ export function compile(source: string, options?: CompileOptions): CompileResult
 
     onProgress?.('Emitting script', 85);
     const emitResult = emit(stackProgram);
+
+    // requireBaked belt-and-braces: in template mode every required prop
+    // without a compile-time value must have produced a constructor slot.
+    if (opts.requireBaked && opts.requireBaked.length > 0) {
+      const slotErrors = findRequireBakedMissingSlots(
+        optimizedAnf,
+        opts.requireBaked,
+        emitResult.constructorSlots,
+      );
+      if (slotErrors.length > 0) {
+        for (const msg of slotErrors) {
+          diagnostics.push({ message: msg, severity: 'error' } as CompilerDiagnostic);
+        }
+        return {
+          anf: optimizedAnf,
+          contract: parseResult.contract,
+          diagnostics,
+          success: false,
+        };
+      }
+    }
+
     onProgress?.('Assembling artifact', 95);
     const artifact = assembleArtifact(
       expandedContract,
@@ -736,6 +790,80 @@ function findUnbakedReferencedReadonly(anf: ANFProgram): string[] {
           `after baking constructorArgs — the emitted script would carry an OP_0 ` +
           `placeholder that fails at runtime. Provide '${prop.name}' in constructorArgs ` +
           `(or give the property an initializer).`,
+      );
+    }
+  }
+  return errors;
+}
+
+/**
+ * Validate `requireBaked` names against the (post-bake, pre-fold) ANF:
+ *  (a) every name must be a contract property;
+ *  (b) it must be readonly — mutable state lives in the OP_RETURN state
+ *      tail, not a baked code slot;
+ *  (c) it must be REFERENCED by at least one method body — an unreferenced
+ *      readonly property is eliminated from the compiled script entirely,
+ *      so its value would not be verifiable on-chain by anyone.
+ */
+function validateRequireBaked(anf: ANFProgram, names: string[]): string[] {
+  const errors: string[] = [];
+  const referenced = collectReferencedProps(anf);
+  for (const name of names) {
+    const prop = anf.properties.find(p => p.name === name);
+    if (!prop) {
+      const propNames = anf.properties.map(p => p.name).join(', ');
+      errors.push(
+        `requireBaked: '${name}' is not a property of contract '${anf.contractName}' ` +
+          `(properties: [${propNames}]).`,
+      );
+      continue;
+    }
+    if (!prop.readonly) {
+      errors.push(
+        `requireBaked: property '${name}' is mutable state — it is serialized into the ` +
+          `OP_RETURN state tail, not baked into the code part. requireBaked applies to ` +
+          `readonly properties only.`,
+      );
+      continue;
+    }
+    if (!referenced.has(name)) {
+      errors.push(
+        `requireBaked: readonly property '${name}' is not referenced by any method body, ` +
+          `so the compiler ELIMINATES it — its value would exist nowhere in the deployed ` +
+          `locking script and could not be verified on-chain by any downstream contract. ` +
+          `Reference it in a method (e.g. checkSig(sig, this.${name}) or ` +
+          `assert(this.${name} >= 1n)) to force it into a constructor slot.`,
+      );
+    }
+  }
+  return errors;
+}
+
+/**
+ * Post-emit requireBaked cross-check (template mode): every required prop
+ * that has no compile-time value must map to at least one emitted
+ * constructor slot. Guards against any optimizer pass dropping a reference
+ * AFTER the ANF-level check.
+ */
+function findRequireBakedMissingSlots(
+  anf: ANFProgram,
+  names: string[],
+  constructorSlots: { paramIndex: number; byteOffset: number }[],
+): string[] {
+  const ctorProps = anf.properties.filter(p => p.initialValue === undefined);
+  const slotNames = new Set(
+    constructorSlots.map(s => ctorProps[s.paramIndex]?.name).filter(n => n !== undefined),
+  );
+  const errors: string[] = [];
+  for (const name of names) {
+    const prop = anf.properties.find(p => p.name === name);
+    if (!prop || !prop.readonly) continue; // reported by validateRequireBaked
+    if (prop.initialValue !== undefined) continue; // baked at compile time
+    if (!slotNames.has(name)) {
+      errors.push(
+        `requireBaked: readonly property '${name}' produced no constructor slot in the ` +
+          `emitted script (optimized away after ANF lowering) — its value would not be ` +
+          `verifiable on-chain.`,
       );
     }
   }

--- a/packages/runar-compiler/src/index.ts
+++ b/packages/runar-compiler/src/index.ts
@@ -68,9 +68,10 @@ import { emit } from './passes/06-emit.js';
 import { optimizeStackIR } from './optimizer/peephole.js';
 import { optimizeEC } from './optimizer/anf-ec.js';
 import { foldConstants } from './optimizer/constant-fold.js';
+import { eliminateDeadBindings } from './optimizer/dce.js';
 import { assembleArtifact } from './artifact/assembler.js';
 import type { CompilerDiagnostic } from './errors.js';
-import type { ContractNode, ANFProgram, RunarArtifact } from './ir/index.js';
+import type { ContractNode, ANFProgram, ANFBinding, RunarArtifact } from './ir/index.js';
 import { InputLimits, CanonicalJsonError } from 'runar-ir-schema';
 
 // ---------------------------------------------------------------------------
@@ -325,10 +326,36 @@ export function compile(source: string, options?: CompileOptions): CompileResult
   // Bake constructor args into ANF properties so stack lowering emits real
   // values instead of OP_0 placeholders.
   if (opts.constructorArgs) {
+    const shapeErrors = validateConstructorArgsShape(anf, opts.constructorArgs);
+    if (shapeErrors.length > 0) {
+      for (const msg of shapeErrors) {
+        diagnostics.push({ message: msg, severity: 'error' } as CompilerDiagnostic);
+      }
+      return {
+        anf: null,
+        contract: parseResult.contract,
+        diagnostics,
+        success: false,
+      };
+    }
+
     for (const prop of anf.properties) {
       if (prop.name in opts.constructorArgs) {
         prop.initialValue = opts.constructorArgs[prop.name];
       }
+    }
+
+    const unbakedErrors = findUnbakedReferencedReadonly(anf);
+    if (unbakedErrors.length > 0) {
+      for (const msg of unbakedErrors) {
+        diagnostics.push({ message: msg, severity: 'error' } as CompilerDiagnostic);
+      }
+      return {
+        anf: null,
+        contract: parseResult.contract,
+        diagnostics,
+        success: false,
+      };
     }
   }
 
@@ -455,10 +482,20 @@ export function compileFromANF(
   // Bake constructor args into ANF properties so stack lowering emits real
   // values instead of OP_0 placeholders.
   if (opts.constructorArgs) {
+    const shapeErrors = validateConstructorArgsShape(anf, opts.constructorArgs);
+    if (shapeErrors.length > 0) {
+      throw new Error(`compileFromANF: ${shapeErrors.join('; ')}`);
+    }
+
     for (const prop of anf.properties) {
       if (prop.name in opts.constructorArgs) {
         prop.initialValue = opts.constructorArgs[prop.name];
       }
+    }
+
+    const unbakedErrors = findUnbakedReferencedReadonly(anf);
+    if (unbakedErrors.length > 0) {
+      throw new Error(`compileFromANF: ${unbakedErrors.join('; ')}`);
     }
   }
 
@@ -632,4 +669,116 @@ export function compileCheck(source: string, fileName?: string, options?: Compil
 
 function hasErrors(diagnostics: CompilerDiagnostic[]): boolean {
   return diagnostics.some(d => d.severity === 'error');
+}
+
+/**
+ * Validate the shape of `constructorArgs` against the contract's properties
+ * BEFORE baking. Returns a list of error messages (empty when valid).
+ *
+ * Rejects:
+ *  (a) positional arrays — `constructorArgs` must be a named record keyed by
+ *      property name. A positional array matches no property names, so
+ *      nothing would be baked and the script would silently keep its OP_0
+ *      placeholders (failing opaquely at runtime).
+ *  (b) keys that do not match any contract property name (typos would
+ *      otherwise silently bake nothing for that key).
+ */
+function validateConstructorArgsShape(
+  anf: ANFProgram,
+  constructorArgs: Record<string, bigint | boolean | string>,
+): string[] {
+  const errors: string[] = [];
+
+  if (Array.isArray(constructorArgs)) {
+    const propNames = anf.properties.map(p => p.name).join(', ');
+    errors.push(
+      `constructorArgs must be a record keyed by property name, not a positional array. ` +
+        `Contract '${anf.contractName}' properties: [${propNames}]. ` +
+        `Example: { ${anf.properties[0]?.name ?? 'propName'}: <value> }`,
+    );
+    return errors;
+  }
+
+  const propNameSet = new Set(anf.properties.map(p => p.name));
+  for (const key of Object.keys(constructorArgs)) {
+    if (!propNameSet.has(key)) {
+      const propNames = anf.properties.map(p => p.name).join(', ');
+      errors.push(
+        `constructorArgs key '${key}' does not match any property of contract ` +
+          `'${anf.contractName}' (properties: [${propNames}]). ` +
+          `Nothing would be baked for this key.`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * After baking `constructorArgs`, find readonly properties that are
+ * REFERENCED by at least one method body but still have no baked
+ * `initialValue`. Such properties would be emitted as OP_0 placeholders,
+ * making the compiled script fail opaquely at runtime (e.g.
+ * `OP_EQUALVERIFY failed` with no hint as to why).
+ *
+ * Only applies when the caller asked for baking — unbaked placeholder
+ * compilation (no `constructorArgs`) is the normal deploy-artifact path
+ * where the SDK substitutes values via `constructorSlots`.
+ */
+function findUnbakedReferencedReadonly(anf: ANFProgram): string[] {
+  const referenced = collectReferencedProps(anf);
+
+  const errors: string[] = [];
+  for (const prop of anf.properties) {
+    if (prop.readonly && prop.initialValue === undefined && referenced.has(prop.name)) {
+      errors.push(
+        `readonly property '${prop.name}' is referenced by a method but has no value ` +
+          `after baking constructorArgs — the emitted script would carry an OP_0 ` +
+          `placeholder that fails at runtime. Provide '${prop.name}' in constructorArgs ` +
+          `(or give the property an initializer).`,
+      );
+    }
+  }
+  return errors;
+}
+
+/**
+ * Collect the property names actually referenced by method bodies.
+ *
+ * The raw ANF from pass 4 loads every property at method entry; only after
+ * dead-binding elimination do the surviving `load_prop` nodes reflect real
+ * references. DCE is a pure function, so running it here on a probe copy
+ * does not perturb the main pipeline.
+ */
+function collectReferencedProps(anf: ANFProgram): Set<string> {
+  const probe = eliminateDeadBindings(anf);
+  const referenced = new Set<string>();
+  for (const method of probe.methods) {
+    // The constructor's super(...) call references every property but is
+    // never emitted as script code — only real method bodies count.
+    if (method.name === 'constructor') continue;
+    collectLoadPropRefs(method.body, referenced);
+  }
+  return referenced;
+}
+
+/** Recursively collect `load_prop` property names from ANF bindings. */
+function collectLoadPropRefs(bindings: ANFBinding[], out: Set<string>): void {
+  for (const binding of bindings) {
+    const v = binding.value;
+    switch (v.kind) {
+      case 'load_prop':
+        out.add(v.name);
+        break;
+      case 'if':
+        collectLoadPropRefs(v.then, out);
+        collectLoadPropRefs(v.else, out);
+        break;
+      case 'loop':
+        collectLoadPropRefs(v.body, out);
+        break;
+      default:
+        break;
+    }
+  }
 }

--- a/packages/runar-compiler/src/ir/artifact.ts
+++ b/packages/runar-compiler/src/ir/artifact.ts
@@ -99,15 +99,45 @@ export interface StateField {
     length: number;
     syntheticNames: string[];
   };
+
+  // -- Byte-layout descriptors (additive; mirror the SDK's serializeState) --
+
+  /** Wire encoding of the serialized field in the OP_RETURN state tail. */
+  encoding?: 'num2bin-le8' | 'bool1' | 'raw' | 'pushdata';
+  /** Byte offset from the byte AFTER the OP_RETURN separator. Omitted when
+   *  any preceding field is variable-length. */
+  byteOffset?: number;
+  /** Serialized length in bytes. Omitted for variable-length fields. */
+  byteLength?: number;
+  /** NEGATIVE byte offset from the END of the locking script. Omitted when
+   *  this or any following field is variable-length. */
+  tailOffset?: number;
 }
 
 // ---------------------------------------------------------------------------
 // Constructor slots
 // ---------------------------------------------------------------------------
 
+/**
+ * One deploy-baked constructor slot: a 1-byte OP_0 placeholder in the
+ * template script. The optional verification-descriptor fields carry
+ * value-INDEPENDENT metadata (name/type/encoding); the SDK's
+ * `resolveSlotLayout(artifact, constructorArgs)` resolves concrete deployed
+ * offsets/lengths for given args.
+ */
 export interface ConstructorSlot {
   paramIndex: number;
   byteOffset: number;
+  /** Constructor parameter name (matches `abi.constructor.params[paramIndex].name`). */
+  name?: string;
+  /** ABI type of the parameter (e.g. `PubKey`, `bigint`, `ByteString`). */
+  type?: string;
+  /** How the deploy-time value is encoded when spliced into the slot. */
+  valueEncoding?: 'data' | 'scriptnum' | 'bool';
+  /** For fixed-size data types only: baked value length in bytes. */
+  fixedValueByteLength?: number;
+  /** For fixed-size data types only: push-header bytes preceding the value. */
+  fixedPushHeaderBytes?: number;
 }
 
 export interface CodeSepIndexSlot {
@@ -115,6 +145,29 @@ export interface CodeSepIndexSlot {
   byteOffset: number;
   /** The template-relative codeSeparatorIndex value this placeholder represents */
   codeSepIndex: number;
+}
+
+// ---------------------------------------------------------------------------
+// Template digest (slot-excised script identity)
+// ---------------------------------------------------------------------------
+
+/** One piece of the slot-excised template identity. */
+export interface TemplateDigestPiece {
+  kind: 'code' | 'slot';
+  /** For kind 'slot': the excised slot's constructor param name. */
+  slot?: string;
+  /** For kind 'slot': the slot's TEMPLATE byte offset. */
+  byteOffset?: number;
+}
+
+/**
+ * Recipe for recomputing the contract's slot-excised template hash:
+ * hash256 over the resolved code part with every constructor slot's VALUE
+ * bytes removed (push headers stay in the hashed template).
+ */
+export interface TemplateDigest {
+  algorithm: 'hash256-excised-slots';
+  pieces: TemplateDigestPiece[];
 }
 
 /**
@@ -178,8 +231,12 @@ export interface RunarArtifact {
   /** State field descriptors (present only for stateful contracts) */
   stateFields?: StateField[];
 
-  /** Byte offsets of constructor parameter placeholders in the script */
+  /** Byte offsets of constructor parameter placeholders in the script,
+   *  enriched with verification-descriptor metadata (name/type/encoding). */
   constructorSlots?: ConstructorSlot[];
+
+  /** Recipe for recomputing the slot-excised template identity hash. */
+  templateDigest?: TemplateDigest;
 
   /** Byte offsets of codeSepIndex placeholders in the script (OP_0 placeholders
    *  that the SDK must replace with the adjusted codeSeparatorIndex). */

--- a/packages/runar-compiler/src/passes/05-stack-lower.ts
+++ b/packages/runar-compiler/src/passes/05-stack-lower.ts
@@ -243,6 +243,11 @@ class StackMap {
     this.slots.push(this.slots[this.slots.length - 1]!);
   }
 
+  /** Debug string of the slot names (bottom -> top) for error messages. */
+  debugSlots(): string {
+    return this.slots.join(', ');
+  }
+
   /** Get the set of all named (non-null) slot values. */
   namedSlots(): Set<string> {
     const names = new Set<string>();
@@ -301,6 +306,28 @@ function computeLastUses(bindings: ANFBinding[]): Map<string, number> {
   }
 
   return lastUse;
+}
+
+/**
+ * Collect every binding name defined anywhere in a binding sequence,
+ * recursing into nested if-branches and loop bodies. Used by lowerLoop to
+ * distinguish loop-internal (re)definitions from true outer-scope refs.
+ */
+function collectDeepBindingNames(bindings: ANFBinding[]): Set<string> {
+  const names = new Set<string>();
+  const walk = (bs: ANFBinding[]): void => {
+    for (const b of bs) {
+      names.add(b.name);
+      if (b.value.kind === 'if') {
+        walk(b.value.then);
+        walk(b.value.else);
+      } else if (b.value.kind === 'loop') {
+        walk(b.value.body);
+      }
+    }
+  };
+  walk(bindings);
+  return names;
 }
 
 function collectRefs(value: ANFValue): string[] {
@@ -1042,7 +1069,7 @@ class LoweringContext {
         this.lowerIf(name, value.cond, value.then, value.else, bindingIndex, lastUses);
         break;
       case 'loop':
-        this.lowerLoop(name, value.count, value.body, value.iterVar);
+        this.lowerLoop(name, value.count, value.body, value.iterVar, bindingIndex, lastUses);
         break;
       case 'assert':
         this.lowerAssert(value.value, bindingIndex, lastUses);
@@ -1173,10 +1200,16 @@ class LoweringContext {
       this.stackMap.pop();
       this.stackMap.push(bindingName);
     } else {
-      // Parameter not found - should not happen in well-formed ANF.
-      // Emit a push of zero as a fallback.
-      this.emitOp({ op: 'push', value: 0n });
-      this.stackMap.push(bindingName);
+      // Parameter no longer on the stack — a compiler invariant violation
+      // (historically caused by unrolled loops consuming outer refs; see
+      // lowerLoop). Silently emitting OP_0 here produced scripts that
+      // compiled, passed the env-based interpreter, and then failed on
+      // chain — fail loudly instead.
+      throw new Error(
+        `Stack lowering: method parameter '${paramName}' is not on the stack ` +
+          `at a post-consumption reference (stack: [${this.stackMap.debugSlots()}]). ` +
+          `Refusing to emit a silent OP_0 placeholder.`,
+      );
     }
   }
 
@@ -1240,9 +1273,14 @@ class LoweringContext {
         this.stackMap.pop();
         this.stackMap.push(bindingName);
       } else {
-        // Referenced value not on stack -- push a placeholder
-        this.emitOp({ op: 'push', value: 0n });
-        this.stackMap.push(bindingName);
+        // Referenced value no longer on the stack — a compiler invariant
+        // violation (see lowerLoadParam for the loop-consumption history).
+        // Fail loudly instead of silently emitting OP_0.
+        throw new Error(
+          `Stack lowering: value '${refName}' referenced by '${bindingName}' is not ` +
+            `on the stack (stack: [${this.stackMap.debugSlots()}]). ` +
+            `Refusing to emit a silent OP_0 placeholder.`,
+        );
       }
       return;
     }
@@ -2169,23 +2207,28 @@ class LoweringContext {
     count: number,
     body: ANFBinding[],
     _iterVar: string,
+    loopBindingIndex?: number,
+    enclosingLastUses?: Map<string, number>,
   ): void {
-    // Collect outer-scope names referenced in the loop body.
-    // These must not be consumed in non-final iterations.
+    // Names (re)defined anywhere inside the loop body, nested branches
+    // included. A name the body itself binds is NOT an outer ref —
+    // reassigned locals (e.g. `off = off + ...` inside an if) flow through
+    // lowerIf's branch-reassignment reconciliation, not through protection
+    // here.
+    const deepBodyBindingNames = collectDeepBindingNames(body);
     const bodyBindingNames = new Set(body.map(b => b.name));
+
+    // Collect ALL outer-scope refs used anywhere in the body — including
+    // refs that only occur inside nested if-branches (collectRefs recurses).
+    // The previous top-level-only scan missed nested references: a const
+    // defined before the loop and referenced only inside an if-branch was
+    // consumed by the first iteration, making iteration 2 fail with
+    // "Value 'X' not found on stack".
     const outerRefs = new Set<string>();
     for (const b of body) {
-      if (b.value.kind === 'load_param' && b.value.name !== _iterVar) {
-        outerRefs.add(b.value.name);
-      }
-      // Also protect @ref: targets from outer scope (not redefined in body)
-      if (b.value.kind === 'load_const') {
-        const v = b.value.value;
-        if (typeof v === 'string' && v.startsWith('@ref:')) {
-          const refName = v.slice(5);
-          if (!bodyBindingNames.has(refName)) {
-            outerRefs.add(refName);
-          }
+      for (const ref of collectRefs(b.value)) {
+        if (ref !== _iterVar && !deepBodyBindingNames.has(ref)) {
+          outerRefs.add(ref);
         }
       }
     }
@@ -2203,10 +2246,23 @@ class LoweringContext {
 
       const lastUses = computeLastUses(body);
 
-      // In non-final iterations, prevent outer-scope refs from being
-      // consumed by setting their last-use beyond any body binding index.
-      if (i < count - 1) {
-        for (const refName of outerRefs) {
+      // Prevent outer-scope refs from being consumed by setting their
+      // last-use beyond any body binding index:
+      //  - in non-final iterations: always (the next iteration re-reads them);
+      //  - in the FINAL iteration: when the enclosing scope still references
+      //    them AFTER the loop. Previously the final iteration consumed
+      //    every outer ref at its last body use, so a method param (or
+      //    const) referenced after the loop was gone from the stack and was
+      //    silently lowered to an OP_0/empty push — compilation succeeded,
+      //    the env-based interpreter passed, but the emitted Script failed
+      //    at runtime (silent interpreter <-> Script divergence).
+      const isFinalIteration = i === count - 1;
+      for (const refName of outerRefs) {
+        const usedAfterLoop =
+          enclosingLastUses !== undefined &&
+          loopBindingIndex !== undefined &&
+          (enclosingLastUses.get(refName) ?? -1) > loopBindingIndex;
+        if (!isFinalIteration || usedAfterLoop) {
           lastUses.set(refName, body.length);
         }
       }

--- a/packages/runar-ir-schema/src/artifact.ts
+++ b/packages/runar-ir-schema/src/artifact.ts
@@ -102,15 +102,92 @@ export interface StateField {
     length: number;
     syntheticNames: string[];
   };
+
+  // -- Byte-layout descriptors (additive; mirror the SDK's serializeState) --
+  //
+  // Stateful contracts serialize state as `<code> OP_RETURN <field0>...<fieldN>`
+  // in `index` order. These fields let a verifier locate a state value inside
+  // a companion input's locking script without re-deriving the layout.
+
+  /**
+   * Wire encoding of the serialized field:
+   *  - 'num2bin-le8': bigint — 8 raw bytes, little-endian sign-magnitude
+   *                   (OP_NUM2BIN 8 semantics; sign bit = MSB of last byte).
+   *  - 'bool1':       bool — 1 raw byte (0x00 / 0x01).
+   *  - 'raw':         fixed-size byte types — raw bytes, no framing
+   *                   (PubKey 33, Addr/Ripemd160 20, Sha256 32, Point 64).
+   *  - 'pushdata':    variable-length types — push-data framed (length
+   *                   prefix + bytes); byte length is value-dependent.
+   */
+  encoding?: 'num2bin-le8' | 'bool1' | 'raw' | 'pushdata';
+  /** Byte offset from the byte AFTER the OP_RETURN separator. Omitted when
+   *  any preceding field is variable-length. */
+  byteOffset?: number;
+  /** Serialized length in bytes (for fixedArray fields: total across all
+   *  flattened leaves). Omitted for variable-length fields. */
+  byteLength?: number;
+  /** NEGATIVE byte offset from the END of the locking script (the state
+   *  tail is the script's suffix, so `scriptLen + tailOffset` is the
+   *  field's start). Omitted when this or any following field is
+   *  variable-length. */
+  tailOffset?: number;
 }
 
 // ---------------------------------------------------------------------------
 // Constructor slots
 // ---------------------------------------------------------------------------
 
+/**
+ * One deploy-baked constructor slot: a 1-byte OP_0 placeholder in the
+ * TEMPLATE script (`artifact.script`) that the SDK replaces with the
+ * encoded constructor arg at deploy time.
+ *
+ * The verification-descriptor fields (`name`, `type`, `valueEncoding`,
+ * `fixedValueByteLength`, `fixedPushHeaderBytes`) are additive metadata that
+ * make cross-contract verification MECHANICAL: a consuming contract (or
+ * off-chain verifier) that inspects a companion input's parent transaction
+ * can locate each baked readonly value without re-deriving offsets by
+ * diffing/`indexOf`-ing compiled scripts — which is fragile and encoding-
+ * sensitive (bigint values 1..16 bake as a single OP_N opcode byte, 0 bakes
+ * as OP_0, and >=17 bakes as a multi-byte push that shifts every downstream
+ * offset).
+ *
+ * DESIGN SPLIT (value-independence): the compiler cannot know the byte
+ * length a slot occupies after deployment — that depends on the VALUE baked
+ * at deploy time (a 33-byte PubKey push vs. a 1-byte OP_N). So the artifact
+ * carries only value-INDEPENDENT metadata here, and the SDK's
+ * `resolveSlotLayout(artifact, constructorArgs)` / `computeTemplateHash(
+ * artifact, constructorArgs)` resolve concrete offsets/lengths/hashes for
+ * GIVEN args.
+ */
 export interface ConstructorSlot {
+  /** Index into `abi.constructor.params`. */
   paramIndex: number;
+  /** Byte offset of the 1-byte OP_0 placeholder in the template script. */
   byteOffset: number;
+  /** Constructor parameter name (matches `abi.constructor.params[paramIndex].name`). */
+  name?: string;
+  /** ABI type of the parameter (e.g. `PubKey`, `bigint`, `ByteString`). */
+  type?: string;
+  /**
+   * How the deploy-time value is encoded when spliced into the slot:
+   *  - 'data':      raw data push (push header + value bytes). Fixed-size
+   *                 types (PubKey 33B, Sha256 32B, ...) always take
+   *                 header 1B + value NB; variable-length ByteString
+   *                 header size depends on the value length.
+   *  - 'scriptnum': minimally-encoded Script number. 0 → OP_0 (1 opcode
+   *                 byte), 1..16 → single OP_N opcode byte (0x50+N),
+   *                 -1 → OP_1NEGATE, else 1-byte header + LE
+   *                 sign-magnitude bytes.
+   *  - 'bool':      single opcode byte (OP_TRUE / OP_0).
+   */
+  valueEncoding?: 'data' | 'scriptnum' | 'bool';
+  /** For fixed-size data types only: the baked value length in bytes
+   *  (PubKey 33, Sha256 32, Addr/Ripemd160 20, Point 64). */
+  fixedValueByteLength?: number;
+  /** For fixed-size data types only: the push-header length in bytes that
+   *  precedes the value (1 for all lengths <= 75). */
+  fixedPushHeaderBytes?: number;
 }
 
 export interface CodeSepIndexSlot {
@@ -118,6 +195,46 @@ export interface CodeSepIndexSlot {
   byteOffset: number;
   /** The template-relative codeSeparatorIndex value this placeholder represents */
   codeSepIndex: number;
+}
+
+// ---------------------------------------------------------------------------
+// Template digest (slot-excised script identity)
+// ---------------------------------------------------------------------------
+
+/**
+ * One piece of the slot-excised template identity.
+ *
+ * The resolved code part (template with constructor args spliced in) is
+ * split at every constructor slot's VALUE bytes: `code` pieces are the
+ * byte runs kept in the template (including each slot's push header, whose
+ * presence pins the baked value's length), `slot` pieces are the excised
+ * value bytes. A verifier recomputes the template hash by concatenating
+ * the `code` pieces of a candidate script — using the concrete boundaries
+ * from the SDK's `resolveSlotLayout` — and hashing the result.
+ */
+export interface TemplateDigestPiece {
+  kind: 'code' | 'slot';
+  /** For kind 'slot': the excised slot's constructor param name. */
+  slot?: string;
+  /** For kind 'slot': the slot's TEMPLATE byte offset (disambiguates
+   *  multiple slots baked from the same parameter). */
+  byteOffset?: number;
+}
+
+/**
+ * Recipe for recomputing the contract's slot-excised template hash.
+ *
+ * `hash256-excised-slots`: hash256 (double SHA-256) over the resolved code
+ * part with every constructor slot's VALUE bytes removed. Push headers of
+ * 'data'/'scriptnum' pushes remain in the hashed template; single-opcode
+ * encodings (OP_N / OP_0 / OP_1NEGATE / bool) contribute no header and the
+ * opcode byte itself is excised.
+ */
+export interface TemplateDigest {
+  algorithm: 'hash256-excised-slots';
+  /** Alternating code/slot pieces, in script order (starts and ends with a
+   *  `code` piece; boundary `code` pieces may be empty byte runs). */
+  pieces: TemplateDigestPiece[];
 }
 
 // ---------------------------------------------------------------------------
@@ -195,8 +312,12 @@ export interface RunarArtifact {
   /** State field descriptors (present only for stateful contracts) */
   stateFields?: StateField[];
 
-  /** Byte offsets of constructor parameter placeholders in the script */
+  /** Byte offsets of constructor parameter placeholders in the script,
+   *  enriched with verification-descriptor metadata (name/type/encoding). */
   constructorSlots?: ConstructorSlot[];
+
+  /** Recipe for recomputing the slot-excised template identity hash. */
+  templateDigest?: TemplateDigest;
 
   /** Byte offsets of codeSepIndex placeholders in the script (OP_0 placeholders
    *  that the SDK must replace with the adjusted codeSeparatorIndex). */

--- a/packages/runar-ir-schema/src/index.ts
+++ b/packages/runar-ir-schema/src/index.ts
@@ -98,8 +98,18 @@ export type {
   StateField,
   ConstructorSlot,
   CodeSepIndexSlot,
+  TemplateDigest,
+  TemplateDigestPiece,
   RunarArtifact,
 } from './artifact.js';
+
+// State-tail byte layout (shared width table: compiler + SDK + verifiers)
+export {
+  STATE_FIELD_WIDTHS,
+  annotateStateFieldLayout,
+  totalStateByteLength,
+} from './state-layout.js';
+export type { StateFieldEncoding } from './state-layout.js';
 
 // Validators
 export {

--- a/packages/runar-ir-schema/src/schemas/artifact.schema.json
+++ b/packages/runar-ir-schema/src/schemas/artifact.schema.json
@@ -70,6 +70,10 @@
       "items": { "$ref": "#/$defs/ConstructorSlot" },
       "description": "Byte offsets of constructor parameter placeholders in the script"
     },
+    "templateDigest": {
+      "$ref": "#/$defs/TemplateDigest",
+      "description": "Recipe for recomputing the slot-excised template identity hash"
+    },
     "codeSepIndexSlots": {
       "type": "array",
       "items": { "$ref": "#/$defs/CodeSepIndexSlot" },
@@ -207,7 +211,27 @@
         "type": { "type": "string", "minLength": 1 },
         "index": { "type": "integer", "minimum": 0 },
         "initialValue": { "$ref": "#/$defs/StateFieldInitialValue" },
-        "fixedArray": { "$ref": "#/$defs/FixedArrayInfo" }
+        "fixedArray": { "$ref": "#/$defs/FixedArrayInfo" },
+        "encoding": {
+          "type": "string",
+          "enum": ["num2bin-le8", "bool1", "raw", "pushdata"],
+          "description": "Wire encoding of the serialized field in the OP_RETURN state tail"
+        },
+        "byteOffset": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Byte offset from the byte AFTER the OP_RETURN separator (omitted when a preceding field is variable-length)"
+        },
+        "byteLength": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Serialized length in bytes (omitted for variable-length fields)"
+        },
+        "tailOffset": {
+          "type": "integer",
+          "maximum": -1,
+          "description": "NEGATIVE byte offset from the END of the locking script (omitted when this or any following field is variable-length)"
+        }
       }
     },
     "ConstructorSlot": {
@@ -216,8 +240,64 @@
       "additionalProperties": false,
       "properties": {
         "paramIndex": { "type": "integer", "minimum": 0 },
-        "byteOffset": { "type": "integer", "minimum": 0 }
+        "byteOffset": { "type": "integer", "minimum": 0 },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Constructor parameter name (matches abi.constructor.params[paramIndex].name)"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1,
+          "description": "ABI type of the parameter (e.g. PubKey, bigint, ByteString)"
+        },
+        "valueEncoding": {
+          "type": "string",
+          "enum": ["data", "scriptnum", "bool"],
+          "description": "How the deploy-time value is encoded when spliced into the slot"
+        },
+        "fixedValueByteLength": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "For fixed-size data types only: baked value length in bytes (PubKey 33, Sha256 32, Addr/Ripemd160 20, Point 64)"
+        },
+        "fixedPushHeaderBytes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "For fixed-size data types only: push-header length in bytes preceding the value"
+        }
       }
+    },
+    "TemplateDigestPiece": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "enum": ["code", "slot"] },
+        "slot": {
+          "type": "string",
+          "minLength": 1,
+          "description": "For kind 'slot': the excised slot's constructor param name"
+        },
+        "byteOffset": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "For kind 'slot': the slot's TEMPLATE byte offset"
+        }
+      }
+    },
+    "TemplateDigest": {
+      "type": "object",
+      "required": ["algorithm", "pieces"],
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": { "type": "string", "enum": ["hash256-excised-slots"] },
+        "pieces": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TemplateDigestPiece" }
+        }
+      },
+      "description": "hash256 over the resolved code part with every constructor slot's VALUE bytes removed (push headers stay in the hashed template)"
     },
     "CodeSepIndexSlot": {
       "type": "object",

--- a/packages/runar-ir-schema/src/state-layout.ts
+++ b/packages/runar-ir-schema/src/state-layout.ts
@@ -1,0 +1,140 @@
+/**
+ * State-tail byte layout — the single source of truth for WHERE each
+ * serialized state field lives in a stateful contract's locking script.
+ *
+ * Mirrors the SDK's `serializeState` wire format exactly:
+ *
+ *   <code part> OP_RETURN <field0> <field1> ... <fieldN>
+ *
+ *   - bigint / int : 8 raw bytes, little-endian sign-magnitude (OP_NUM2BIN 8)
+ *   - bool         : 1 raw byte (0x00 / 0x01)
+ *   - PubKey       : 33 raw bytes          - Addr / Ripemd160 : 20 raw bytes
+ *   - Sha256       : 32 raw bytes          - Point            : 64 raw bytes
+ *   - anything else: push-data framed (variable length)
+ *
+ * Fields are concatenated in `StateField.index` order. FixedArray fields
+ * serialize as their flattened leaves back-to-back.
+ *
+ * Lives in runar-ir-schema so the compiler (which annotates `stateFields`
+ * in the artifact), the SDK's state codec, and any verifier tooling share
+ * ONE width table instead of re-deriving it.
+ */
+
+import type { StateField } from './artifact.js';
+
+export type StateFieldEncoding = NonNullable<StateField['encoding']>;
+
+/**
+ * Fixed serialized widths (bytes) for scalar state-field types.
+ * Types absent from this table serialize as push-data framed variable-length
+ * values ('pushdata').
+ */
+export const STATE_FIELD_WIDTHS: Readonly<
+  Record<string, { readonly size: number; readonly encoding: StateFieldEncoding }>
+> = {
+  int: { size: 8, encoding: 'num2bin-le8' },
+  bigint: { size: 8, encoding: 'num2bin-le8' },
+  bool: { size: 1, encoding: 'bool1' },
+  boolean: { size: 1, encoding: 'bool1' },
+  PubKey: { size: 33, encoding: 'raw' },
+  Addr: { size: 20, encoding: 'raw' },
+  Ripemd160: { size: 20, encoding: 'raw' },
+  Sha256: { size: 32, encoding: 'raw' },
+  Point: { size: 64, encoding: 'raw' },
+};
+
+/** Return the innermost scalar type of a (possibly nested) FixedArray string. */
+function unwrapFixedArrayLeaf(type: string): string {
+  let current = type.trim();
+  while (current.startsWith('FixedArray<')) {
+    const inner = current.slice('FixedArray<'.length, -1);
+    let depth = 0;
+    let splitAt = -1;
+    for (let i = inner.length - 1; i >= 0; i--) {
+      const ch = inner[i]!;
+      if (ch === '>') depth++;
+      else if (ch === '<') depth--;
+      else if (ch === ',' && depth === 0) {
+        splitAt = i;
+        break;
+      }
+    }
+    if (splitAt < 0) return current;
+    current = inner.slice(0, splitAt).trim();
+  }
+  return current;
+}
+
+/**
+ * Annotate state fields with their byte layout (`encoding`, `byteOffset`,
+ * `byteLength`, `tailOffset`). Returns NEW field objects (inputs are not
+ * mutated), sorted by `index` — the serialization order.
+ *
+ * `byteOffset` counts from the byte AFTER the OP_RETURN separator and is
+ * present only while every preceding field is fixed-length. `tailOffset` is
+ * a NEGATIVE offset from the END of the locking script and is present only
+ * when the field itself and every following field is fixed-length.
+ */
+export function annotateStateFieldLayout(fields: StateField[]): StateField[] {
+  const sorted = [...fields].sort((a, b) => a.index - b.index);
+
+  const out: StateField[] = sorted.map(field => {
+    const annotated: StateField = { ...field };
+    if (field.fixedArray) {
+      // Flattened leaves serialize back-to-back; fixed only if the leaf is.
+      const leaf = STATE_FIELD_WIDTHS[unwrapFixedArrayLeaf(field.type)];
+      const count = field.fixedArray.syntheticNames.length;
+      if (leaf) {
+        annotated.encoding = leaf.encoding;
+        annotated.byteLength = leaf.size * count;
+      } else {
+        annotated.encoding = 'pushdata';
+      }
+      return annotated;
+    }
+    const fixed = STATE_FIELD_WIDTHS[field.type];
+    if (fixed) {
+      annotated.encoding = fixed.encoding;
+      annotated.byteLength = fixed.size;
+    } else {
+      annotated.encoding = 'pushdata';
+    }
+    return annotated;
+  });
+
+  // Forward pass: byteOffset while all preceding fields are fixed-length.
+  let offset = 0;
+  let frontFixed = true;
+  for (const f of out) {
+    if (frontFixed) f.byteOffset = offset;
+    if (f.byteLength === undefined) {
+      frontFixed = false;
+    } else {
+      offset += f.byteLength;
+    }
+  }
+
+  // Backward pass: tailOffset while the field and all following are fixed.
+  let fromEnd = 0;
+  for (let i = out.length - 1; i >= 0; i--) {
+    const f = out[i]!;
+    if (f.byteLength === undefined) break;
+    fromEnd += f.byteLength;
+    f.tailOffset = -fromEnd;
+  }
+
+  return out;
+}
+
+/**
+ * Total serialized state length in bytes (after the OP_RETURN byte), or
+ * undefined when any field is variable-length.
+ */
+export function totalStateByteLength(fields: StateField[]): number | undefined {
+  let total = 0;
+  for (const f of annotateStateFieldLayout(fields)) {
+    if (f.byteLength === undefined) return undefined;
+    total += f.byteLength;
+  }
+  return total;
+}

--- a/packages/runar-sdk/src/__tests__/multi-contract-call.regtest.test.ts
+++ b/packages/runar-sdk/src/__tests__/multi-contract-call.regtest.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Regtest integration test for `assembleMultiContractCall` — the on-chain
+ * counterpart of multi-contract-call.test.ts.
+ *
+ * Two DIFFERENT artifacts are deployed as real UTXOs and consumed by ONE
+ * spending tx assembled via the new surface:
+ *   input 0: OutputBinder.release (terminal, binds outputs via hashOutputs)
+ *   input 1: BumpToken.bump      (stateful continuation + P2PKH change)
+ *
+ * The real node accepting that tx is the proof; a wrong-owner assembly must be
+ * rejected BY THE NODE. Suite skips gracefully when no regtest node is up.
+ *
+ * Node defaults match integration/regtest.sh (RPC_URL / RPC_USER / RPC_PASS
+ * env overrides supported).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { compile } from 'runar-compiler';
+import { RunarContract } from '../contract.js';
+import { assembleMultiContractCall, dryRunMultiContractInput } from '../multi-contract.js';
+import { RPCProvider } from '../providers/rpc-provider.js';
+import { LocalSigner } from '../signers/local.js';
+import { ExternalSigner } from '../signers/external.js';
+import { Hash, Utils } from '@bsv/sdk';
+import type { RunarArtifact } from 'runar-ir-schema';
+
+// ---------------------------------------------------------------------------
+// Regtest RPC helpers (self-contained)
+// ---------------------------------------------------------------------------
+
+const RPC_URL = process.env.RPC_URL ?? 'http://localhost:18332';
+const RPC_USER = process.env.RPC_USER ?? 'bitcoin';
+const RPC_PASS = process.env.RPC_PASS ?? 'bitcoin';
+
+async function rpcCall(method: string, ...params: unknown[]): Promise<unknown> {
+  const auth = Buffer.from(`${RPC_USER}:${RPC_PASS}`).toString('base64');
+  const response = await fetch(RPC_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Basic ${auth}` },
+    body: JSON.stringify({ jsonrpc: '1.0', id: 'multi-contract', method, params }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const json = (await response.json()) as { result: unknown; error: unknown };
+  if (json.error) {
+    throw new Error(`RPC ${method}: ${(json.error as { message?: string }).message ?? JSON.stringify(json.error)}`);
+  }
+  return json.result;
+}
+
+async function mine(blocks: number): Promise<void> {
+  try {
+    await rpcCall('generate', blocks);
+  } catch {
+    const addr = (await rpcCall('getnewaddress')) as string;
+    await rpcCall('generatetoaddress', blocks, addr);
+  }
+}
+
+async function isNodeAvailable(): Promise<boolean> {
+  try {
+    await rpcCall('getblockcount');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+function base58Encode(buffer: Buffer): string {
+  let num = BigInt('0x' + buffer.toString('hex'));
+  let result = '';
+  while (num > 0n) { result = BASE58[Number(num % 58n)] + result; num /= 58n; }
+  for (const byte of buffer) { if (byte === 0) result = '1' + result; else break; }
+  return result;
+}
+function regtestAddress(pubKeyHash: string): string {
+  const payload = Buffer.concat([Buffer.from([0x6f]), Buffer.from(pubKeyHash, 'hex')]);
+  const h1 = createHash('sha256').update(payload).digest();
+  const h2 = createHash('sha256').update(h1).digest();
+  return base58Encode(Buffer.concat([payload, h2.subarray(0, 4)]));
+}
+
+const hash160hex = (pubKeyHex: string): string =>
+  Utils.toHex(Hash.hash160(Utils.toArray(pubKeyHex, 'hex')));
+const hash256hex = (hex: string): string => {
+  const f = createHash('sha256').update(Buffer.from(hex, 'hex')).digest();
+  return createHash('sha256').update(f).digest('hex');
+};
+const u64le = (n: bigint): string => {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64LE(n);
+  return b.toString('hex');
+};
+const varintHex = (n: number): string => {
+  if (n < 0xfd) return n.toString(16).padStart(2, '0');
+  const b = Buffer.alloc(2);
+  b.writeUInt16LE(n);
+  return 'fd' + b.toString('hex');
+};
+
+interface TestWallet { pubKeyHex: string; local: LocalSigner; signer: ExternalSigner }
+
+async function createFundedWallet(btcAmount = 0.05): Promise<TestWallet> {
+  const local = new LocalSigner(
+    createHash('sha256').update(`multi-contract-${Date.now()}-${Math.random()}`).digest('hex'),
+  );
+  const pubKeyHex = await local.getPublicKey();
+  const address = regtestAddress(hash160hex(pubKeyHex));
+  await rpcCall('importaddress', address, '', false);
+  try {
+    await rpcCall('sendtoaddress', address, btcAmount);
+  } catch {
+    await mine(101);
+    await rpcCall('sendtoaddress', address, btcAmount);
+  }
+  await mine(1);
+  const signer = new ExternalSigner(
+    pubKeyHex, address,
+    async (txHex, inputIndex, subscript, satoshis, sigHashType) =>
+      local.sign(txHex, inputIndex, subscript, satoshis, sigHashType ?? 0x41),
+  );
+  return { pubKeyHex, local, signer };
+}
+
+// ---------------------------------------------------------------------------
+// Contracts — same neutral pair as the unit suite
+// ---------------------------------------------------------------------------
+
+const TOKEN_SOURCE = `
+import { StatefulSmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig } from 'runar-lang';
+
+class BumpToken extends StatefulSmartContract {
+  owner: PubKey;
+  value: bigint;
+
+  constructor(owner: PubKey, value: bigint) {
+    super(owner, value);
+    this.owner = owner;
+    this.value = value;
+  }
+
+  public bump(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.value + 1n);
+  }
+
+  public freeze(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.value);
+  }
+}
+`;
+
+const BINDER_SOURCE = `
+import { StatefulSmartContract, assert, checkSig, hash256, extractOutputHash } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class OutputBinder extends StatefulSmartContract {
+  owner: PubKey;
+
+  constructor(owner: PubKey) {
+    super(owner);
+    this.owner = owner;
+  }
+
+  public release(sig: Sig, expectedOutputs: ByteString) {
+    assert(checkSig(sig, this.owner));
+    assert(hash256(expectedOutputs) === extractOutputHash(this.txPreimage));
+  }
+}
+`;
+
+function compileSource(source: string, fileName: string): RunarArtifact {
+  const result = compile(source, { fileName });
+  if (!result.artifact) {
+    throw new Error(`compile failed for ${fileName}: ${JSON.stringify(result.diagnostics)}`);
+  }
+  return result.artifact;
+}
+
+const tokenArtifact = compileSource(TOKEN_SOURCE, 'BumpToken.runar.ts');
+const binderArtifact = compileSource(BINDER_SOURCE, 'OutputBinder.runar.ts');
+
+const nodeUp = await isNodeAvailable();
+
+// ---------------------------------------------------------------------------
+// Shared assembly for both cases
+// ---------------------------------------------------------------------------
+
+async function deployPairAndAssemble(wallet: TestWallet, sigWallet: TestWallet) {
+  const provider = new RPCProvider(RPC_URL, RPC_USER, RPC_PASS, { autoMine: true, network: 'testnet' });
+
+  const token = new RunarContract(tokenArtifact, [wallet.pubKeyHex, 5n]);
+  await token.deploy(provider, wallet.signer, { satoshis: 3000 });
+  const binder = new RunarContract(binderArtifact, [wallet.pubKeyHex]);
+  await binder.deploy(provider, wallet.signer, { satoshis: 3000 });
+
+  const tokenNext = new RunarContract(tokenArtifact, [wallet.pubKeyHex, 5n]);
+  tokenNext.setState({ owner: wallet.pubKeyHex, value: 6n });
+  const contScript = tokenNext.getLockingScript();
+  const changePKH = hash160hex(wallet.pubKeyHex);
+  const changeScript = '76a914' + changePKH + '88ac';
+  const outputs = [
+    { satoshis: 1500, script: contScript },
+    { satoshis: 1000, script: changeScript },
+  ];
+  const expectedOutputs =
+    u64le(1500n) + varintHex(contScript.length / 2) + contScript +
+    u64le(1000n) + varintHex(changeScript.length / 2) + changeScript;
+
+  const assembled = await assembleMultiContractCall(
+    [
+      {
+        contract: binder, method: 'release',
+        args: [null, expectedOutputs], signer: sigWallet.local,
+      },
+      {
+        contract: token, method: 'bump',
+        args: [null, 1500n], signer: sigWallet.local,
+        changePKH, changeAmount: 1000n,
+      },
+    ],
+    outputs,
+    { dryRun: false }, // validated explicitly per-case below
+  );
+  return { assembled, token, binder };
+}
+
+// ---------------------------------------------------------------------------
+// The suite
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!nodeUp)('assembleMultiContractCall — regtest integration', () => {
+  it('ACCEPT: a tx with two different-artifact covenant inputs is accepted and confirmed', async () => {
+    const wallet = await createFundedWallet();
+    const { assembled, token, binder } = await deployPairAndAssemble(wallet, wallet);
+
+    // Offline gate first (ladder discipline: local-before-chain).
+    const bU = binder.getUtxo()!;
+    const tU = token.getUtxo()!;
+    expect(dryRunMultiContractInput(assembled.txHex, 0, bU.script, bU.satoshis).valid).toBe(true);
+    expect(dryRunMultiContractInput(assembled.txHex, 1, tU.script, tU.satoshis).valid).toBe(true);
+
+    const txid = (await rpcCall('sendrawtransaction', assembled.txHex)) as string;
+    expect(txid).toMatch(/^[0-9a-f]{64}$/);
+    expect(txid).toBe(hash256hex(assembled.txHex).match(/.{2}/g)!.reverse().join(''));
+
+    await mine(1);
+    const verbose = (await rpcCall('getrawtransaction', txid, true)) as { confirmations?: number };
+    expect(verbose.confirmations ?? 0).toBeGreaterThanOrEqual(1);
+  }, 120_000);
+
+  it('REJECT: the same assembly signed by a non-owner is rejected by the node', async () => {
+    const wallet = await createFundedWallet();
+    const stranger = await createFundedWallet(0.01);
+    const { assembled } = await deployPairAndAssemble(wallet, stranger);
+
+    let rejection = '';
+    try {
+      await rpcCall('sendrawtransaction', assembled.txHex);
+    } catch (e) {
+      rejection = e instanceof Error ? e.message : String(e);
+    }
+    expect(rejection).toMatch(/mandatory-script-verify-flag-failed|Script failed|non-mandatory/i);
+  }, 120_000);
+});
+
+if (!nodeUp) {
+  console.warn(`[multi-contract regtest] node not reachable at ${RPC_URL} — suite skipped`);
+}

--- a/packages/runar-sdk/src/__tests__/multi-contract-call.test.ts
+++ b/packages/runar-sdk/src/__tests__/multi-contract-call.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for `assembleMultiContractCall` — cross-artifact tx assembly.
+ *
+ * Two DIFFERENT artifacts compose one spending tx:
+ *   input 0: OutputBinder.release  (terminal — binds the output set via hashOutputs)
+ *   input 1: BumpToken.bump        (stateful continuation + P2PKH change)
+ *
+ * Both unlocks are validated through @bsv/sdk's production Spend interpreter
+ * (real ECDSA, real BIP-143) — no regtest node needed. The companion regtest
+ * suite (multi-contract-call.regtest.test.ts) broadcasts the same shape.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from 'runar-compiler';
+import { RunarContract, encodePushData } from '../contract.js';
+import {
+  assembleMultiContractCall,
+  dryRunMultiContractInput,
+} from '../multi-contract.js';
+import { LocalSigner } from '../signers/local.js';
+import { Hash, Utils } from '@bsv/sdk';
+import type { RunarArtifact } from 'runar-ir-schema';
+
+// ---------------------------------------------------------------------------
+// Contracts (inline, neutral)
+// ---------------------------------------------------------------------------
+
+const TOKEN_SOURCE = `
+import { StatefulSmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig } from 'runar-lang';
+
+class BumpToken extends StatefulSmartContract {
+  owner: PubKey;
+  value: bigint;
+
+  constructor(owner: PubKey, value: bigint) {
+    super(owner, value);
+    this.owner = owner;
+    this.value = value;
+  }
+
+  public bump(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.value + 1n);
+  }
+
+  public freeze(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.value);
+  }
+}
+`;
+
+const BINDER_SOURCE = `
+import { StatefulSmartContract, assert, checkSig, hash256, extractOutputHash } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class OutputBinder extends StatefulSmartContract {
+  owner: PubKey;
+
+  constructor(owner: PubKey) {
+    super(owner);
+    this.owner = owner;
+  }
+
+  public release(sig: Sig, expectedOutputs: ByteString) {
+    assert(checkSig(sig, this.owner));
+    assert(hash256(expectedOutputs) === extractOutputHash(this.txPreimage));
+  }
+}
+`;
+
+function compileSource(source: string, fileName: string): RunarArtifact {
+  const result = compile(source, { fileName });
+  if (!result.artifact) {
+    throw new Error(`compile failed for ${fileName}: ${JSON.stringify(result.diagnostics)}`);
+  }
+  return result.artifact;
+}
+
+const tokenArtifact = compileSource(TOKEN_SOURCE, 'BumpToken.runar.ts');
+const binderArtifact = compileSource(BINDER_SOURCE, 'OutputBinder.runar.ts');
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const OWNER_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
+const WRONG_KEY = '0000000000000000000000000000000000000000000000000000000000000002';
+
+const ownerSigner = new LocalSigner(OWNER_KEY);
+const wrongSigner = new LocalSigner(WRONG_KEY);
+const ownerPub = await ownerSigner.getPublicKey();
+
+const hash160hex = (pubKeyHex: string): string =>
+  Utils.toHex(Hash.hash160(Utils.toArray(pubKeyHex, 'hex')));
+const u64le = (n: bigint): string => {
+  const b = new DataView(new ArrayBuffer(8));
+  b.setBigUint64(0, n, true);
+  return Utils.toHex(Array.from(new Uint8Array(b.buffer)));
+};
+
+const changePKH = hash160hex(ownerPub);
+const changeScript = '76a914' + changePKH + '88ac';
+
+interface Fixture {
+  token: RunarContract;
+  binder: RunarContract;
+  tokenUtxo: { txid: string; outputIndex: number; satoshis: number; script: string };
+  binderUtxo: { txid: string; outputIndex: number; satoshis: number; script: string };
+  contScript: string;
+  outputs: Array<{ satoshis: number; script: string }>;
+  expectedOutputs: string;
+}
+
+function makeFixture(): Fixture {
+  const token = new RunarContract(tokenArtifact, [ownerPub, 5n]);
+  const binder = new RunarContract(binderArtifact, [ownerPub]);
+  const tokenScript = token.getLockingScript();
+  const binderScript = binder.getLockingScript();
+  const tokenUtxo = { txid: 'aa'.repeat(32), outputIndex: 0, satoshis: 5000, script: tokenScript };
+  const binderUtxo = { txid: 'bb'.repeat(32), outputIndex: 0, satoshis: 6000, script: binderScript };
+
+  // bump continuation: value 5n -> 6n, 2000 sats; plus the unconditional P2PKH change (1000 sats).
+  const tokenNext = new RunarContract(tokenArtifact, [ownerPub, 5n]);
+  tokenNext.setState({ owner: ownerPub, value: 6n });
+  const contScript = tokenNext.getLockingScript();
+  const outputs = [
+    { satoshis: 2000, script: contScript },
+    { satoshis: 1000, script: changeScript },
+  ];
+  const varint1 = (n: number): string => n.toString(16).padStart(2, '0'); // scripts here < 0xfd? cont may exceed
+  const varintHex = (n: number): string => {
+    if (n < 0xfd) return varint1(n);
+    const lo = (n & 0xff).toString(16).padStart(2, '0');
+    const hi = ((n >> 8) & 0xff).toString(16).padStart(2, '0');
+    return 'fd' + lo + hi;
+  };
+  const expectedOutputs =
+    u64le(2000n) + varintHex(contScript.length / 2) + contScript +
+    u64le(1000n) + varintHex(changeScript.length / 2) + changeScript;
+  return { token, binder, tokenUtxo, binderUtxo, contScript, outputs, expectedOutputs };
+}
+
+function inputsFor(f: Fixture, opts: { signer0?: LocalSigner; signer1?: LocalSigner } = {}) {
+  return [
+    {
+      contract: f.binder,
+      method: 'release',
+      args: [null, f.expectedOutputs],
+      utxo: f.binderUtxo,
+      signer: opts.signer0 ?? ownerSigner,
+    },
+    {
+      contract: f.token,
+      method: 'bump',
+      args: [null, 2000n],
+      utxo: f.tokenUtxo,
+      signer: opts.signer1 ?? ownerSigner,
+      changePKH,
+      changeAmount: 1000n,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('assembleMultiContractCall — two different artifacts in one tx', () => {
+  it('assembles a tx whose EVERY covenant input passes the Spend interpreter', async () => {
+    const f = makeFixture();
+    const assembled = await assembleMultiContractCall(inputsFor(f), f.outputs);
+
+    // dryRun defaults to true, so reaching here means both inputs validated.
+    // Re-validate explicitly through the exported helper anyway.
+    const r0 = dryRunMultiContractInput(assembled.txHex, 0, f.binderUtxo.script, f.binderUtxo.satoshis);
+    expect(r0.error).toBeUndefined();
+    expect(r0.valid).toBe(true);
+    const r1 = dryRunMultiContractInput(assembled.txHex, 1, f.tokenUtxo.script, f.tokenUtxo.satoshis);
+    expect(r1.error).toBeUndefined();
+    expect(r1.valid).toBe(true);
+
+    expect(assembled.tx.inputs.length).toBe(2);
+    expect(assembled.tx.outputs.length).toBe(2);
+    expect(assembled.unlocks.length).toBe(2);
+    expect(assembled.preimages.length).toBe(2);
+  });
+
+  it('unlock layout: continuation input is prefixed with _codePart and suffixed with its method selector', async () => {
+    const f = makeFixture();
+    const assembled = await assembleMultiContractCall(inputsFor(f), f.outputs);
+
+    // input 1 (BumpToken.bump, method index 0 of 2 public methods):
+    // [_codePart] [_opPushTxSig] [sig] [outputSatoshis] [_changePKH] [_changeAmount] [preimage] [selector=OP_0]
+    const codePartPush = encodePushData(f.token.getCodePartHex());
+    expect(assembled.unlocks[1]!.startsWith(codePartPush)).toBe(true);
+    expect(assembled.unlocks[1]!.endsWith(encodePushData(assembled.preimages[1]!) + '00')).toBe(true);
+
+    // input 0 (OutputBinder.release, single public method): no codePart, no selector;
+    // the unlock ends with the raw preimage push.
+    expect(assembled.unlocks[0]!.startsWith(codePartPush)).toBe(false);
+    expect(assembled.unlocks[0]!.endsWith(encodePushData(assembled.preimages[0]!))).toBe(true);
+  });
+
+  it('each input signature commits to ITS OWN input slot (swapped unlocks fail both inputs)', async () => {
+    const f = makeFixture();
+    const assembled = await assembleMultiContractCall(inputsFor(f), f.outputs);
+    // The two preimages must differ (different outpoints, different scriptCode).
+    expect(assembled.preimages[0]).not.toBe(assembled.preimages[1]);
+
+    // Rebuild the SAME tx shape fresh (never mutate a serialized Transaction —
+    // @bsv/sdk caches hex) with the two unlocking scripts swapped.
+    const { Transaction, UnlockingScript, LockingScript } = await import('@bsv/sdk');
+    const swapped = new Transaction();
+    swapped.addInput({
+      sourceTXID: f.binderUtxo.txid, sourceOutputIndex: f.binderUtxo.outputIndex,
+      unlockingScript: UnlockingScript.fromHex(assembled.unlocks[1]!), sequence: 0xffffffff,
+    });
+    swapped.addInput({
+      sourceTXID: f.tokenUtxo.txid, sourceOutputIndex: f.tokenUtxo.outputIndex,
+      unlockingScript: UnlockingScript.fromHex(assembled.unlocks[0]!), sequence: 0xffffffff,
+    });
+    for (const out of f.outputs) {
+      swapped.addOutput({ satoshis: out.satoshis, lockingScript: LockingScript.fromHex(out.script) });
+    }
+    const swappedHex = swapped.toHex();
+    expect(dryRunMultiContractInput(swappedHex, 0, f.binderUtxo.script, f.binderUtxo.satoshis).valid).toBe(false);
+    expect(dryRunMultiContractInput(swappedHex, 1, f.tokenUtxo.script, f.tokenUtxo.satoshis).valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The dryRun gate
+// ---------------------------------------------------------------------------
+
+describe('assembleMultiContractCall — dryRun gate', () => {
+  it('THROWS (and never returns a broadcastable hex) when a covenant input cannot validate', async () => {
+    const f = makeFixture();
+    // Wrong owner key signs the binder input -> checkSig fails offline.
+    await expect(
+      assembleMultiContractCall(inputsFor(f, { signer0: wrongSigner }), f.outputs),
+    ).rejects.toThrow(/offline validation FAILED for input 0/);
+  });
+
+  it('dryRun:false returns the (invalid) assembly for inspection', async () => {
+    const f = makeFixture();
+    const assembled = await assembleMultiContractCall(
+      inputsFor(f, { signer1: wrongSigner }), f.outputs, { dryRun: false },
+    );
+    const r1 = dryRunMultiContractInput(assembled.txHex, 1, f.tokenUtxo.script, f.tokenUtxo.satoshis);
+    expect(r1.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths
+// ---------------------------------------------------------------------------
+
+describe('assembleMultiContractCall — argument validation', () => {
+  it('rejects an unknown method', async () => {
+    const f = makeFixture();
+    const inputs = inputsFor(f);
+    inputs[0] = { ...inputs[0]!, method: 'nope' };
+    await expect(assembleMultiContractCall(inputs, f.outputs)).rejects.toThrow(/'nope' not found/);
+  });
+
+  it('rejects a user-arg count mismatch', async () => {
+    const f = makeFixture();
+    const inputs = inputsFor(f);
+    inputs[1] = { ...inputs[1]!, args: [null] }; // bump expects (sig, outputSatoshis)
+    await expect(assembleMultiContractCall(inputs, f.outputs)).rejects.toThrow(/expects 2 args, got 1/);
+  });
+
+  it('rejects a missing UTXO', async () => {
+    const f = makeFixture();
+    const inputs = inputsFor(f);
+    inputs[0] = { ...inputs[0]!, utxo: undefined }; // binder never deployed/connected
+    await expect(assembleMultiContractCall(inputs, f.outputs)).rejects.toThrow(/has no UTXO/);
+  });
+
+  it('rejects a null Sig arg without a signer', async () => {
+    const f = makeFixture();
+    const inputs = inputsFor(f);
+    inputs[0] = { ...inputs[0]!, signer: undefined };
+    await expect(assembleMultiContractCall(inputs, f.outputs)).rejects.toThrow(/no `signer`/);
+  });
+
+  it('rejects a continuation method without changePKH (ABI declares _changePKH)', async () => {
+    const f = makeFixture();
+    const inputs = inputsFor(f);
+    inputs[1] = { ...inputs[1]!, changePKH: undefined };
+    await expect(assembleMultiContractCall(inputs, f.outputs)).rejects.toThrow(/requires `changePKH`/);
+  });
+
+  it('rejects empty inputs / outputs', async () => {
+    const f = makeFixture();
+    await expect(assembleMultiContractCall([], f.outputs)).rejects.toThrow(/at least one input/);
+    await expect(assembleMultiContractCall(inputsFor(f), [])).rejects.toThrow(/at least one output/);
+  });
+});

--- a/packages/runar-sdk/src/__tests__/slot-layout.test.ts
+++ b/packages/runar-sdk/src/__tests__/slot-layout.test.ts
@@ -1,0 +1,271 @@
+/**
+ * resolveSlotLayout / computeTemplateHash / resolveStateLayout — the
+ * value-dependent half of the artifact's verification descriptors.
+ *
+ * PARITY ORACLE: the EAC companion-input verification work derived every
+ * constant by hand from compiled bytes — issuer offset via `indexOf` on the
+ * code part, source offset via diffing two bakes, the template hash via a
+ * 3-piece excise-and-concat. A mini version of that derivation is ported
+ * here as the oracle: the descriptor APIs must reproduce EXACTLY the same
+ * values, or they are useless as a replacement.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { compile } from 'runar-compiler';
+import { RunarContract } from '../contract.js';
+import {
+  resolveSlotLayout,
+  computeTemplateHash,
+  buildResolvedCodeHex,
+  resolveStateLayout,
+} from '../slot-layout.js';
+import { serializeState } from '../state.js';
+
+// ---------------------------------------------------------------------------
+// Contract under test: the EAC shape (stateful token, readonly PubKey issuer
+// anchored via checkSig, readonly bigint source anchored via an assert)
+// ---------------------------------------------------------------------------
+
+const EAC_SHAPED_SOURCE = `
+import { StatefulSmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class EacShaped extends StatefulSmartContract {
+  owner: PubKey;
+  quantityWh: bigint;
+  status: bigint;
+
+  readonly issuer: PubKey;
+  readonly source: bigint;
+  readonly tokenId: ByteString;
+
+  constructor(
+    owner: PubKey,
+    quantityWh: bigint,
+    status: bigint,
+    issuer: PubKey,
+    source: bigint,
+    tokenId: ByteString,
+  ) {
+    super(owner, quantityWh, status, issuer, source, tokenId);
+    this.owner = owner;
+    this.quantityWh = quantityWh;
+    this.status = status;
+    this.issuer = issuer;
+    this.source = source;
+    this.tokenId = tokenId;
+  }
+
+  public retire(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(this.status === 1n);
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.quantityWh, 3n);
+  }
+
+  public withdraw(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.issuer));
+    assert(this.source >= 1n);
+    assert(this.status === 1n);
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.quantityWh, 4n);
+  }
+}
+`;
+
+const compiled = compile(EAC_SHAPED_SOURCE, { fileName: 'EacShaped.runar.ts' });
+if (!compiled.artifact) {
+  throw new Error('compile failed: ' + JSON.stringify(compiled.diagnostics));
+}
+const artifact = compiled.artifact;
+
+const OWNER = '02' + '11'.repeat(32);
+const ISSUER = '03' + 'ab'.repeat(32);
+
+/** ctor args: [owner, quantityWh, status, issuer, source, tokenId] */
+const argsWithSource = (source: bigint): unknown[] =>
+  [OWNER, 10n, 1n, ISSUER, source, 'deadbeef'];
+const ARGS = argsWithSource(1n);
+
+const hash256hex = (hex: string): string => {
+  const first = createHash('sha256').update(Buffer.from(hex, 'hex')).digest();
+  return createHash('sha256').update(first).digest('hex');
+};
+
+const codePartHex = (args: unknown[]): string => {
+  const c = new RunarContract(artifact, args);
+  return (c as unknown as { getCodePartHex(): string }).getCodePartHex().toLowerCase();
+};
+
+// ---------------------------------------------------------------------------
+// THE ORACLE: hand-derivation exactly as the companion-input verification
+// tests do it today (indexOf + two-bake diff + 3-piece excise).
+// ---------------------------------------------------------------------------
+
+function oracleDerivation() {
+  const code = codePartHex(ARGS);
+
+  let idx = code.indexOf(ISSUER);
+  while (idx >= 0 && idx % 2 !== 0) idx = code.indexOf(ISSUER, idx + 1);
+  if (idx < 0) throw new Error('issuer pubkey not found in code part');
+  const issuerOffset = idx / 2;
+
+  // Diff two bakes that differ only in source (both 1..16 → single OP_N byte)
+  const code2 = codePartHex(argsWithSource(2n));
+  if (code.length !== code2.length) throw new Error('source bake changed code length');
+  const diffs: number[] = [];
+  for (let i = 0; i < code.length; i += 2) {
+    if (code.slice(i, i + 2) !== code2.slice(i, i + 2)) diffs.push(i / 2);
+  }
+  if (diffs.length !== 1) throw new Error(`expected 1 differing byte, got ${diffs.length}`);
+  const sourceOffset = diffs[0]!;
+  if (code.slice(sourceOffset * 2, sourceOffset * 2 + 2) !== '51') {
+    throw new Error('source slot is not baked as OP_N');
+  }
+
+  const codeLen = code.length / 2;
+  const codePostLen = codeLen - sourceOffset - 1;
+  const template =
+    code.slice(0, issuerOffset * 2) +
+    code.slice((issuerOffset + 33) * 2, sourceOffset * 2) +
+    code.slice((sourceOffset + 1) * 2);
+  return { code, issuerOffset, sourceOffset, codeLen, codePostLen, codeHash: hash256hex(template) };
+}
+
+const oracle = oracleDerivation();
+
+// ---------------------------------------------------------------------------
+// Parity: descriptor APIs must reproduce the oracle exactly
+// ---------------------------------------------------------------------------
+
+describe('resolveSlotLayout parity with the indexOf oracle', () => {
+  const layout = resolveSlotLayout(artifact, ARGS);
+  const issuer = layout.slots.find(s => s.name === 'issuer')!;
+  const source = layout.slots.find(s => s.name === 'source')!;
+
+  it('issuer slot: data-push, header 1, value at the oracle offset, 33 bytes', () => {
+    expect(issuer.encoding).toBe('data-push');
+    expect(issuer.pushHeaderBytes).toBe(1);
+    expect(issuer.valueByteOffset).toBe(oracle.issuerOffset);
+    expect(issuer.valueByteLength).toBe(33);
+    expect(issuer.byteOffset).toBe(oracle.issuerOffset - 1); // the 0x21 push header
+    expect(issuer.byteLength).toBe(34);
+  });
+
+  it('source slot: single OP_N opcode byte at the oracle offset', () => {
+    expect(source.encoding).toBe('op-n');
+    expect(source.pushHeaderBytes).toBe(0);
+    expect(source.byteOffset).toBe(oracle.sourceOffset);
+    expect(source.byteLength).toBe(1);
+    expect(source.valueByteOffset).toBe(oracle.sourceOffset);
+    expect(source.valueByteLength).toBe(1);
+  });
+
+  it('slot order and derived constants match (source after issuer + 33)', () => {
+    expect(source.byteOffset).toBeGreaterThan(issuer.valueByteOffset + 33);
+    expect(layout.codeByteLength).toBe(oracle.codeLen);
+    // codePostLen exactly as the consuming covenant computes it
+    expect(layout.codeByteLength - source.byteOffset - 1).toBe(oracle.codePostLen);
+  });
+
+  it('buildResolvedCodeHex is byte-identical to RunarContract.getCodePartHex()', () => {
+    expect(buildResolvedCodeHex(artifact, ARGS).toLowerCase()).toBe(oracle.code);
+  });
+
+  it('extracted slot bytes are the baked values', () => {
+    expect(oracle.code.slice(issuer.valueByteOffset * 2, (issuer.valueByteOffset + 33) * 2))
+      .toBe(ISSUER);
+    // OP_N rule: opcode byte = 0x50 + source
+    expect(oracle.code.slice(source.byteOffset * 2, source.byteOffset * 2 + 2)).toBe('51');
+  });
+});
+
+describe('computeTemplateHash parity', () => {
+  it('reproduces the oracle template hash exactly', () => {
+    expect(computeTemplateHash(artifact, ARGS)).toBe(oracle.codeHash);
+  });
+
+  it('is invariant across baked slot VALUES of the same width class', () => {
+    // Different issuer + different 1..16 source → same excised template
+    const otherArgs = ['02' + '22'.repeat(32), 999n, 3n, '02' + 'cd'.repeat(32), 7n, 'beef'];
+    expect(computeTemplateHash(artifact, otherArgs)).toBe(oracle.codeHash);
+  });
+
+  it('differs when a scriptnum slot changes width class (>= 17 bakes as 2 bytes)', () => {
+    // The push header (0x01) stays in the template, so the identity changes —
+    // exactly the offset-shifting trap the OP_N (1..16) constraint avoids.
+    expect(computeTemplateHash(artifact, argsWithSource(17n))).not.toBe(oracle.codeHash);
+  });
+});
+
+describe('the OP_N / OP_0 / multi-byte encoding boundaries (iteration-010 trap)', () => {
+  it('source = 16n is still a single OP_16 opcode', () => {
+    const s = resolveSlotLayout(artifact, argsWithSource(16n)).slots.find(x => x.name === 'source')!;
+    expect(s.encoding).toBe('op-n');
+    expect(s.byteLength).toBe(1);
+    const code = codePartHex(argsWithSource(16n));
+    expect(code.slice(s.byteOffset * 2, s.byteOffset * 2 + 2)).toBe('60'); // OP_16
+  });
+
+  it('source = 17n becomes a 2-byte scriptnum push and shifts the code length', () => {
+    const layout = resolveSlotLayout(artifact, argsWithSource(17n));
+    const s = layout.slots.find(x => x.name === 'source')!;
+    expect(s.encoding).toBe('scriptnum-push');
+    expect(s.pushHeaderBytes).toBe(1);
+    expect(s.valueByteLength).toBe(1);
+    expect(s.byteLength).toBe(2);
+    expect(layout.codeByteLength).toBe(oracle.codeLen + 1);
+    // parity against the real bake
+    const code = codePartHex(argsWithSource(17n));
+    expect(code.length / 2).toBe(layout.codeByteLength);
+    expect(code.slice(s.byteOffset * 2, (s.byteOffset + 2) * 2)).toBe('0111'); // push1 0x11
+  });
+
+  it('source = 0n bakes as OP_0 — flagged as the placeholder-lookalike it is', () => {
+    const s = resolveSlotLayout(artifact, argsWithSource(0n)).slots.find(x => x.name === 'source')!;
+    expect(s.encoding).toBe('op-0');
+    expect(s.byteLength).toBe(1);
+  });
+});
+
+describe('resolveStateLayout', () => {
+  const layout = resolveStateLayout(artifact);
+
+  it('lays out owner/quantityWh/status per serializeState', () => {
+    expect(layout.fields.map(f => f.name)).toEqual(['owner', 'quantityWh', 'status']);
+    expect(layout.fields[0]).toMatchObject({ encoding: 'raw', byteOffset: 0, byteLength: 33, tailOffset: -49 });
+    expect(layout.fields[1]).toMatchObject({ encoding: 'num2bin-le8', byteOffset: 33, byteLength: 8, tailOffset: -16 });
+    expect(layout.fields[2]).toMatchObject({ encoding: 'num2bin-le8', byteOffset: 41, byteLength: 8, tailOffset: -8 });
+    expect(layout.totalByteLength).toBe(49);
+  });
+
+  it('offsets slice the REAL serialized state and locking script correctly', () => {
+    const state = { owner: OWNER, quantityWh: 10n, status: 3n };
+    const stateHex = serializeState(artifact.stateFields!, state);
+    expect(stateHex.length / 2).toBe(layout.totalByteLength);
+
+    const c = new RunarContract(artifact, ARGS);
+    (c as unknown as { setState(s: Record<string, unknown>): void }).setState(state);
+    const script = (c.getLockingScript() as string).toLowerCase();
+    const scriptLen = script.length / 2;
+
+    // tail offsets are from the END of the locking script
+    const owner = layout.fields[0]!;
+    expect(script.slice((scriptLen + owner.tailOffset!) * 2, (scriptLen + owner.tailOffset! + owner.byteLength!) * 2))
+      .toBe(OWNER);
+    const status = layout.fields[2]!;
+    expect(script.slice((scriptLen + status.tailOffset!) * 2))
+      .toBe('0300000000000000'); // 3n as NUM2BIN-8 LE
+  });
+
+  it('works on artifacts that predate the layout annotation (fallback path)', () => {
+    const bare = {
+      ...artifact,
+      stateFields: artifact.stateFields!.map(f => ({ name: f.name, type: f.type, index: f.index })),
+    };
+    const fallback = resolveStateLayout(bare);
+    expect(fallback.fields[1]).toMatchObject({ encoding: 'num2bin-le8', byteOffset: 33, tailOffset: -16 });
+    expect(fallback.totalByteLength).toBe(49);
+  });
+});

--- a/packages/runar-sdk/src/__tests__/slot-layout.test.ts
+++ b/packages/runar-sdk/src/__tests__/slot-layout.test.ts
@@ -229,6 +229,136 @@ describe('the OP_N / OP_0 / multi-byte encoding boundaries (iteration-010 trap)'
   });
 });
 
+// ---------------------------------------------------------------------------
+// Descriptor hardening: the anchor points (byteOffset / paramIndex / name)
+// are trusted verbatim from the artifact JSON. A corrupted or mismatched
+// descriptor must fail loudly instead of being spliced over silently.
+// ---------------------------------------------------------------------------
+
+/** Stateful contract with a variable-length state field → codeSepIndexSlots. */
+const VARLEN_STATE_SOURCE = `
+import { StatefulSmartContract, assert, checkSig } from 'runar-lang';
+import type { PubKey, Sig, ByteString } from 'runar-lang';
+
+class VarState extends StatefulSmartContract {
+  owner: PubKey;
+  memo: ByteString;
+
+  readonly issuer: PubKey;
+  readonly bound: bigint;
+
+  constructor(owner: PubKey, memo: ByteString, issuer: PubKey, bound: bigint) {
+    super(owner, memo, issuer, bound);
+    this.owner = owner;
+    this.memo = memo;
+    this.issuer = issuer;
+    this.bound = bound;
+  }
+
+  public update(sig: Sig, newMemo: ByteString, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(this.bound >= 1n);
+    assert(outputSatoshis >= 1n);
+    this.memo = newMemo;
+    this.addOutput(outputSatoshis, this.owner, this.memo);
+  }
+
+  public reclaim(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.issuer));
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.memo);
+  }
+}
+`;
+
+const varlenCompiled = compile(VARLEN_STATE_SOURCE, { fileName: 'VarState.runar.ts' });
+if (!varlenCompiled.artifact) {
+  throw new Error('varlen compile failed: ' + JSON.stringify(varlenCompiled.diagnostics));
+}
+const varlenArtifact = varlenCompiled.artifact;
+/** ctor args: [owner, memo, issuer, bound] */
+const VARLEN_ARGS: unknown[] = [OWNER, 'aabbcc', ISSUER, 5n];
+
+/** Corrupt the 1-byte placeholder at `byteOffset` in a cloned artifact. */
+function withCorruptedByte(a: typeof artifact, byteOffset: number): typeof artifact {
+  const s = a.script;
+  return {
+    ...a,
+    script: s.slice(0, byteOffset * 2) + 'ee' + s.slice(byteOffset * 2 + 2),
+  };
+}
+
+describe('descriptor hardening asserts', () => {
+  it('sanity: the varlen fixture actually carries codeSepIndexSlots', () => {
+    expect(varlenArtifact.codeSepIndexSlots!.length).toBeGreaterThanOrEqual(1);
+    expect(varlenArtifact.constructorSlots!.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('throws when a constructor slot byteOffset does not point at an OP_0 placeholder', () => {
+    const slot = artifact.constructorSlots![0]!;
+    const corrupted = withCorruptedByte(artifact, slot.byteOffset);
+    expect(() => resolveSlotLayout(corrupted, ARGS)).toThrow(/OP_0 placeholder/);
+    expect(() => buildResolvedCodeHex(corrupted, ARGS)).toThrow(/OP_0 placeholder/);
+    expect(() => computeTemplateHash(corrupted, ARGS)).toThrow(/OP_0 placeholder/);
+  });
+
+  it('throws when a constructor slot byteOffset points past the end of the script', () => {
+    const bad = {
+      ...artifact,
+      constructorSlots: artifact.constructorSlots!.map((s, i) =>
+        i === 0 ? { ...s, byteOffset: artifact.script.length / 2 + 10 } : s,
+      ),
+    };
+    expect(() => resolveSlotLayout(bad, ARGS)).toThrow(/end-of-script/);
+  });
+
+  it('throws when an enriched slot name does not match the ABI param at its paramIndex', () => {
+    // Swap the two slots' names — offsets stay valid, so only the
+    // name/paramIndex correspondence check can catch this.
+    const [a, b] = artifact.constructorSlots!;
+    const swapped = {
+      ...artifact,
+      constructorSlots: [
+        { ...a!, name: b!.name },
+        { ...b!, name: a!.name },
+      ],
+    };
+    expect(() => resolveSlotLayout(swapped, ARGS)).toThrow(/named .* but abi\.constructor\.params/);
+    expect(() => computeTemplateHash(swapped, ARGS)).toThrow(/named .* but abi\.constructor\.params/);
+  });
+
+  it('accepts un-enriched slots (no name) — pre-descriptor artifacts still resolve', () => {
+    const bare = {
+      ...artifact,
+      constructorSlots: artifact.constructorSlots!.map(s => ({
+        paramIndex: s.paramIndex,
+        byteOffset: s.byteOffset,
+      })),
+    };
+    expect(buildResolvedCodeHex(bare, ARGS).toLowerCase()).toBe(oracle.code);
+  });
+
+  it('throws when a codeSepIndex slot byteOffset does not point at an OP_0 placeholder', () => {
+    const slot = varlenArtifact.codeSepIndexSlots![0]!;
+    const corrupted = withCorruptedByte(varlenArtifact, slot.byteOffset);
+    expect(() => buildResolvedCodeHex(corrupted, VARLEN_ARGS)).toThrow(
+      /codeSepIndex slot .*OP_0 placeholder/,
+    );
+  });
+
+  it('parity on a codeSepIndexSlots artifact: buildResolvedCodeHex === getCodePartHex', () => {
+    const c = new RunarContract(varlenArtifact, VARLEN_ARGS);
+    const expected = (c as unknown as { getCodePartHex(): string })
+      .getCodePartHex()
+      .toLowerCase();
+    expect(buildResolvedCodeHex(varlenArtifact, VARLEN_ARGS).toLowerCase()).toBe(expected);
+    // and the codeSep placeholders are actually gone
+    for (const cs of varlenArtifact.codeSepIndexSlots!) {
+      expect(varlenArtifact.script.slice(cs.byteOffset * 2, cs.byteOffset * 2 + 2)).toBe('00');
+    }
+  });
+});
+
 describe('resolveStateLayout', () => {
   const layout = resolveStateLayout(artifact);
 

--- a/packages/runar-sdk/src/contract.ts
+++ b/packages/runar-sdk/src/contract.ts
@@ -1492,8 +1492,13 @@ export class RunarContract {
    * Includes the inscription envelope if one is attached — this is required for
    * stateful contracts where the on-chain hashOutputs verification includes
    * the envelope as part of the codePart.
+   *
+   * Public low-level assembly surface: needed for cross-artifact transaction
+   * assembly (see `assembleMultiContractCall`), where a spending tx mixes
+   * covenant inputs from DIFFERENT artifacts and each input's `_codePart` /
+   * continuation script must be built outside `call()`.
    */
-  private getCodePartHex(): string {
+  getCodePartHex(): string {
     if (this._codeScript) return this._codeScript;
     let code = this.buildCodeScript();
     if (this._inscription) {
@@ -1583,8 +1588,12 @@ export class RunarContract {
    * whenever the OP_CODESEPARATOR sits after constructor slots that expand at
    * deploy time. The symptom of using the wrong offset is NULLFAIL at
    * OP_CHECKSIG for terminal methods.
+   *
+   * Public low-level assembly surface: multi-contract tx assembly must sign
+   * each covenant input's user `Sig` over ITS artifact's codesep-trimmed
+   * subscript, which `call()` only does for its own single primary input.
    */
-  private getSubscriptForSigning(fullScript: string, methodIndex?: number): string {
+  getSubscriptForSigning(fullScript: string, methodIndex?: number): string {
     if (this._codeScript !== null) {
       const realOffsets = findCodesepOffsets(this._codeScript);
       if (realOffsets.length > 0) {
@@ -1622,8 +1631,12 @@ export class RunarContract {
    * For multi-method contracts, each method has its own separator at a different
    * byte offset. Uses codeSeparatorIndices[methodIndex] if available, otherwise
    * falls back to the single codeSeparatorIndex.
+   *
+   * Public low-level assembly surface: each covenant input of a
+   * multi-contract tx needs its own OP_PUSH_TX signature + BIP-143 preimage
+   * computed against ITS artifact's code separator layout.
    */
-  private computeOpPushTxWithCodeSep(
+  computeOpPushTxWithCodeSep(
     tx: BsvTransaction,
     inputIndex: number,
     subscript: string,
@@ -1648,8 +1661,12 @@ export class RunarContract {
    * Build the prefix for an unlocking script: optionally _codePart + _opPushTxSig.
    * needsCodePart should be true only when the method constructs continuation outputs
    * (non-terminal stateful calls). Terminal and stateless methods don't use _codePart.
+   *
+   * Public low-level assembly surface: the stateful unlock layout is
+   * `[_codePart?] _opPushTxSig args... [_changePKH _changeAmount] [_newAmount]
+   * txPreimage [selector]` — multi-contract assembly rebuilds it per input.
    */
-  private buildStatefulPrefix(opSig: string, needsCodePart: boolean = false): string {
+  buildStatefulPrefix(opSig: string, needsCodePart: boolean = false): string {
     let prefix = '';
     if (needsCodePart && this.artifact.codeSeparatorIndex !== undefined) {
       prefix += encodePushData(this.getCodePartHex());
@@ -2020,8 +2037,12 @@ function buildNamedArgs(
 
 /**
  * Encode an argument value as a Bitcoin Script push data element.
+ *
+ * Exported as part of the low-level assembly surface: multi-contract tx
+ * assembly (and any external unlocking-script construction) must encode
+ * arguments byte-identically to `buildUnlockingScript`.
  */
-function encodeArg(value: unknown): string {
+export function encodeArg(value: unknown): string {
   if (typeof value === 'bigint') {
     return encodeScriptNumber(value);
   }
@@ -2039,7 +2060,12 @@ function encodeArg(value: unknown): string {
   return encodePushData(String(value));
 }
 
-function encodeScriptNumber(n: bigint): string {
+/**
+ * Encode a bigint as a minimally-encoded Bitcoin Script number push
+ * (OP_0 / OP_1..OP_16 / OP_1NEGATE / sign-magnitude LE push data).
+ * Exported as part of the low-level assembly surface.
+ */
+export function encodeScriptNumber(n: bigint): string {
   if (n === 0n) {
     return '00'; // OP_0
   }
@@ -2094,7 +2120,11 @@ function normalizeWitnessBytes(value: string | Uint8Array): string {
   return out;
 }
 
-function encodePushData(dataHex: string): string {
+/**
+ * Encode raw hex bytes as a Bitcoin Script push (direct push / PUSHDATA1/2/4).
+ * Exported as part of the low-level assembly surface.
+ */
+export function encodePushData(dataHex: string): string {
   if (dataHex.length === 0) return '00'; // OP_0
   const len = dataHex.length / 2;
 

--- a/packages/runar-sdk/src/index.ts
+++ b/packages/runar-sdk/src/index.ts
@@ -23,7 +23,16 @@ export { LocalSigner, MockSigner, ExternalSigner, WalletSigner } from './signers
 export type { Signer, SignCallback, WalletSignerOptions } from './signers/index.js';
 
 // Contract
-export { RunarContract } from './contract.js';
+export { RunarContract, encodeArg, encodePushData, encodeScriptNumber } from './contract.js';
+
+// Cross-artifact transaction assembly (N different-artifact covenant inputs in one tx)
+export { assembleMultiContractCall, dryRunMultiContractInput } from './multi-contract.js';
+export type {
+  MultiContractCallInput,
+  MultiContractCallOutput,
+  AssembleMultiContractCallOptions,
+  AssembledMultiContractCall,
+} from './multi-contract.js';
 
 // Typed SDK errors
 export { ScriptSizeExceededError, assertScriptHexUnderLimit } from './errors.js';

--- a/packages/runar-sdk/src/index.ts
+++ b/packages/runar-sdk/src/index.ts
@@ -56,6 +56,21 @@ export { computeOpPushTx } from './oppushtx.js';
 // Script utilities
 export { buildP2PKHScript, extractConstructorArgs, matchesArtifact, pubkeyToPKH } from './script-utils.js';
 
+// Verification-descriptor resolution (value-dependent half of the artifact's
+// constructorSlots/stateFields/templateDigest descriptors)
+export {
+  resolveSlotLayout,
+  computeTemplateHash,
+  buildResolvedCodeHex,
+  resolveStateLayout,
+} from './slot-layout.js';
+export type {
+  ResolvedSlot,
+  ResolvedSlotLayout,
+  ResolvedSlotEncoding,
+  ResolvedStateLayout,
+} from './slot-layout.js';
+
 // Signed-envelope wire protocol for overlay apps
 export { canonicalJson, signEnvelope, verifyEnvelope } from './envelope.js';
 export type {
@@ -106,6 +121,9 @@ export type {
   ABIParam,
   ABIConstructor,
   StateField,
+  ConstructorSlot,
+  TemplateDigest,
+  TemplateDigestPiece,
   SourceMap,
   SourceMapping,
 } from 'runar-ir-schema';

--- a/packages/runar-sdk/src/multi-contract.ts
+++ b/packages/runar-sdk/src/multi-contract.ts
@@ -1,0 +1,311 @@
+// ---------------------------------------------------------------------------
+// runar-sdk/multi-contract.ts — cross-artifact transaction assembly
+// ---------------------------------------------------------------------------
+//
+// `RunarContract.call()` builds a tx around ONE primary contract input (plus
+// `additionalContractInputs` sharing the SAME artifact — the token-ft merge
+// shape). Cross-contract composition — e.g. a settlement covenant at input 0
+// consuming a token covenant at input 1, each compiled from a DIFFERENT
+// artifact — previously required fully manual assembly against private
+// helpers.
+//
+// `assembleMultiContractCall` is that manual assembly, made a first-class,
+// typed surface. It builds and signs a transaction with N covenant inputs
+// from N (potentially different) artifacts:
+//
+//   - the tx skeleton (all inputs with empty unlocks + the final outputs) is
+//     built first; BIP-143 preimages never cover unlocking scripts, so every
+//     per-input signature is computed against the skeleton in a single pass —
+//     no fixpoint iteration;
+//   - each input's OP_PUSH_TX signature + preimage come from ITS artifact's
+//     code-separator layout (`computeOpPushTxWithCodeSep`);
+//   - each input's user `Sig` params are signed over ITS codesep-trimmed
+//     subscript (`getSubscriptForSigning`);
+//   - each unlock replicates the compiled stateful layout exactly:
+//     `[_codePart?] _opPushTxSig args... [_changePKH _changeAmount]
+//     [_newAmount] txPreimage [selector]`;
+//   - the signed tx is constructed FRESH from parts (inputs are never mutated
+//     after `toHex()`), sidestepping the @bsv/sdk transaction hex cache.
+//
+// The caller owns output construction (continuation scripts, change, fees):
+// with multiple covenants in one tx there is no single "the" continuation the
+// SDK could infer — every input's covenant must independently agree with the
+// final output set via its own hashOutputs binding.
+
+import {
+  Transaction as BsvTransaction,
+  LockingScript,
+  UnlockingScript,
+  Spend,
+} from '@bsv/sdk';
+import type { RunarContract } from './contract.js';
+import { encodeArg, encodePushData, encodeScriptNumber } from './contract.js';
+import type { Signer } from './signers/index.js';
+import type { UTXO } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** One covenant input of a multi-contract transaction. */
+export interface MultiContractCallInput {
+  /** The contract instance (its artifact + constructor args drive the unlock layout). */
+  contract: RunarContract;
+  /** Public method to invoke on this input. */
+  method: string;
+  /**
+   * User-facing args in ABI order, EXCLUDING auto-injected params
+   * (`txPreimage`, `_changePKH`, `_changeAmount`, `_newAmount`).
+   * A `null` in a `Sig` position is signed automatically with `signer`.
+   */
+  args: unknown[];
+  /** The UTXO this input spends. Defaults to `contract.getUtxo()`. */
+  utxo?: UTXO;
+  /** Signs `null` `Sig` args over the codesep-trimmed subscript. */
+  signer?: Signer;
+  /**
+   * hash160 (hex) for the method's `_changePKH` param, when the ABI declares
+   * one. Compiled stateful methods with `_changePKH` reconstruct
+   * `<continuation><P2PKH change>` in hashOutputs unconditionally — the
+   * spending tx must actually carry that change output.
+   */
+  changePKH?: string;
+  /** Value for `_changeAmount` (satoshis of the change output). Default 0n. */
+  changeAmount?: bigint;
+  /** Value for `_newAmount` when the ABI declares it. Defaults to the UTXO's satoshis. */
+  newAmount?: bigint;
+}
+
+/** One output of the multi-contract transaction (fully caller-specified). */
+export interface MultiContractCallOutput {
+  satoshis: number;
+  /** Locking script hex (continuation script, P2PKH change, data output, ...). */
+  script: string;
+}
+
+export interface AssembleMultiContractCallOptions {
+  /** nLockTime of the assembled tx. Default 0. */
+  lockTime?: number;
+  /** nSequence for every input. Default 0xffffffff. */
+  sequence?: number;
+  /**
+   * Validate every covenant input offline through @bsv/sdk's Spend
+   * interpreter after assembly, throwing on the first failure. Strongly
+   * recommended before broadcasting. Default true.
+   */
+  dryRun?: boolean;
+}
+
+export interface AssembledMultiContractCall {
+  /** The fully-signed transaction. */
+  tx: BsvTransaction;
+  /** Raw tx hex (safe to broadcast if `dryRun` passed). */
+  txHex: string;
+  /** Per-input unlocking script hex, in input order. */
+  unlocks: string[];
+  /** Per-input BIP-143 preimage hex, in input order. */
+  preimages: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Assembly
+// ---------------------------------------------------------------------------
+
+const AUTO_PARAM_NAMES = new Set(['_changePKH', '_changeAmount', '_newAmount']);
+const isWitnessParam = (name: string): boolean =>
+  name.startsWith('_prevOutScript_') || name === '_serialisedOutputs';
+
+/**
+ * Build and sign a transaction whose inputs are N covenant UTXOs from N
+ * (potentially different) artifacts, with a caller-specified output set.
+ *
+ * Input order in the tx is the order of `inputs`. Positional conventions
+ * asserted by the contracts themselves (e.g. "I am input 0, my companion is
+ * input 1") are the caller's responsibility to honor here.
+ *
+ * @throws if a method is unknown/non-public, an arg count mismatches, a UTXO
+ *         or required signer/changePKH is missing, a method declares
+ *         intent-intrinsic witness params (unsupported in v1), or — with
+ *         `dryRun` (default) — an assembled input fails offline validation.
+ */
+export async function assembleMultiContractCall(
+  inputs: MultiContractCallInput[],
+  outputs: MultiContractCallOutput[],
+  opts: AssembleMultiContractCallOptions = {},
+): Promise<AssembledMultiContractCall> {
+  if (inputs.length === 0) throw new Error('assembleMultiContractCall: at least one input required');
+  if (outputs.length === 0) throw new Error('assembleMultiContractCall: at least one output required');
+  const sequence = opts.sequence ?? 0xffffffff;
+  const lockTime = opts.lockTime ?? 0;
+
+  // Resolve UTXOs up front so every failure happens before any signing work.
+  const utxos: UTXO[] = inputs.map((inp, i) => {
+    const utxo = inp.utxo ?? inp.contract.getUtxo();
+    if (!utxo) {
+      throw new Error(
+        `assembleMultiContractCall: input ${i} has no UTXO — pass \`utxo\` or deploy/connect the contract first`,
+      );
+    }
+    return utxo;
+  });
+
+  // Fresh-build the tx for a given unlock set. Never mutate a Transaction
+  // after toHex(): @bsv/sdk caches serialized hex, and a mutated-then-reused
+  // instance serializes stale bytes.
+  const build = (unlockHexes: string[]): BsvTransaction => {
+    const tx = new BsvTransaction();
+    tx.lockTime = lockTime;
+    for (let i = 0; i < inputs.length; i++) {
+      tx.addInput({
+        sourceTXID: utxos[i]!.txid,
+        sourceOutputIndex: utxos[i]!.outputIndex,
+        unlockingScript: UnlockingScript.fromHex(unlockHexes[i] ?? ''),
+        sequence,
+      });
+    }
+    for (const out of outputs) {
+      tx.addOutput({
+        satoshis: out.satoshis,
+        lockingScript: LockingScript.fromHex(out.script),
+      });
+    }
+    return tx;
+  };
+
+  const skeleton = build(inputs.map(() => ''));
+  const skeletonHex = skeleton.toHex();
+
+  const unlocks: string[] = [];
+  const preimages: string[] = [];
+
+  for (let i = 0; i < inputs.length; i++) {
+    const inp = inputs[i]!;
+    const utxo = utxos[i]!;
+    const artifact = inp.contract.artifact;
+    const publicMethods = artifact.abi.methods.filter((m) => m.isPublic);
+    const methodIndex = publicMethods.findIndex((m) => m.name === inp.method);
+    if (methodIndex < 0) {
+      throw new Error(
+        `assembleMultiContractCall: input ${i}: public method '${inp.method}' not found on ${artifact.contractName}`,
+      );
+    }
+    const method = publicMethods[methodIndex]!;
+
+    const witnessParams = method.params.filter((p) => isWitnessParam(p.name));
+    if (witnessParams.length > 0) {
+      throw new Error(
+        `assembleMultiContractCall: input ${i}: method '${inp.method}' declares intent-intrinsic witness params ` +
+        `(${witnessParams.map((p) => p.name).join(', ')}) — not supported by multi-contract assembly yet`,
+      );
+    }
+
+    const methodNeedsChange = method.params.some((p) => p.name === '_changePKH');
+    const methodNeedsNewAmount = method.params.some((p) => p.name === '_newAmount');
+    const methodUsesCodePart = method.usesCodePart ?? methodNeedsChange;
+    const userParams = method.params.filter(
+      (p) => p.type !== 'SigHashPreimage' && !AUTO_PARAM_NAMES.has(p.name),
+    );
+    if (userParams.length !== inp.args.length) {
+      throw new Error(
+        `assembleMultiContractCall: input ${i}: method '${inp.method}' expects ${userParams.length} args, got ${inp.args.length}`,
+      );
+    }
+    if (methodNeedsChange && !inp.changePKH) {
+      throw new Error(
+        `assembleMultiContractCall: input ${i}: method '${inp.method}' requires \`changePKH\` (ABI declares _changePKH)`,
+      );
+    }
+
+    // OP_PUSH_TX signature + preimage against THIS artifact's codesep layout.
+    const { sigHex: opSig, preimageHex } = inp.contract.computeOpPushTxWithCodeSep(
+      skeleton, i, utxo.script, utxo.satoshis, methodIndex,
+    );
+
+    // Resolve user args; sign null Sig params over the trimmed subscript.
+    let argsHex = '';
+    for (let a = 0; a < userParams.length; a++) {
+      let value = inp.args[a];
+      if (userParams[a]!.type === 'Sig' && value === null) {
+        if (!inp.signer) {
+          throw new Error(
+            `assembleMultiContractCall: input ${i}: arg ${a} is a null Sig but no \`signer\` was provided`,
+          );
+        }
+        const trimmed = inp.contract.getSubscriptForSigning(utxo.script, methodIndex);
+        value = await inp.signer.sign(skeletonHex, i, trimmed, utxo.satoshis);
+      }
+      argsHex += encodeArg(value);
+    }
+
+    let changeHex = '';
+    if (methodNeedsChange) {
+      changeHex = encodePushData(inp.changePKH!) + encodeScriptNumber(inp.changeAmount ?? 0n);
+    }
+    let newAmountHex = '';
+    if (methodNeedsNewAmount) {
+      newAmountHex = encodeScriptNumber(inp.newAmount ?? BigInt(utxo.satoshis));
+    }
+    const selectorHex = publicMethods.length > 1 ? encodeScriptNumber(BigInt(methodIndex)) : '';
+
+    const unlock =
+      inp.contract.buildStatefulPrefix(opSig, methodUsesCodePart) +
+      argsHex + changeHex + newAmountHex +
+      encodePushData(preimageHex) +
+      selectorHex;
+
+    unlocks.push(unlock);
+    preimages.push(preimageHex);
+  }
+
+  const tx = build(unlocks);
+  const txHex = tx.toHex();
+
+  if (opts.dryRun !== false) {
+    for (let i = 0; i < inputs.length; i++) {
+      const r = dryRunMultiContractInput(txHex, i, utxos[i]!.script, utxos[i]!.satoshis);
+      if (!r.valid) {
+        throw new Error(
+          `assembleMultiContractCall: offline validation FAILED for input ${i} ` +
+          `(${inputs[i]!.contract.artifact.contractName}.${inputs[i]!.method}): ${r.error ?? 'script invalid'}`,
+        );
+      }
+    }
+  }
+
+  return { tx, txHex, unlocks, preimages };
+}
+
+/**
+ * Offline validation of one input of a fully-assembled tx through @bsv/sdk's
+ * production Spend interpreter (real OP_CHECKSIG, real BIP-143). Exported so
+ * callers can re-validate independently before broadcast.
+ */
+export function dryRunMultiContractInput(
+  txHex: string,
+  inputIndex: number,
+  utxoScriptHex: string,
+  utxoSatoshis: number,
+): { valid: boolean; error?: string } {
+  const tx = BsvTransaction.fromHex(txHex);
+  const input = tx.inputs[inputIndex];
+  if (!input) return { valid: false, error: `no input at index ${inputIndex}` };
+  const otherInputs = tx.inputs.filter((_, i) => i !== inputIndex);
+  try {
+    const spend = new Spend({
+      sourceTXID: input.sourceTXID!,
+      sourceOutputIndex: input.sourceOutputIndex,
+      sourceSatoshis: utxoSatoshis,
+      lockingScript: LockingScript.fromHex(utxoScriptHex),
+      transactionVersion: tx.version,
+      otherInputs,
+      outputs: tx.outputs,
+      inputIndex,
+      unlockingScript: input.unlockingScript!,
+      inputSequence: input.sequence ?? 0xffffffff,
+      lockTime: tx.lockTime,
+    });
+    return { valid: !!spend.validate() };
+  } catch (e) {
+    return { valid: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/packages/runar-sdk/src/slot-layout.ts
+++ b/packages/runar-sdk/src/slot-layout.ts
@@ -168,6 +168,32 @@ interface Substitution {
   slot?: ConstructorSlot;
 }
 
+/**
+ * Assert that the template script actually carries the 1-byte OP_0
+ * placeholder (0x00) at a slot's byteOffset. The descriptor anchor points
+ * (`constructorSlots[].byteOffset`, `codeSepIndexSlots[].byteOffset`) are
+ * trusted verbatim from the artifact JSON — a corrupted or mismatched
+ * descriptor (wrong offsets for this script) would otherwise be spliced
+ * over silently, yielding wrong layouts and a wrong template hash.
+ */
+function assertPlaceholderByte(
+  artifact: RunarArtifact,
+  byteOffset: number,
+  slotKind: string,
+  slotLabel: string,
+): void {
+  const byteHex = artifact.script.slice(byteOffset * 2, byteOffset * 2 + 2);
+  if (byteHex !== '00') {
+    throw new Error(
+      `resolveSlotLayout: ${slotKind} ${slotLabel} expects an OP_0 placeholder ` +
+        `(0x00) at byteOffset ${byteOffset} of the template script, found ` +
+        `${byteHex === '' ? 'end-of-script' : `0x${byteHex}`} — ` +
+        `the descriptor does not match this artifact's script (corrupted or ` +
+        `mismatched artifact JSON)`,
+    );
+  }
+}
+
 /** All template substitutions (constructor slots + codeSepIndex slots). */
 function collectSubstitutions(
   artifact: RunarArtifact,
@@ -175,13 +201,31 @@ function collectSubstitutions(
 ): Substitution[] {
   const subs: Substitution[] = [];
   for (const slot of artifact.constructorSlots ?? []) {
+    const abiParamName = artifact.abi.constructor.params[slot.paramIndex]?.name;
     if (slot.paramIndex >= constructorArgs.length) {
       throw new Error(
         `resolveSlotLayout: constructor slot for paramIndex ${slot.paramIndex} ` +
-          `('${slot.name ?? artifact.abi.constructor.params[slot.paramIndex]?.name ?? '?'}') ` +
+          `('${slot.name ?? abiParamName ?? '?'}') ` +
           `has no matching constructor arg (got ${constructorArgs.length} args)`,
       );
     }
+    // An enriched slot's name must correspond to the ABI constructor param
+    // at its paramIndex — a mismatch means the descriptor's slot metadata
+    // and the ABI disagree about which value lands in this slot.
+    if (slot.name !== undefined && slot.name !== abiParamName) {
+      throw new Error(
+        `resolveSlotLayout: constructor slot at byteOffset ${slot.byteOffset} ` +
+          `is named '${slot.name}' but abi.constructor.params[${slot.paramIndex}] ` +
+          `is ${abiParamName === undefined ? 'missing' : `named '${abiParamName}'`} — ` +
+          `corrupted or mismatched descriptor`,
+      );
+    }
+    assertPlaceholderByte(
+      artifact,
+      slot.byteOffset,
+      'constructor slot',
+      `'${slot.name ?? abiParamName ?? `param${slot.paramIndex}`}'`,
+    );
     subs.push({
       templateByteOffset: slot.byteOffset,
       encodedHex: encodeArg(constructorArgs[slot.paramIndex]),
@@ -189,6 +233,12 @@ function collectSubstitutions(
     });
   }
   for (const rs of resolvedCodeSepSlotValues(artifact, constructorArgs)) {
+    assertPlaceholderByte(
+      artifact,
+      rs.templateByteOffset,
+      'codeSepIndex slot',
+      `(adjusted value ${rs.adjustedValue})`,
+    );
     subs.push({
       templateByteOffset: rs.templateByteOffset,
       encodedHex: encodeScriptNumber(BigInt(rs.adjustedValue)),

--- a/packages/runar-sdk/src/slot-layout.ts
+++ b/packages/runar-sdk/src/slot-layout.ts
@@ -1,0 +1,322 @@
+// ---------------------------------------------------------------------------
+// runar-sdk/slot-layout.ts — resolve verification descriptors for GIVEN args
+// ---------------------------------------------------------------------------
+//
+// The artifact's `constructorSlots` / `stateFields` / `templateDigest` carry
+// value-INDEPENDENT descriptor metadata (the compiler cannot know how many
+// bytes a slot occupies after deployment — that depends on the VALUE baked at
+// deploy time: a 33-byte PubKey push vs. a single OP_N opcode byte). This
+// module is the value-DEPENDENT half of that design split:
+//
+//   resolveSlotLayout(artifact, args)   → concrete slot offsets/lengths in the
+//                                         deployed code part
+//   computeTemplateHash(artifact, args) → hash256 of the code part with every
+//                                         slot's VALUE bytes excised (the
+//                                         template identity a companion-input
+//                                         verifier checks)
+//   resolveStateLayout(artifact)        → per-state-field byte layout in the
+//                                         OP_RETURN state tail
+//
+// Encoding classes a verifier must distinguish (single-opcode encodings have
+// NO push header — the opcode byte IS the value):
+//   - 'data-push'      raw data push: 1/2/3/5-byte header + value bytes
+//   - 'scriptnum-push' Script number >= 17 or <= -2: 1-byte header + LE
+//                      sign-magnitude payload
+//   - 'op-n'           bigint 1..16 → single opcode 0x51..0x60 (value = byte - 0x50)
+//   - 'op-0'           bigint 0 / empty data → single 0x00 opcode
+//   - 'op-1negate'     bigint -1 → single 0x4f opcode
+//   - 'bool'           boolean → single 0x51 / 0x00 opcode
+//
+// NOTE: offsets are relative to the CODE PART (the locking script before any
+// inscription envelope and before the OP_RETURN state tail) — the same bytes
+// `RunarContract.getCodePartHex()` returns for a template-built contract.
+// Inscription envelopes are appended AFTER the code part and do not shift
+// slot offsets.
+
+import { Hash, Utils } from '@bsv/sdk';
+import type { RunarArtifact, ConstructorSlot, StateField } from 'runar-ir-schema';
+import { annotateStateFieldLayout, totalStateByteLength } from 'runar-ir-schema';
+import { encodeArg, encodeScriptNumber } from './contract.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ResolvedSlotEncoding =
+  | 'data-push'
+  | 'scriptnum-push'
+  | 'op-n'
+  | 'op-0'
+  | 'op-1negate'
+  | 'bool';
+
+/** One constructor slot resolved against concrete constructor args. */
+export interface ResolvedSlot {
+  /** Constructor param name (from the enriched slot, falling back to the ABI). */
+  name: string;
+  /** Index into `abi.constructor.params`. */
+  paramIndex: number;
+  /** Byte offset of the 1-byte OP_0 placeholder in the TEMPLATE script. */
+  templateByteOffset: number;
+  /** Byte offset of the slot's first byte (push header, or the single
+   *  opcode) in the RESOLVED code part. */
+  byteOffset: number;
+  /** Total encoded length in bytes (header + value; 1 for single-opcode
+   *  encodings). */
+  byteLength: number;
+  /** Push-header length in bytes (0 for single-opcode encodings). */
+  pushHeaderBytes: number;
+  /** Byte offset of the VALUE bytes in the resolved code part. For
+   *  single-opcode encodings this is the opcode byte itself (a verifier of
+   *  an 'op-n' slot reads this byte and compares against 0x50 + N). */
+  valueByteOffset: number;
+  /** Length of the value bytes (1 for single-opcode encodings). */
+  valueByteLength: number;
+  /** How the value is encoded at this slot for THESE args. */
+  encoding: ResolvedSlotEncoding;
+}
+
+export interface ResolvedSlotLayout {
+  /** Resolved slots in ascending byteOffset order. */
+  slots: ResolvedSlot[];
+  /** Total length in bytes of the resolved code part. */
+  codeByteLength: number;
+}
+
+/** State-tail layout resolved from an artifact. */
+export interface ResolvedStateLayout {
+  /** State fields annotated with encoding/byteOffset/byteLength/tailOffset,
+   *  in serialization order. */
+  fields: StateField[];
+  /** Total serialized state length in bytes (after the OP_RETURN byte).
+   *  Absent when any field is variable-length. */
+  totalByteLength?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const hash256hex = (hex: string): string =>
+  Utils.toHex(Hash.hash256(Utils.toArray(hex, 'hex')));
+
+/**
+ * Resolve the adjusted codeSep index values for all codeSepIndex slots.
+ * Mirrors RunarContract's private `_resolvedCodeSepSlotValues` — a pure
+ * function of (artifact, constructorArgs); kept in sync by the layout
+ * parity tests (`slot-layout.test.ts` asserts byte-identity against
+ * `getCodePartHex()`, which exercises the contract-side twin).
+ */
+function resolvedCodeSepSlotValues(
+  artifact: RunarArtifact,
+  constructorArgs: unknown[],
+): Array<{ templateByteOffset: number; adjustedValue: number }> {
+  if (!artifact.codeSepIndexSlots || artifact.codeSepIndexSlots.length === 0) {
+    return [];
+  }
+  const sorted = [...artifact.codeSepIndexSlots].sort((a, b) => a.byteOffset - b.byteOffset);
+  const result: Array<{ templateByteOffset: number; adjustedValue: number }> = [];
+  for (const slot of sorted) {
+    let shift = 0;
+    if (artifact.constructorSlots) {
+      for (const cs of artifact.constructorSlots) {
+        if (cs.byteOffset < slot.codeSepIndex) {
+          const encoded = encodeArg(constructorArgs[cs.paramIndex]);
+          shift += encoded.length / 2 - 1;
+        }
+      }
+    }
+    for (const prev of result) {
+      if (prev.templateByteOffset < slot.codeSepIndex) {
+        const prevEncoded = encodeScriptNumber(BigInt(prev.adjustedValue));
+        shift += prevEncoded.length / 2 - 1;
+      }
+    }
+    result.push({ templateByteOffset: slot.byteOffset, adjustedValue: slot.codeSepIndex + shift });
+  }
+  return result;
+}
+
+/** Classify the encoded slot bytes (see ResolvedSlotEncoding). */
+function classifyEncoded(
+  encodedHex: string,
+  argValue: unknown,
+): { encoding: ResolvedSlotEncoding; pushHeaderBytes: number } {
+  const b0 = parseInt(encodedHex.slice(0, 2), 16);
+
+  if (typeof argValue === 'boolean') {
+    return { encoding: 'bool', pushHeaderBytes: 0 };
+  }
+  if (typeof argValue === 'bigint' || typeof argValue === 'number') {
+    if (b0 === 0x00) return { encoding: 'op-0', pushHeaderBytes: 0 };
+    if (b0 === 0x4f) return { encoding: 'op-1negate', pushHeaderBytes: 0 };
+    if (b0 >= 0x51 && b0 <= 0x60) return { encoding: 'op-n', pushHeaderBytes: 0 };
+    return { encoding: 'scriptnum-push', pushHeaderBytes: 1 };
+  }
+  // Data (hex string): OP_0 for empty, else direct push / PUSHDATA1/2/4.
+  if (b0 === 0x00) return { encoding: 'op-0', pushHeaderBytes: 0 };
+  if (b0 <= 0x4b) return { encoding: 'data-push', pushHeaderBytes: 1 };
+  if (b0 === 0x4c) return { encoding: 'data-push', pushHeaderBytes: 2 };
+  if (b0 === 0x4d) return { encoding: 'data-push', pushHeaderBytes: 3 };
+  return { encoding: 'data-push', pushHeaderBytes: 5 }; // 0x4e
+}
+
+interface Substitution {
+  templateByteOffset: number;
+  encodedHex: string;
+  /** Present for constructor slots; absent for codeSepIndex slots. */
+  slot?: ConstructorSlot;
+}
+
+/** All template substitutions (constructor slots + codeSepIndex slots). */
+function collectSubstitutions(
+  artifact: RunarArtifact,
+  constructorArgs: unknown[],
+): Substitution[] {
+  const subs: Substitution[] = [];
+  for (const slot of artifact.constructorSlots ?? []) {
+    if (slot.paramIndex >= constructorArgs.length) {
+      throw new Error(
+        `resolveSlotLayout: constructor slot for paramIndex ${slot.paramIndex} ` +
+          `('${slot.name ?? artifact.abi.constructor.params[slot.paramIndex]?.name ?? '?'}') ` +
+          `has no matching constructor arg (got ${constructorArgs.length} args)`,
+      );
+    }
+    subs.push({
+      templateByteOffset: slot.byteOffset,
+      encodedHex: encodeArg(constructorArgs[slot.paramIndex]),
+      slot,
+    });
+  }
+  for (const rs of resolvedCodeSepSlotValues(artifact, constructorArgs)) {
+    subs.push({
+      templateByteOffset: rs.templateByteOffset,
+      encodedHex: encodeScriptNumber(BigInt(rs.adjustedValue)),
+    });
+  }
+  subs.sort((a, b) => a.templateByteOffset - b.templateByteOffset);
+  return subs;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the artifact's constructor slots against concrete constructor
+ * args, returning exact byte offsets/lengths in the deployed code part.
+ *
+ * This is the mechanical replacement for hand-deriving offsets from a
+ * compiled script with `indexOf`/byte-diffing: a downstream verifier
+ * (e.g. a consuming covenant that template-checks a companion input's
+ * parent-tx output) takes `valueByteOffset` / `valueByteLength` /
+ * `encoding` from here instead.
+ */
+export function resolveSlotLayout(
+  artifact: RunarArtifact,
+  constructorArgs: unknown[],
+): ResolvedSlotLayout {
+  const subs = collectSubstitutions(artifact, constructorArgs);
+
+  const slots: ResolvedSlot[] = [];
+  let shift = 0;
+  for (const sub of subs) {
+    const byteOffset = sub.templateByteOffset + shift;
+    const byteLength = sub.encodedHex.length / 2;
+    if (sub.slot) {
+      const { encoding, pushHeaderBytes } = classifyEncoded(
+        sub.encodedHex,
+        constructorArgs[sub.slot.paramIndex],
+      );
+      slots.push({
+        name:
+          sub.slot.name ??
+          artifact.abi.constructor.params[sub.slot.paramIndex]?.name ??
+          `param${sub.slot.paramIndex}`,
+        paramIndex: sub.slot.paramIndex,
+        templateByteOffset: sub.templateByteOffset,
+        byteOffset,
+        byteLength,
+        pushHeaderBytes,
+        valueByteOffset: byteOffset + pushHeaderBytes,
+        valueByteLength: byteLength - pushHeaderBytes,
+        encoding,
+      });
+    }
+    shift += byteLength - 1; // each substitution replaces a 1-byte OP_0
+  }
+
+  return {
+    slots,
+    codeByteLength: artifact.script.length / 2 + shift,
+  };
+}
+
+/**
+ * Build the resolved code part (template with all substitutions spliced in)
+ * — byte-identical to `RunarContract.getCodePartHex()` for a template-built
+ * contract without an inscription envelope.
+ */
+export function buildResolvedCodeHex(
+  artifact: RunarArtifact,
+  constructorArgs: unknown[],
+): string {
+  const subs = collectSubstitutions(artifact, constructorArgs);
+  let script = artifact.script;
+  // Descending order so each splice doesn't invalidate earlier offsets.
+  for (const sub of [...subs].sort((a, b) => b.templateByteOffset - a.templateByteOffset)) {
+    const hexOffset = sub.templateByteOffset * 2;
+    script = script.slice(0, hexOffset) + sub.encodedHex + script.slice(hexOffset + 2);
+  }
+  return script;
+}
+
+/**
+ * Compute the slot-excised template hash for the artifact deployed with the
+ * given constructor args: hash256 (hex) of the resolved code part with every
+ * slot's VALUE bytes removed.
+ *
+ * Push headers of 'data-push'/'scriptnum-push' slots REMAIN in the hashed
+ * template (pinning the baked value's length); single-opcode encodings
+ * (op-n / op-0 / op-1negate / bool) have their opcode byte excised.
+ *
+ * The result is what a consuming covenant bakes as its expected companion
+ * code hash (`templateDigest.algorithm === 'hash256-excised-slots'`), and
+ * what an off-chain verifier recomputes from a candidate script using
+ * `resolveSlotLayout` boundaries.
+ */
+export function computeTemplateHash(
+  artifact: RunarArtifact,
+  constructorArgs: unknown[],
+): string {
+  const code = buildResolvedCodeHex(artifact, constructorArgs);
+  const { slots } = resolveSlotLayout(artifact, constructorArgs);
+
+  // Excise value ranges in descending order.
+  let template = code;
+  for (const s of [...slots].sort((a, b) => b.valueByteOffset - a.valueByteOffset)) {
+    template =
+      template.slice(0, s.valueByteOffset * 2) +
+      template.slice((s.valueByteOffset + s.valueByteLength) * 2);
+  }
+  return hash256hex(template);
+}
+
+/**
+ * Resolve the state-tail byte layout for a stateful contract's artifact.
+ *
+ * Prefers the compiler-annotated `stateFields` layout when present; falls
+ * back to computing it (via the shared `runar-ir-schema` width table) for
+ * artifacts produced before descriptor emission. Returns fields in
+ * serialization order.
+ */
+export function resolveStateLayout(artifact: RunarArtifact): ResolvedStateLayout {
+  const fields = artifact.stateFields ?? [];
+  const annotated = fields.every(f => f.encoding !== undefined)
+    ? [...fields].sort((a, b) => a.index - b.index)
+    : annotateStateFieldLayout(fields);
+  const total = totalStateByteLength(fields);
+  const result: ResolvedStateLayout = { fields: annotated };
+  if (total !== undefined) result.totalByteLength = total;
+  return result;
+}

--- a/packages/runar-sdk/src/state.ts
+++ b/packages/runar-sdk/src/state.ts
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------------
 
 import type { StateField, RunarArtifact } from 'runar-ir-schema';
+import { STATE_FIELD_WIDTHS } from 'runar-ir-schema';
 
 /**
  * Serialize a set of state values into a hex-encoded Bitcoin Script data
@@ -362,33 +363,28 @@ function decodeStateValue(
   offset: number,
   type: string,
 ): { value: unknown; bytesRead: number } {
-  switch (type) {
-    case 'bool': {
-      // 1 raw byte: 0x00 = false, 0x01 = true
-      return { value: hex.slice(offset, offset + 2) !== '00', bytesRead: 2 };
-    }
-    case 'int':
-    case 'bigint': {
-      // 8 raw bytes LE sign-magnitude (NUM2BIN 8)
-      const hexWidth = 16; // 8 bytes * 2
-      const data = hex.slice(offset, offset + hexWidth);
-      return { value: decodeNum2Bin(data), bytesRead: hexWidth };
-    }
-    case 'PubKey':
-      return { value: hex.slice(offset, offset + 66), bytesRead: 66 }; // 33 bytes
-    case 'Addr':
-    case 'Ripemd160':
-      return { value: hex.slice(offset, offset + 40), bytesRead: 40 }; // 20 bytes
-    case 'Sha256':
-      return { value: hex.slice(offset, offset + 64), bytesRead: 64 }; // 32 bytes
-    case 'Point':
-      return { value: hex.slice(offset, offset + 128), bytesRead: 128 }; // 64 bytes
-    default: {
-      // For unknown types, fall back to push-data decoding
-      const { data, bytesRead } = decodePushData(hex, offset);
-      return { value: data, bytesRead };
+  // Fixed-width types read exactly `size` raw bytes; widths come from the
+  // shared runar-ir-schema table so the codec, the compiler's stateField
+  // layout annotations, and verifier tooling can never drift apart.
+  const width = STATE_FIELD_WIDTHS[type];
+  if (width) {
+    const hexWidth = width.size * 2;
+    const data = hex.slice(offset, offset + hexWidth);
+    switch (width.encoding) {
+      case 'bool1':
+        // 1 raw byte: 0x00 = false, 0x01 = true
+        return { value: data !== '00', bytesRead: hexWidth };
+      case 'num2bin-le8':
+        // 8 raw bytes LE sign-magnitude (NUM2BIN 8)
+        return { value: decodeNum2Bin(data), bytesRead: hexWidth };
+      default:
+        // Raw fixed-size byte types (PubKey 33, Addr/Ripemd160 20, Sha256 32, Point 64)
+        return { value: data, bytesRead: hexWidth };
     }
   }
+  // For variable-length / unknown types, fall back to push-data decoding
+  const { data, bytesRead } = decodePushData(hex, offset);
+  return { value: data, bytesRead };
 }
 
 /**

--- a/packages/runar-testing/package.json
+++ b/packages/runar-testing/package.json
@@ -28,6 +28,7 @@
     "@bsv/sdk": "^2.0.7"
   },
   "devDependencies": {
+    "runar-sdk": "workspace:*",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0",
     "fast-check": "^3.22.0"

--- a/packages/runar-testing/src/__tests__/loop-walk-vm.test.ts
+++ b/packages/runar-testing/src/__tests__/loop-walk-vm.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Runtime proof for the unrolled-loop outer-ref fix: a method param
+ * referenced inside AND after a for-loop must compile to a Script that
+ * actually executes correctly in the VM (previously the post-loop
+ * reference was a silent OP_0/empty push — the interpreter passed while
+ * the Script failed with "OP_SPLIT: position N out of range [0, 0]").
+ *
+ * The repro is the multi-input tx walk pattern (V003): walk up to 3
+ * inputs of a serialized tx, advancing a running offset, then read the
+ * byte at the final offset.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from 'runar-compiler';
+import { TestSmartContract, expectScriptSuccess, expectScriptFailure } from '../helpers.js';
+
+const LOOP_WALK_SOURCE = `
+import { SmartContract, assert, substr, cat, bin2num } from 'runar-lang';
+import type { ByteString } from 'runar-lang';
+
+class LoopWalk extends SmartContract {
+  readonly pad00: ByteString = "00" as ByteString;
+
+  constructor() {
+    super();
+  }
+
+  public walk(data: ByteString) {
+    let off = 5n;
+    for (let i = 0n; i < 3n; i++) {
+      if (i < bin2num(cat(substr(data, 4n, 1n), this.pad00))) {
+        const sl = bin2num(cat(substr(data, off + 36n, 1n), this.pad00));
+        assert(sl < 253n);
+        off = off + 36n + 1n + sl + 4n;
+      }
+    }
+    const tail = bin2num(cat(substr(data, off, 1n), this.pad00));
+    assert(tail === 7n);
+  }
+}
+`;
+
+// Serialized-input helpers: outpoint(36) + scriptLen(1) + script + sequence(4)
+const input = (fill: string, scriptLen: number) =>
+  fill.repeat(36) + scriptLen.toString(16).padStart(2, '0') + 'ab'.repeat(scriptLen) + 'ffffffff';
+
+/** version(4) + inputCount(1) + inputs + tail byte */
+const txData = (inputs: string[], tail: string) =>
+  '00'.repeat(4) +
+  inputs.length.toString(16).padStart(2, '0') +
+  inputs.join('') +
+  tail;
+
+describe('compiled loop-walk executes correctly in the VM', () => {
+  const result = compile(LOOP_WALK_SOURCE, { fileName: 'LoopWalk.runar.ts' });
+  expect(result.success).toBe(true);
+  const contract = TestSmartContract.fromArtifact(result.artifact!, []);
+
+  it('walks 1 input', () => {
+    expectScriptSuccess(contract.call('walk', [txData([input('11', 2)], '07')]));
+  });
+
+  it('walks 2 inputs (variable script lengths)', () => {
+    expectScriptSuccess(
+      contract.call('walk', [txData([input('11', 2), input('22', 1)], '07')]),
+    );
+  });
+
+  it('walks 3 inputs', () => {
+    expectScriptSuccess(
+      contract.call('walk', [
+        txData([input('11', 2), input('22', 1), input('33', 3)], '07'),
+      ]),
+    );
+  });
+
+  it('fails when the byte at the walked offset is wrong', () => {
+    expectScriptFailure(
+      contract.call('walk', [txData([input('11', 2), input('22', 1)], '09')]),
+    );
+  });
+});

--- a/packages/runar-testing/src/__tests__/mock-preimage-prevouts.test.ts
+++ b/packages/runar-testing/src/__tests__/mock-preimage-prevouts.test.ts
@@ -1,0 +1,145 @@
+/**
+ * buildStatefulPreimage outpoint / prevouts overrides — multi-input
+ * covenant tests need control over the spent outpoint and hashPrevouts
+ * (contracts verifying companion inputs via extractHashPrevouts /
+ * extractOutpoint). Previously both were hardcoded to a 36-zero-byte
+ * dummy outpoint.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import { compile } from 'runar-compiler';
+import type { RunarArtifact } from 'runar-ir-schema';
+import { buildStatefulPreimage } from '../mock-preimage.js';
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const counterSource = `
+import { StatefulSmartContract, assert } from 'runar-lang';
+
+class Counter extends StatefulSmartContract {
+  count: bigint;
+
+  constructor(count: bigint) {
+    super(count);
+    this.count = count;
+  }
+
+  public increment() {
+    this.count++;
+  }
+}
+`;
+
+let artifact: RunarArtifact;
+{
+  const result = compile(counterSource, { fileName: 'Counter.runar.ts' });
+  if (!result.success || !result.artifact) {
+    throw new Error(
+      result.diagnostics.map((d) => d.message).join('\n') || 'compile failed',
+    );
+  }
+  artifact = result.artifact;
+}
+
+function baseParams() {
+  return {
+    artifact,
+    constructorArgs: { count: 0n },
+    state: { count: 5n },
+    newState: { count: 6n },
+  };
+}
+
+function hash256hex(hex: string): string {
+  const one = createHash('sha256').update(Buffer.from(hex, 'hex')).digest();
+  return createHash('sha256').update(one).digest('hex');
+}
+
+const DUMMY_OUTPOINT = '00'.repeat(36);
+const OUTPOINT_A = 'aa'.repeat(32) + '01000000';
+const OUTPOINT_B = 'bb'.repeat(32) + '00000000';
+
+/** Slice helpers over the BIP-143 preimage layout. */
+function preimageHashPrevouts(preimageHex: string): string {
+  return preimageHex.slice(8, 8 + 64); // after nVersion(4B)
+}
+function preimageOutpoint(preimageHex: string): string {
+  return preimageHex.slice(8 + 64 + 64, 8 + 64 + 64 + 72); // after hashSequence
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('buildStatefulPreimage outpoint/prevouts overrides', () => {
+  it('defaults are backward compatible (dummy outpoint, hashPrevouts = hash256(dummy))', () => {
+    const result = buildStatefulPreimage(baseParams());
+    expect(preimageOutpoint(result.preimageHex)).toBe(DUMMY_OUTPOINT);
+    expect(preimageHashPrevouts(result.preimageHex)).toBe(
+      hash256hex(DUMMY_OUTPOINT),
+    );
+  });
+
+  it('outpoint override lands in the preimage and in hashPrevouts', () => {
+    const result = buildStatefulPreimage({
+      ...baseParams(),
+      outpoint: OUTPOINT_A,
+    });
+    expect(preimageOutpoint(result.preimageHex)).toBe(OUTPOINT_A);
+    expect(preimageHashPrevouts(result.preimageHex)).toBe(
+      hash256hex(OUTPOINT_A),
+    );
+  });
+
+  it('prevouts override: hashPrevouts = hash256(concat(prevouts)), outpoint defaults to first prevout', () => {
+    const result = buildStatefulPreimage({
+      ...baseParams(),
+      prevouts: [OUTPOINT_A, OUTPOINT_B],
+    });
+    expect(preimageOutpoint(result.preimageHex)).toBe(OUTPOINT_A);
+    expect(preimageHashPrevouts(result.preimageHex)).toBe(
+      hash256hex(OUTPOINT_A + OUTPOINT_B),
+    );
+  });
+
+  it('outpoint + prevouts: spent input can be the second prevout', () => {
+    const result = buildStatefulPreimage({
+      ...baseParams(),
+      outpoint: OUTPOINT_B,
+      prevouts: [OUTPOINT_A, OUTPOINT_B],
+    });
+    expect(preimageOutpoint(result.preimageHex)).toBe(OUTPOINT_B);
+    expect(preimageHashPrevouts(result.preimageHex)).toBe(
+      hash256hex(OUTPOINT_A + OUTPOINT_B),
+    );
+  });
+
+  it('default call is byte-identical to the pre-override behaviour', () => {
+    const legacy = buildStatefulPreimage(baseParams());
+    const explicit = buildStatefulPreimage({
+      ...baseParams(),
+      outpoint: DUMMY_OUTPOINT,
+      prevouts: [DUMMY_OUTPOINT],
+    });
+    expect(explicit.preimageHex).toBe(legacy.preimageHex);
+    expect(explicit.signatureHex).toBe(legacy.signatureHex);
+  });
+
+  it('rejects malformed outpoint / prevouts', () => {
+    expect(() =>
+      buildStatefulPreimage({ ...baseParams(), outpoint: 'aa'.repeat(32) }),
+    ).toThrow(/72 hex chars/);
+    expect(() =>
+      buildStatefulPreimage({
+        ...baseParams(),
+        prevouts: [OUTPOINT_A, 'zz'.repeat(36)],
+      }),
+    ).toThrow(/prevouts\[1\]/);
+    expect(() =>
+      buildStatefulPreimage({ ...baseParams(), prevouts: [] }),
+    ).toThrow(/must not be empty/);
+  });
+});

--- a/packages/runar-testing/src/__tests__/test-smart-contract-baking.test.ts
+++ b/packages/runar-testing/src/__tests__/test-smart-contract-baking.test.ts
@@ -1,0 +1,134 @@
+/**
+ * TestSmartContract.fromArtifact constructor-arg baking — previously the
+ * wrapper stored `constructorArgs` but executed the RAW placeholder script,
+ * so any contract whose readonly props are baked at deploy failed with
+ * `OP_EQUALVERIFY failed` (comparing against an OP_0 placeholder).
+ *
+ * Now `constructorSlots` substitution is applied, mirroring runar-sdk's
+ * `RunarContract.buildCodeScript`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import { compile } from 'runar-compiler';
+import {
+  TestSmartContract,
+  expectScriptSuccess,
+  expectScriptFailure,
+} from '../helpers.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Referenced readonly Sha256 — the exact shape that used to fail. */
+const HASH_LOCK_SOURCE = `
+class HashLock extends SmartContract {
+  readonly hashValue: Sha256;
+
+  constructor(hashValue: Sha256) {
+    super(hashValue);
+    this.hashValue = hashValue;
+  }
+
+  public unlock(preimage: ByteString) {
+    assert(sha256(preimage) === this.hashValue);
+  }
+}
+`;
+
+/** Two constructor params: bigint + bytes. */
+const TWO_ARG_SOURCE = `
+class TwoArg extends SmartContract {
+  readonly target: bigint;
+  readonly tag: ByteString;
+
+  constructor(target: bigint, tag: ByteString) {
+    super(target, tag);
+    this.target = target;
+    this.tag = tag;
+  }
+
+  public check(x: bigint, t: ByteString) {
+    assert(x === this.target);
+    assert(t === this.tag);
+  }
+}
+`;
+
+const PREIMAGE_HEX = 'deadbeef';
+const HASH_HEX = createHash('sha256')
+  .update(Buffer.from(PREIMAGE_HEX, 'hex'))
+  .digest('hex');
+
+function compileUnbaked(source: string) {
+  const result = compile(source);
+  expect(result.success).toBe(true);
+  expect(result.artifact!.constructorSlots!.length).toBeGreaterThanOrEqual(1);
+  return result.artifact!;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TestSmartContract.fromArtifact bakes constructorArgs', () => {
+  it('referenced readonly Sha256 passes a VM call with the baked value', () => {
+    const artifact = compileUnbaked(HASH_LOCK_SOURCE);
+    const contract = TestSmartContract.fromArtifact(artifact, [HASH_HEX]);
+
+    // Previously: OP_EQUALVERIFY failed at PC~3 (placeholder OP_0 vs hash).
+    expectScriptSuccess(contract.call('unlock', [PREIMAGE_HEX]));
+  });
+
+  it('wrong preimage still fails against the baked value', () => {
+    const artifact = compileUnbaked(HASH_LOCK_SOURCE);
+    const contract = TestSmartContract.fromArtifact(artifact, [HASH_HEX]);
+
+    expectScriptFailure(contract.call('unlock', ['00112233']));
+  });
+
+  it('bakes multiple positional args (bigint + ByteString)', () => {
+    const artifact = compileUnbaked(TWO_ARG_SOURCE);
+    const contract = TestSmartContract.fromArtifact(artifact, [42n, 'cafe']);
+
+    expectScriptSuccess(contract.call('check', [42n, 'cafe']));
+    expectScriptFailure(contract.call('check', [43n, 'cafe']));
+    expectScriptFailure(contract.call('check', [42n, 'beef']));
+  });
+
+  it('getLockingScriptHex returns the baked script (no OP_0 placeholder)', () => {
+    const artifact = compileUnbaked(HASH_LOCK_SOURCE);
+    const contract = TestSmartContract.fromArtifact(artifact, [HASH_HEX]);
+
+    expect(contract.getLockingScriptHex()).toContain(HASH_HEX);
+    expect(contract.getLockingScriptHex()).not.toBe(artifact.script);
+  });
+
+  it('throws when constructorSlots exist but args are missing', () => {
+    const artifact = compileUnbaked(HASH_LOCK_SOURCE);
+    expect(() => TestSmartContract.fromArtifact(artifact, [])).toThrow(
+      /expects 1 constructor arg/,
+    );
+  });
+
+  it('throws on arg count mismatch', () => {
+    const artifact = compileUnbaked(TWO_ARG_SOURCE);
+    expect(() =>
+      TestSmartContract.fromArtifact(artifact, [42n]),
+    ).toThrow(/expects 2 constructor arg/);
+  });
+
+  it('accepts non-empty args when the artifact has no constructorSlots', () => {
+    // Compile with baked args — no slots remain; passing args again is fine
+    // (matches the pre-fix calling convention).
+    const result = compile(HASH_LOCK_SOURCE, {
+      constructorArgs: { hashValue: HASH_HEX },
+    });
+    expect(result.success).toBe(true);
+    const contract = TestSmartContract.fromArtifact(result.artifact!, [
+      HASH_HEX,
+    ]);
+    expectScriptSuccess(contract.call('unlock', [PREIMAGE_HEX]));
+  });
+});

--- a/packages/runar-testing/src/__tests__/test-smart-contract-baking.test.ts
+++ b/packages/runar-testing/src/__tests__/test-smart-contract-baking.test.ts
@@ -132,3 +132,113 @@ describe('TestSmartContract.fromArtifact bakes constructorArgs', () => {
     expectScriptSuccess(contract.call('unlock', [PREIMAGE_HEX]));
   });
 });
+
+// ---------------------------------------------------------------------------
+// codeSepIndexSlots baking — stateful contracts with variable-length state
+// fields carry OP_0 placeholders for the adjusted codeSeparatorIndex. The
+// original fix baked constructorSlots only, so the test script diverged
+// from the deployed bytes for these artifacts (test↔deploy fidelity gap).
+// ---------------------------------------------------------------------------
+
+/** Stateful + varlen ByteString state field → artifact.codeSepIndexSlots. */
+const VARLEN_STATE_SOURCE = `
+class VarState extends StatefulSmartContract {
+  owner: PubKey;
+  memo: ByteString;
+
+  readonly issuer: PubKey;
+  readonly bound: bigint;
+
+  constructor(owner: PubKey, memo: ByteString, issuer: PubKey, bound: bigint) {
+    super(owner, memo, issuer, bound);
+    this.owner = owner;
+    this.memo = memo;
+    this.issuer = issuer;
+    this.bound = bound;
+  }
+
+  public update(sig: Sig, newMemo: ByteString, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.owner));
+    assert(this.bound >= 1n);
+    assert(outputSatoshis >= 1n);
+    this.memo = newMemo;
+    this.addOutput(outputSatoshis, this.owner, this.memo);
+  }
+
+  public reclaim(sig: Sig, outputSatoshis: bigint) {
+    assert(checkSig(sig, this.issuer));
+    assert(outputSatoshis >= 1n);
+    this.addOutput(outputSatoshis, this.owner, this.memo);
+  }
+}
+`;
+
+const OWNER_PK = '02' + '11'.repeat(32);
+const ISSUER_PK = '03' + 'ab'.repeat(32);
+/** ctor args: [owner, memo, issuer, bound] */
+const VARLEN_ARGS: unknown[] = [OWNER_PK, 'aabbcc', ISSUER_PK, 5n];
+
+describe('TestSmartContract.fromArtifact bakes codeSepIndexSlots', () => {
+  const result = compile(VARLEN_STATE_SOURCE, { fileName: 'VarState.runar.ts' });
+  expect(result.success).toBe(true);
+  const artifact = result.artifact!;
+
+  it('fixture sanity: the artifact carries both slot kinds', () => {
+    expect(artifact.codeSepIndexSlots!.length).toBeGreaterThanOrEqual(1);
+    expect(artifact.constructorSlots!.length).toBeGreaterThanOrEqual(1);
+    for (const cs of artifact.codeSepIndexSlots!) {
+      expect(artifact.script.slice(cs.byteOffset * 2, cs.byteOffset * 2 + 2)).toBe('00');
+    }
+  });
+
+  it('baked script is byte-identical to runar-sdk buildResolvedCodeHex (deploy parity)', async () => {
+    // Cross-implementation oracle: the SDK's resolver is itself pinned
+    // byte-identical to RunarContract.getCodePartHex by its own suite.
+    const { buildResolvedCodeHex } = await import('runar-sdk');
+    const contract = TestSmartContract.fromArtifact(artifact, VARLEN_ARGS);
+    expect(contract.getLockingScriptHex().toLowerCase()).toBe(
+      buildResolvedCodeHex(artifact, VARLEN_ARGS).toLowerCase(),
+    );
+  });
+
+  it('substitutes every codeSepIndex placeholder (no OP_0 left at a slot)', () => {
+    const contract = TestSmartContract.fromArtifact(artifact, VARLEN_ARGS);
+    const baked = contract.getLockingScriptHex();
+    expect(baked).not.toBe(artifact.script);
+    // First codeSep slot precedes every constructor slot in this fixture, so
+    // its byte offset is unshifted; its codeSepIndex (6) bakes as OP_6.
+    const sortedSep = [...artifact.codeSepIndexSlots!].sort((a, b) => a.byteOffset - b.byteOffset);
+    const sortedCtor = [...artifact.constructorSlots!].sort((a, b) => a.byteOffset - b.byteOffset);
+    const first = sortedSep[0]!;
+    if (first.byteOffset < sortedCtor[0]!.byteOffset && first.codeSepIndex <= 16) {
+      expect(baked.slice(first.byteOffset * 2, first.byteOffset * 2 + 2)).toBe(
+        (0x50 + first.codeSepIndex).toString(16),
+      );
+    }
+  });
+
+  it('bakes codeSepIndexSlots even when constructor args were baked at compile time', async () => {
+    // Baked-args compile leaves no constructorSlots, but the codeSepIndex
+    // placeholders are always emitted for the SDK to fill.
+    const baked = compile(VARLEN_STATE_SOURCE, {
+      fileName: 'VarState.runar.ts',
+      constructorArgs: {
+        owner: OWNER_PK,
+        memo: 'aabbcc',
+        issuer: ISSUER_PK,
+        bound: 5n,
+      },
+    });
+    expect(baked.success).toBe(true);
+    const bakedArtifact = baked.artifact!;
+    expect(bakedArtifact.constructorSlots ?? []).toHaveLength(0);
+    expect(bakedArtifact.codeSepIndexSlots!.length).toBeGreaterThanOrEqual(1);
+
+    const { buildResolvedCodeHex } = await import('runar-sdk');
+    const contract = TestSmartContract.fromArtifact(bakedArtifact, []);
+    expect(contract.getLockingScriptHex().toLowerCase()).toBe(
+      buildResolvedCodeHex(bakedArtifact, []).toLowerCase(),
+    );
+    expect(contract.getLockingScriptHex()).not.toBe(bakedArtifact.script);
+  });
+});

--- a/packages/runar-testing/src/__tests__/vm-codeseparator.test.ts
+++ b/packages/runar-testing/src/__tests__/vm-codeseparator.test.ts
@@ -1,0 +1,109 @@
+/**
+ * OP_CODESEPARATOR (0xab) — previously the ScriptVM threw
+ * "Unknown or disabled opcode: 0xab", so compiled STATEFUL Rúnar contracts
+ * (which all carry a codeSeparator-trimmed scriptCode) could not be
+ * replayed in the in-house VM at all.
+ *
+ * Post-Genesis BSV semantics: during execution OP_CODESEPARATOR marks the
+ * position after itself as the scriptCode start for subsequent signature
+ * ops. With the mockable checkSigCallback this means: don't throw, track
+ * the offset, keep executing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from 'runar-compiler';
+import { ScriptVM } from '../vm/index.js';
+import { Opcode } from '../vm/opcodes.js';
+
+describe('ScriptVM OP_CODESEPARATOR', () => {
+  it('executes a script containing 0xab instead of throwing', () => {
+    // OP_1 OP_CODESEPARATOR OP_1 OP_ADD  =>  2
+    const vm = new ScriptVM();
+    const result = vm.executeHex('51ab5193');
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('tracks lastCodeSeparator as the offset after the separator', () => {
+    const vm = new ScriptVM();
+    expect(vm.lastCodeSeparator).toBe(-1);
+
+    // bytes: 0x51 @0, 0xab @1, 0x51 @2, 0x93 @3
+    const result = vm.executeHex('51ab5193');
+    expect(result.success).toBe(true);
+    expect(vm.lastCodeSeparator).toBe(2);
+  });
+
+  it('updates lastCodeSeparator on each executed separator', () => {
+    // OP_1 0xab OP_1 0xab OP_ADD => last separator at offset 3, start = 4
+    const vm = new ScriptVM();
+    const result = vm.executeHex('51ab51ab93');
+    expect(result.success).toBe(true);
+    expect(vm.lastCodeSeparator).toBe(4);
+  });
+
+  it('does not track a separator inside a non-executing branch', () => {
+    // OP_0 OP_IF 0xab OP_ENDIF OP_1
+    const vm = new ScriptVM();
+    const result = vm.executeHex('0063ab6851');
+    expect(result.success).toBe(true);
+    expect(vm.lastCodeSeparator).toBe(-1);
+  });
+
+  it('works before a mocked OP_CHECKSIG (stateful scriptCode shape)', () => {
+    // <sig> <pubkey> pushed by unlocking; locking: 0xab OP_CHECKSIG
+    const vm = new ScriptVM();
+    const unlocking = new Uint8Array([0x01, 0xaa, 0x01, 0xbb]); // push 0xaa, push 0xbb
+    const locking = new Uint8Array([Opcode.OP_CODESEPARATOR, Opcode.OP_CHECKSIG]);
+    const result = vm.execute(unlocking, locking);
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('step mode steps over OP_CODESEPARATOR without error', () => {
+    const vm = new ScriptVM();
+    vm.loadHex('', '51ab5193');
+
+    const opcodes: string[] = [];
+    let step = vm.step();
+    while (step !== null) {
+      expect(step.error).toBeUndefined();
+      opcodes.push(step.opcode);
+      step = vm.step();
+    }
+
+    expect(opcodes).toContain('OP_CODESEPARATOR');
+    expect(vm.isComplete).toBe(true);
+    expect(vm.isSuccess).toBe(true);
+    expect(vm.lastCodeSeparator).toBe(2);
+  });
+
+  it('a compiled stateful contract script no longer dies at 0xab', () => {
+    const source = `
+import { StatefulSmartContract, assert } from 'runar-lang';
+
+class Counter extends StatefulSmartContract {
+  count: bigint;
+
+  constructor(count: bigint) {
+    super(count);
+    this.count = count;
+  }
+
+  public increment() {
+    this.count++;
+  }
+}
+`;
+    const result = compile(source, { fileName: 'Counter.runar.ts' });
+    expect(result.success).toBe(true);
+    expect(result.scriptHex).toContain('ab');
+
+    // Without valid preimage args the script fails on its own asserts —
+    // but it must no longer fail with "Unknown or disabled opcode: 0xab".
+    const vm = new ScriptVM();
+    const vmResult = vm.executeHex(result.scriptHex!);
+    expect(vmResult.error ?? '').not.toMatch(/unknown or disabled opcode: 0xab/i);
+  });
+});

--- a/packages/runar-testing/src/helpers.ts
+++ b/packages/runar-testing/src/helpers.ts
@@ -23,6 +23,7 @@ export class TestSmartContract {
   private readonly artifact: RunarArtifact;
   readonly constructorArgs: unknown[];
   private readonly lockingScript: Uint8Array;
+  private readonly lockingScriptHex: string;
   private vmOptions: VMOptions;
 
   private constructor(
@@ -32,7 +33,11 @@ export class TestSmartContract {
   ) {
     this.artifact = artifact;
     this.constructorArgs = constructorArgs;
-    this.lockingScript = hexToBytes(artifact.script);
+    this.lockingScriptHex = bakeConstructorArgsIntoScript(
+      artifact,
+      constructorArgs,
+    );
+    this.lockingScript = hexToBytes(this.lockingScriptHex);
     this.vmOptions = vmOptions;
   }
 
@@ -75,10 +80,10 @@ export class TestSmartContract {
   }
 
   /**
-   * Get the locking script as a hex string.
+   * Get the locking script as a hex string (with constructor args baked in).
    */
   getLockingScriptHex(): string {
-    return this.artifact.script;
+    return this.lockingScriptHex;
   }
 
   /**
@@ -141,6 +146,91 @@ export class TestSmartContract {
   getContractName(): string {
     return this.artifact.contractName;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor arg baking
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the artifact's `constructorSlots` substitution so the locking script
+ * carries the real constructor values instead of OP_0 placeholders (mirrors
+ * runar-sdk's `RunarContract.buildCodeScript`).
+ *
+ * Previously `fromArtifact` stored `constructorArgs` but executed the raw
+ * placeholder script, so any comparison against a baked readonly value
+ * failed with `OP_EQUALVERIFY failed` and no hint as to why.
+ *
+ * - No `constructorSlots`: the raw script is returned unchanged. Passing
+ *   non-empty args is fine when the ABI declares constructor params —
+ *   unreferenced readonly properties are eliminated by the compiler and
+ *   simply have no placeholder to fill.
+ * - `constructorSlots` present: every slot's `paramIndex` must resolve to a
+ *   provided arg, and the arg count must match the ABI constructor's param
+ *   count; otherwise this throws instead of silently running placeholders.
+ */
+function bakeConstructorArgsIntoScript(
+  artifact: RunarArtifact,
+  constructorArgs: unknown[],
+): string {
+  const slots = artifact.constructorSlots;
+  if (!slots || slots.length === 0) {
+    return artifact.script;
+  }
+
+  const abiParams = artifact.abi.constructor?.params ?? [];
+  if (constructorArgs.length !== abiParams.length) {
+    throw new Error(
+      `TestSmartContract.fromArtifact: contract '${artifact.contractName}' ` +
+        `expects ${abiParams.length} constructor arg(s) ` +
+        `(${abiParams.map((p) => p.name).join(', ')}), got ${constructorArgs.length}`,
+    );
+  }
+
+  // Substitute in descending byte-offset order so earlier splices don't
+  // invalidate later offsets.
+  const sorted = [...slots].sort((a, b) => b.byteOffset - a.byteOffset);
+  let script = artifact.script;
+  for (const slot of sorted) {
+    const value = constructorArgs[slot.paramIndex];
+    if (value === undefined) {
+      const paramName = abiParams[slot.paramIndex]?.name ?? `#${slot.paramIndex}`;
+      throw new Error(
+        `TestSmartContract.fromArtifact: missing constructor arg '${paramName}' ` +
+          `(paramIndex ${slot.paramIndex}) required by a constructorSlot of ` +
+          `contract '${artifact.contractName}'`,
+      );
+    }
+    const encoded = encodeConstructorValueHex(value);
+    const hexOffset = slot.byteOffset * 2;
+    // Replace the 1-byte OP_0 placeholder (2 hex chars) with the encoded push.
+    script = script.slice(0, hexOffset) + encoded + script.slice(hexOffset + 2);
+  }
+  return script;
+}
+
+/**
+ * Encode a constructor value as a Bitcoin Script push element (hex).
+ * Mirrors runar-sdk's `encodeArg`.
+ */
+function encodeConstructorValueHex(value: unknown): string {
+  if (typeof value === 'bigint' || typeof value === 'number') {
+    const n = typeof value === 'bigint' ? value : BigInt(value);
+    if (n === 0n) return '00'; // OP_0
+    if (n >= 1n && n <= 16n) return (0x50 + Number(n)).toString(16); // OP_1..OP_16
+    if (n === -1n) return '4f'; // OP_1NEGATE
+    return bytesToHex(encodePushData(encodeScriptNumber(n)));
+  }
+  if (typeof value === 'boolean') {
+    return value ? '51' : '00';
+  }
+  if (typeof value === 'string') {
+    // Hex-encoded data (ByteString / PubKey / Sha256 / ...)
+    return bytesToHex(encodePushData(hexToBytes(value)));
+  }
+  throw new Error(
+    `TestSmartContract.fromArtifact: unsupported constructor arg type '${typeof value}'`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/runar-testing/src/helpers.ts
+++ b/packages/runar-testing/src/helpers.ts
@@ -153,33 +153,44 @@ export class TestSmartContract {
 // ---------------------------------------------------------------------------
 
 /**
- * Apply the artifact's `constructorSlots` substitution so the locking script
- * carries the real constructor values instead of OP_0 placeholders (mirrors
- * runar-sdk's `RunarContract.buildCodeScript`).
+ * Apply the artifact's `constructorSlots` AND `codeSepIndexSlots`
+ * substitutions so the locking script carries the real constructor values
+ * and adjusted codeSeparatorIndex values instead of OP_0 placeholders
+ * (mirrors runar-sdk's `RunarContract.buildCodeScript` exactly).
  *
  * Previously `fromArtifact` stored `constructorArgs` but executed the raw
  * placeholder script, so any comparison against a baked readonly value
- * failed with `OP_EQUALVERIFY failed` and no hint as to why.
+ * failed with `OP_EQUALVERIFY failed` and no hint as to why. The first fix
+ * baked `constructorSlots` only; `codeSepIndexSlots` (emitted for stateful
+ * contracts with variable-length state fields) were still left as OP_0,
+ * diverging from the deployed script bytes.
  *
- * - No `constructorSlots`: the raw script is returned unchanged. Passing
- *   non-empty args is fine when the ABI declares constructor params —
- *   unreferenced readonly properties are eliminated by the compiler and
- *   simply have no placeholder to fill.
+ * - No `constructorSlots` and no `codeSepIndexSlots`: the raw script is
+ *   returned unchanged. Passing non-empty args is fine when the ABI
+ *   declares constructor params — unreferenced readonly properties are
+ *   eliminated by the compiler and simply have no placeholder to fill.
  * - `constructorSlots` present: every slot's `paramIndex` must resolve to a
  *   provided arg, and the arg count must match the ABI constructor's param
  *   count; otherwise this throws instead of silently running placeholders.
+ * - `codeSepIndexSlots` present: each OP_0 placeholder is replaced with the
+ *   adjusted codeSeparatorIndex (template index shifted by constructor-arg
+ *   expansion and earlier codeSepIndex slot expansions), exactly as the
+ *   SDK does at deploy time.
  */
 function bakeConstructorArgsIntoScript(
   artifact: RunarArtifact,
   constructorArgs: unknown[],
 ): string {
   const slots = artifact.constructorSlots;
-  if (!slots || slots.length === 0) {
+  const hasConstructorSlots = !!slots && slots.length > 0;
+  const hasCodeSepSlots =
+    !!artifact.codeSepIndexSlots && artifact.codeSepIndexSlots.length > 0;
+  if (!hasConstructorSlots && !hasCodeSepSlots) {
     return artifact.script;
   }
 
   const abiParams = artifact.abi.constructor?.params ?? [];
-  if (constructorArgs.length !== abiParams.length) {
+  if (hasConstructorSlots && constructorArgs.length !== abiParams.length) {
     throw new Error(
       `TestSmartContract.fromArtifact: contract '${artifact.contractName}' ` +
         `expects ${abiParams.length} constructor arg(s) ` +
@@ -187,26 +198,96 @@ function bakeConstructorArgsIntoScript(
     );
   }
 
+  type Substitution = { byteOffset: number; encoded: string };
+  const subs: Substitution[] = [];
+
+  if (hasConstructorSlots) {
+    for (const slot of slots!) {
+      const value = constructorArgs[slot.paramIndex];
+      if (value === undefined) {
+        const paramName = abiParams[slot.paramIndex]?.name ?? `#${slot.paramIndex}`;
+        throw new Error(
+          `TestSmartContract.fromArtifact: missing constructor arg '${paramName}' ` +
+            `(paramIndex ${slot.paramIndex}) required by a constructorSlot of ` +
+            `contract '${artifact.contractName}'`,
+        );
+      }
+      subs.push({
+        byteOffset: slot.byteOffset,
+        encoded: encodeConstructorValueHex(value),
+      });
+    }
+  }
+
+  if (hasCodeSepSlots) {
+    for (const rs of resolvedCodeSepSlotValues(artifact, constructorArgs)) {
+      subs.push({
+        byteOffset: rs.templateByteOffset,
+        encoded: encodeConstructorValueHex(BigInt(rs.adjustedValue)),
+      });
+    }
+  }
+
   // Substitute in descending byte-offset order so earlier splices don't
   // invalidate later offsets.
-  const sorted = [...slots].sort((a, b) => b.byteOffset - a.byteOffset);
+  subs.sort((a, b) => b.byteOffset - a.byteOffset);
   let script = artifact.script;
-  for (const slot of sorted) {
-    const value = constructorArgs[slot.paramIndex];
-    if (value === undefined) {
-      const paramName = abiParams[slot.paramIndex]?.name ?? `#${slot.paramIndex}`;
-      throw new Error(
-        `TestSmartContract.fromArtifact: missing constructor arg '${paramName}' ` +
-          `(paramIndex ${slot.paramIndex}) required by a constructorSlot of ` +
-          `contract '${artifact.contractName}'`,
-      );
-    }
-    const encoded = encodeConstructorValueHex(value);
-    const hexOffset = slot.byteOffset * 2;
+  for (const sub of subs) {
+    const hexOffset = sub.byteOffset * 2;
     // Replace the 1-byte OP_0 placeholder (2 hex chars) with the encoded push.
-    script = script.slice(0, hexOffset) + encoded + script.slice(hexOffset + 2);
+    script = script.slice(0, hexOffset) + sub.encoded + script.slice(hexOffset + 2);
   }
   return script;
+}
+
+/**
+ * Resolve the adjusted codeSep index values for all codeSepIndex slots,
+ * processing them in ascending template byte-offset order so that each
+ * slot's value correctly accounts for earlier slots' expansions.
+ *
+ * Mirror of runar-sdk `RunarContract._resolvedCodeSepSlotValues` — a pure
+ * function of (artifact, constructorArgs). `encodeConstructorValueHex`
+ * encodes bigints identically to the SDK's `encodeScriptNumber`
+ * (OP_0 / OP_1..OP_16 / OP_1NEGATE / sign-magnitude LE push), so the
+ * computed shifts are byte-exact.
+ */
+function resolvedCodeSepSlotValues(
+  artifact: RunarArtifact,
+  constructorArgs: unknown[],
+): Array<{ templateByteOffset: number; adjustedValue: number }> {
+  if (!artifact.codeSepIndexSlots || artifact.codeSepIndexSlots.length === 0) {
+    return [];
+  }
+  // Sort by template byte offset ascending (left-to-right in the script)
+  const sorted = [...artifact.codeSepIndexSlots].sort(
+    (a, b) => a.byteOffset - b.byteOffset,
+  );
+  const result: Array<{ templateByteOffset: number; adjustedValue: number }> = [];
+  for (const slot of sorted) {
+    // Compute the fully-adjusted codeSep index: constructor expansion +
+    // expansion from earlier codeSepIndex slots that precede this slot's
+    // codeSepIndex.
+    let shift = 0;
+    if (artifact.constructorSlots) {
+      for (const cs of artifact.constructorSlots) {
+        if (cs.byteOffset < slot.codeSepIndex) {
+          const encoded = encodeConstructorValueHex(constructorArgs[cs.paramIndex]);
+          shift += encoded.length / 2 - 1;
+        }
+      }
+    }
+    for (const prev of result) {
+      if (prev.templateByteOffset < slot.codeSepIndex) {
+        const prevEncoded = encodeConstructorValueHex(BigInt(prev.adjustedValue));
+        shift += prevEncoded.length / 2 - 1;
+      }
+    }
+    result.push({
+      templateByteOffset: slot.byteOffset,
+      adjustedValue: slot.codeSepIndex + shift,
+    });
+  }
+  return result;
 }
 
 /**

--- a/packages/runar-testing/src/mock-preimage.ts
+++ b/packages/runar-testing/src/mock-preimage.ts
@@ -44,6 +44,20 @@ export interface StatefulPreimageParams {
   version?: number;
   locktime?: number;
   sequence?: number;
+  /**
+   * Outpoint of the input being spent (72 hex chars: 32-byte txid +
+   * 4-byte LE vout). Defaults to the first entry of `prevouts` when that
+   * is given, otherwise to 36 zero bytes (legacy behaviour).
+   */
+  outpoint?: string;
+  /**
+   * All input outpoints of the spending transaction, in input order
+   * (each 72 hex chars). When given,
+   * `hashPrevouts = hash256(concat(prevouts))`, enabling multi-input
+   * covenant tests (`extractHashPrevouts` / companion-input checks).
+   * Defaults to `[outpoint]` (single-input, legacy behaviour).
+   */
+  prevouts?: string[];
 }
 
 export interface StatefulPreimageResult {
@@ -361,7 +375,29 @@ export function buildStatefulPreimage(
     version = 1,
     locktime = 0,
     sequence = 0xffffffff,
+    outpoint,
+    prevouts,
   } = params;
+
+  // Validate outpoint / prevouts overrides (72 hex chars = 36 bytes each).
+  const OUTPOINT_RE = /^[0-9a-fA-F]{72}$/;
+  if (outpoint !== undefined && !OUTPOINT_RE.test(outpoint)) {
+    throw new Error(
+      `buildStatefulPreimage: outpoint must be 72 hex chars (32-byte txid + 4-byte LE vout), got ${outpoint.length} chars`,
+    );
+  }
+  if (prevouts !== undefined) {
+    if (prevouts.length === 0) {
+      throw new Error('buildStatefulPreimage: prevouts must not be empty');
+    }
+    for (const [idx, po] of prevouts.entries()) {
+      if (!OUTPOINT_RE.test(po)) {
+        throw new Error(
+          `buildStatefulPreimage: prevouts[${idx}] must be 72 hex chars (32-byte txid + 4-byte LE vout), got ${po.length} chars`,
+        );
+      }
+    }
+  }
 
   // Build code part and full locking script
   const codePart = buildCodePart(artifact, constructorArgs);
@@ -421,11 +457,18 @@ export function buildStatefulPreimage(
 
   const nVersion = uint32LE(version);
 
-  // Dummy outpoint: 32 zero bytes (txid) + 00000000 (vout 0)
-  const dummyOutpoint = '00'.repeat(32) + '00000000';
+  // Outpoint of the input being spent. Default: first prevout when given,
+  // otherwise 32 zero bytes (txid) + 00000000 (vout 0) — legacy behaviour.
+  const spentOutpoint = (
+    outpoint ?? prevouts?.[0] ?? '00'.repeat(32) + '00000000'
+  ).toLowerCase();
 
-  // hashPrevouts = hash256(outpoint)
-  const hashPrevouts = bytesToHex(hash256(hexToBytes(dummyOutpoint)));
+  // hashPrevouts = hash256(concat(all input outpoints)).
+  // Default (single input): hash256(spent outpoint).
+  const prevoutsHex = prevouts
+    ? prevouts.join('').toLowerCase()
+    : spentOutpoint;
+  const hashPrevouts = bytesToHex(hash256(hexToBytes(prevoutsHex)));
 
   // hashSequence = hash256(sequence as 4-byte LE)
   const hashSequence = bytesToHex(hash256(hexToBytes(uint32LE(sequence))));
@@ -450,7 +493,7 @@ export function buildStatefulPreimage(
     nVersion +
     hashPrevouts +
     hashSequence +
-    dummyOutpoint +
+    spentOutpoint +
     scriptCodePrefixed +
     amountHex +
     nSequence +

--- a/packages/runar-testing/src/vm/opcodes.ts
+++ b/packages/runar-testing/src/vm/opcodes.ts
@@ -126,6 +126,7 @@ export enum Opcode {
   OP_SHA256 = 0xa8,
   OP_HASH160 = 0xa9,
   OP_HASH256 = 0xaa,
+  OP_CODESEPARATOR = 0xab,
   OP_CHECKSIG = 0xac,
   OP_CHECKSIGVERIFY = 0xad,
   OP_CHECKMULTISIG = 0xae,

--- a/packages/runar-testing/src/vm/script-vm.ts
+++ b/packages/runar-testing/src/vm/script-vm.ts
@@ -96,6 +96,15 @@ export class ScriptVM {
   private ifStack: boolean[] = [];
   private opsExecuted = 0;
   private maxStackDepth = 0;
+  /**
+   * Byte offset just AFTER the most recently executed OP_CODESEPARATOR in
+   * the currently running script, or -1 if none has executed. Post-Genesis
+   * BSV semantics: this marks where scriptCode starts for subsequent
+   * signature operations. With the mockable checkSigCallback the offset is
+   * informational — it is tracked and exposed so callers (and a future
+   * real-sighash mode) can compute the trimmed subscript.
+   */
+  private _lastCodeSeparator = -1;
 
   private readonly maxOps: number;
   private readonly maxStackSize: number;
@@ -302,6 +311,14 @@ export class ScriptVM {
   get isSuccess(): boolean { return this._isSuccess; }
 
   /**
+   * Byte offset just after the most recently executed OP_CODESEPARATOR in
+   * the currently running script (-1 if none executed yet). This is the
+   * scriptCode start position for subsequent signature ops per post-Genesis
+   * BSV semantics.
+   */
+  get lastCodeSeparator(): number { return this._lastCodeSeparator; }
+
+  /**
    * Get a human-readable name for the opcode at the given position.
    */
   private getOpcodeName(byte: number): string {
@@ -410,6 +427,15 @@ export class ScriptVM {
     // Skip non-executing opcodes
     if (!this.isExecuting()) return i;
 
+    // OP_CODESEPARATOR: track the scriptCode start position relative to the
+    // CURRENT script (handled here rather than via the single-byte
+    // delegation below, which would lose the real byte offset).
+    if (byte === Opcode.OP_CODESEPARATOR) {
+      this.countOp();
+      this._lastCodeSeparator = i;
+      return i;
+    }
+
     // All remaining opcodes: delegate to runScript on a single-byte script.
     // Save and restore ifStack to bypass the end-of-script balance check.
     const savedIfStack = [...this.ifStack];
@@ -439,6 +465,7 @@ export class ScriptVM {
     this._isComplete = false;
     this._isSuccess = false;
     this._stepError = undefined;
+    this._lastCodeSeparator = -1;
   }
 
   // -------------------------------------------------------------------------
@@ -1352,6 +1379,19 @@ export class ScriptVM {
           const sha1 = createHash('sha256').update(data).digest();
           const sha2 = createHash('sha256').update(sha1).digest();
           this.push(new Uint8Array(sha2));
+          continue;
+        }
+
+        // OP_CODESEPARATOR (0xab) — post-Genesis BSV semantics: marks the
+        // position after itself as the new scriptCode start for subsequent
+        // signature operations. Execution continues; no stack effect.
+        // The offset is tracked so callers (and the mockable checkSig path)
+        // can compute the trimmed subscript. Compiled STATEFUL Rúnar
+        // contracts all carry an OP_CODESEPARATOR, so the VM must not
+        // reject it as unknown.
+        if (byte === Opcode.OP_CODESEPARATOR) {
+          this.countOp();
+          this._lastCodeSeparator = i;
           continue;
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       fast-check:
         specifier: ^3.22.0
         version: 3.23.2
+      runar-sdk:
+        specifier: workspace:*
+        version: link:../runar-sdk
       typescript:
         specifier: ^5.6.0
         version: 5.9.3


### PR DESCRIPTION
**Stacked on #113 and #114** — this branch contains those PRs' six commits plus five new commits (`45ab252`, `fe8fe26`, `d9785a1`, `988a2f1`, `179faec`, each reviewable independently); only those five are new here. Will rebase as the earlier PRs merge. Together the three PRs complete one story: a contract that verifies the attributes of a *companion input* (another covenant spent in the same transaction) by parsing that companion's parent transaction in Script — no oracle, no indexer, and now no hand-derived byte offsets.

## The gap

Writing a companion-input verifier today means hand-deriving layout facts from compiled bytes: where each constructor slot sits, how wide its push encoding is (which is value-dependent — a bigint bakes as OP_N for 1..16 but a 2-byte push at 17, silently shifting every downstream offset), how state fields are laid out, and what the contract's slot-excised template hash is. Those derivations are per-contract heroics and break invisibly when a value crosses an encoding boundary.

## Change, commit by commit

### `45ab252` — feat(artifact): verification descriptors

Makes the layout facts machine-readable, split by what depends on deploy-time values:

- **Value-independent (compiler emits):** `ConstructorSlot` gains optional `name`, `type`, `valueEncoding` (`data|scriptnum|bool`) and, for fixed-size types, `fixedValueByteLength` + `fixedPushHeaderBytes`. `StateField` gains byte-layout annotations (`encoding`, `byteOffset`, `byteLength`, `tailOffset`) mirroring `serializeState` exactly, driven by a new shared `STATE_FIELD_WIDTHS` table in `runar-ir-schema` that the SDK state codec now also uses — the two layouts cannot drift. New artifact field `templateDigest`: a hash256-excised-slots recipe for recomputing the slot-excised template identity hash.
- **Value-dependent (SDK resolves):** new `runar-sdk` module `slot-layout.ts` — `resolveSlotLayout(artifact, args)` (concrete offsets/lengths and encoding class, with the OP_N / OP_0 / OP_1NEGATE / pushdata boundaries handled explicitly), `computeTemplateHash(artifact, args)`, `buildResolvedCodeHex(artifact, args)`, `resolveStateLayout(artifact)`.

All fields are additive and optional — existing consumers and existing artifacts are unaffected. Tests include an SDK parity suite proving `resolveSlotLayout`/`computeTemplateHash` reproduce exactly the values an independent indexOf/two-bake-diff oracle derives, including the encoding boundaries.

### `fe8fe26` — feat(compiler): `requireBaked` compile option

A readonly property that no method references is silently eliminated from the compiled script; its value then exists nowhere in the deployed UTXO and cannot be verified on-chain by any downstream contract. `CompileOptions.requireBaked: string[]` turns that silent elimination into a compile error (names must exist, be readonly, be referenced by a method body — checked on the post-bake, pre-fold ANF so template and baked modes behave identically; belt-and-braces slot check in template mode). Deliberately a compile **option**, not a `verifiable` keyword: a new modifier would be a parser change across all nine language front-ends; the option delivers the same guarantee with a far smaller surface. 7 new tests; full compiler suite green.

### `d9785a1` — fix(sdk,testing): harden descriptor resolution, complete TestSmartContract baking

Security-review hardening before exposing the above: (a) `collectSubstitutions` asserts the template script actually carries the 1-byte OP_0 placeholder at every constructor and codeSepIndex slot offset before splicing — corrupted/mismatched artifact descriptors now throw instead of silently producing a wrong layout and wrong template hash; (b) an enriched `ConstructorSlot.name` must match the ABI constructor param at its `paramIndex` — a swapped/forged name field throws; (c) `TestSmartContract.fromArtifact` baking now also substitutes `codeSepIndexSlots` exactly as `RunarContract.buildCodeScript` does, closing the remaining test-vs-deploy byte divergence for stateful artifacts with variable-length state fields. Negative tests for each, plus byte-parity tests pinning `TestSmartContract` baking to `buildResolvedCodeHex` for template-mode and compile-baked artifacts.

### `988a2f1` — docs(examples): companion-verifier example

`examples/ts/companion-verifier/` — a two-contract teaching example of the full pattern:

- `AttributedToken.runar.ts`: a token whose immutable attributes (attestor pubkey, category enum) are baked as constructor slots and inherited byte-for-byte across splits; documents the fixed-width slot encoding rules and the "referenced attributes only" load-bearing rule (which `requireBaked` now enforces).
- `CompanionVerifier.runar.ts`: the seven normative steps — prevouts binding, positional convention, parent binding, bounded structural walk, slot-excised template identity, attribute extraction + predicate, terminal output binding — with sign-safe `bin2num` discipline throughout.
- `CompanionVerifier.test.ts`: 17 cases in the token-ft/cross-covenant conventions (TestContract, ALICE/BOB/CHARLIE keys) — accept battery plus adversarial: multi-input parents, second allowlisted attestor, rogue attestor, counterfeit template planting an allowlisted key, tampered parent tx, tampered prevouts, wrong category, min-amount, retired status, wrong vout, >3-input parent, short-script marker.
- Layout constants are derived via `resolveSlotLayout`/`computeTemplateHash` — the example dogfoods the descriptor APIs instead of hand-counting offsets.
- Registered the cross-covenant way: auto-run by CI's `npx vitest run examples/ts/`, cross-referenced from `docs/cross-covenant-pattern.md` as the stronger companion-input form of the output-reference pattern.

### `179faec` — test(decompiler): align constructor-slot expectations with descriptors

The decompiler suites asserted the bare `{ paramIndex, byteOffset }` slot shape; they now expect the enriched shape, and the decompile→recompile round-trip comparisons ignore only the `name` field (recovered sources declare synthetic `propN` names — the name is source metadata, not byte-derivable; every byte-level field still round-trips).

## Cross-tier scoping (disclosure)

The example is TS-only for now: the bounded multi-input walk needs the outer-scope-refs-across-unrolled-loops stack-lowering fix (in #113), which the Go/Rust tiers do not carry yet (they fail with `value 'inCount' not found on stack`). Tracked exclusions with justifications were added using the repo's own mechanisms — `TS_ONLY_EXAMPLES` in `cross-compiler.test.ts` and `ZIG_PORT_PENDING` in `zig-parser-examples.test.ts` — to be removed when the loop-scope fix is ported to the other tiers. Descriptor **schema** fields are additive in `runar-ir-schema` (shared JSON schema updated); non-TS compilers ignore them safely and can adopt the enrichment incrementally. Happy to port both alongside the loop fix as follow-ups.

## Tests

- Compiler descriptor emission suite (enrichment, elimination, state layout, digest recipe, JSON schema validation) + SDK parity suite: 7/7 descriptor cases.
- `requireBaked`: 7 new tests.
- Hardening: corrupted placeholder byte, out-of-range offset, swapped slot names, corrupted codeSep placeholder, un-enriched slot acceptance, byte-parity suites.
- Example: 17/17, runs in CI's examples pass.
- Full repo TS suite (`npx vitest run`, packages + conformance + examples) re-run green on this branch immediately before filing: **7,378 passed, 0 failed** (202 skipped).

## Field evidence

The pattern this enables (verifier + attributed token composed in one tx, layout facts from descriptors) is proven on public BSV mainnet — consuming tx `8d96b792e6b6f376f0cc93728f62509e5594fd8cbab7f52d7b4ce0f52df8e0f1`.
