### PR TITLE
fix(testing): use the SDK's encodeArg for mock-preimage constructor args

### DIFF
--- a/packages/runar-compiler/src/__tests__/constructor-args-validation.test.ts
+++ b/packages/runar-compiler/src/__tests__/constructor-args-validation.test.ts
@@ -1,0 +1,123 @@
+/**
+ * constructorArgs shape validation — `compile(opts.constructorArgs)` must
+ * reject inputs that would silently bake nothing and emit placeholder
+ * scripts that fail opaquely at runtime:
+ *
+ *  (a) positional arrays (natural guess, but keys match no property names)
+ *  (b) keys that don't match any contract property (typos)
+ *  (c) referenced readonly properties left unbaked after applying the args
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from '../index.js';
+
+// ---------------------------------------------------------------------------
+// Contract sources
+// ---------------------------------------------------------------------------
+
+const HASH_LOCK_SOURCE = `
+class HashLock extends SmartContract {
+  readonly hashValue: Sha256;
+
+  constructor(hashValue: Sha256) {
+    super(hashValue);
+    this.hashValue = hashValue;
+  }
+
+  public unlock(preimage: ByteString) {
+    assert(sha256(preimage) === this.hashValue);
+  }
+}
+`;
+
+const TWO_PROP_SOURCE = `
+class TwoProp extends SmartContract {
+  readonly target: bigint;
+  readonly unused: bigint;
+
+  constructor(target: bigint, unused: bigint) {
+    super(target, unused);
+    this.target = target;
+    this.unused = unused;
+  }
+
+  public check(x: bigint) {
+    assert(x === this.target);
+  }
+}
+`;
+
+const HASH = 'aa'.repeat(32);
+
+function errorMessages(result: ReturnType<typeof compile>): string {
+  return result.diagnostics
+    .filter((d) => d.severity === 'error')
+    .map((d) => d.message)
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('constructorArgs validation', () => {
+  it('rejects a positional array with a diagnostic error', () => {
+    const result = compile(HASH_LOCK_SOURCE, {
+      // Positional array — the shape RunarContract/TestSmartContract take,
+      // but NOT what compile() takes. Previously baked nothing silently.
+      constructorArgs: [HASH] as unknown as Record<string, string>,
+    });
+
+    expect(result.success).toBe(false);
+    expect(errorMessages(result)).toMatch(/positional array/i);
+  });
+
+  it('rejects keys that match no contract property', () => {
+    const result = compile(HASH_LOCK_SOURCE, {
+      constructorArgs: { hashVal: HASH }, // typo: hashValue
+    });
+
+    expect(result.success).toBe(false);
+    const msgs = errorMessages(result);
+    expect(msgs).toContain("'hashVal'");
+    expect(msgs).toContain('hashValue');
+  });
+
+  it('rejects when a referenced readonly property remains unbaked', () => {
+    const result = compile(TWO_PROP_SOURCE, {
+      // 'target' is referenced by check() but not provided.
+      constructorArgs: { unused: 1n },
+    });
+
+    expect(result.success).toBe(false);
+    expect(errorMessages(result)).toMatch(/'target'.*placeholder/s);
+  });
+
+  it('accepts an unreferenced readonly property left unbaked', () => {
+    // 'unused' is never referenced by a method — DCE eliminates it, so
+    // leaving it unbaked is fine.
+    const result = compile(TWO_PROP_SOURCE, {
+      constructorArgs: { target: 42n },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.scriptHex).toBeDefined();
+  });
+
+  it('accepts a complete named record (baked script, no slots)', () => {
+    const result = compile(HASH_LOCK_SOURCE, {
+      constructorArgs: { hashValue: HASH },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.artifact!.script).toContain(HASH);
+    const slots = result.artifact!.constructorSlots;
+    expect(slots === undefined || slots.length === 0).toBe(true);
+  });
+
+  it('still compiles placeholder artifacts when no constructorArgs given', () => {
+    const result = compile(HASH_LOCK_SOURCE);
+    expect(result.success).toBe(true);
+    expect(result.artifact!.constructorSlots!.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/runar-compiler/src/__tests__/loop-outer-refs.test.ts
+++ b/packages/runar-compiler/src/__tests__/loop-outer-refs.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Stack lowering across unrolled for-loops — outer-scope refs (method
+ * params, pre-loop consts) must survive loop unrolling:
+ *
+ *  (a) a const defined before a loop and referenced inside it (including
+ *      only inside a nested if-branch) failed compilation with
+ *      "Value 'X' not found on stack" — the first iteration consumed it;
+ *  (b) worse, a method PARAM referenced after an unrolled loop whose body
+ *      also references it was silently lowered to an empty push (OP_0):
+ *      compilation succeeded, the env-based interpreter passed, but the
+ *      emitted Script failed at runtime (silent interpreter<->Script
+ *      divergence).
+ *
+ * The fix: lowerLoop collects outer refs deeply (nested branches included)
+ * and protects them in non-final iterations, and in the final iteration
+ * whenever the enclosing scope still references them after the loop. The
+ * old silent OP_0 fallbacks are now hard errors.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile, compileFromANF } from '../index.js';
+import type { ANFProgram } from '../ir/index.js';
+
+// ---------------------------------------------------------------------------
+// Sources
+// ---------------------------------------------------------------------------
+
+/** V003 repro: multi-input tx walk — param `data` used inside AND after the loop. */
+const LOOP_WALK_SOURCE = `
+import { SmartContract, assert, substr, cat, bin2num } from 'runar-lang';
+import type { ByteString } from 'runar-lang';
+
+class LoopWalk extends SmartContract {
+  readonly pad00: ByteString = "00" as ByteString;
+
+  constructor() {
+    super();
+  }
+
+  public walk(data: ByteString) {
+    let off = 5n;
+    for (let i = 0n; i < 3n; i++) {
+      if (i < bin2num(cat(substr(data, 4n, 1n), this.pad00))) {
+        const sl = bin2num(cat(substr(data, off + 36n, 1n), this.pad00));
+        assert(sl < 253n);
+        off = off + 36n + 1n + sl + 4n;
+      }
+    }
+    const tail = bin2num(cat(substr(data, off, 1n), this.pad00));
+    assert(tail === 7n);
+  }
+}
+`;
+
+/** Symptom (a): const defined before the loop, referenced inside it. */
+const CONST_BEFORE_LOOP_SOURCE = `
+import { SmartContract, assert, substr, cat, bin2num } from 'runar-lang';
+import type { ByteString } from 'runar-lang';
+
+class ConstLoop extends SmartContract {
+  readonly pad00: ByteString = "00" as ByteString;
+
+  constructor() {
+    super();
+  }
+
+  public probe(data: ByteString) {
+    const base = 5n;
+    let acc = 0n;
+    for (let i = 0n; i < 3n; i++) {
+      const b = bin2num(cat(substr(data, base + i, 1n), this.pad00));
+      acc = acc + b;
+    }
+    assert(acc === 6n);
+  }
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('stack lowering: outer refs across unrolled loops', () => {
+  it('param referenced after a loop is not lowered to an empty push', () => {
+    const result = compile(LOOP_WALK_SOURCE, { fileName: 'LoopWalk.runar.ts' });
+    expect(result.success).toBe(true);
+
+    // The post-loop code (after the last OP_ENDIF) reads `data` via
+    // substr(data, off, 1n). With the bug, `data` was emitted as OP_0
+    // right after the final OP_ENDIF; fixed code brings the real param up.
+    const asm = result.scriptAsm!;
+    const postLoop = asm.slice(asm.lastIndexOf('OP_ENDIF'));
+    expect(postLoop).not.toContain('OP_0');
+  });
+
+  it('const defined before a loop and referenced inside compiles', () => {
+    const result = compile(CONST_BEFORE_LOOP_SOURCE, {
+      fileName: 'ConstLoop.runar.ts',
+    });
+    // Previously: "Value 'base' not found on stack (...)"
+    expect(result.success).toBe(true);
+    expect(result.scriptHex).toBeDefined();
+  });
+
+  it('a load_param that cannot be satisfied is a loud error, not OP_0', () => {
+    // Hand-written ANF referencing a parameter the method does not have —
+    // the old code silently emitted OP_0 here.
+    const program: ANFProgram = {
+      contractName: 'Broken',
+      properties: [],
+      methods: [
+        {
+          name: 'run',
+          isPublic: true,
+          params: [{ name: 'x', type: 'bigint' }],
+          body: [
+            { name: 't0', value: { kind: 'load_param', name: 'ghost' } },
+            { name: 't1', value: { kind: 'assert', value: 't0' } },
+          ],
+        },
+      ],
+    };
+
+    expect(() => compileFromANF(program)).toThrow(
+      /Refusing to emit a silent OP_0/,
+    );
+  });
+});

--- a/packages/runar-compiler/src/index.ts
+++ b/packages/runar-compiler/src/index.ts
@@ -68,9 +68,10 @@ import { emit } from './passes/06-emit.js';
 import { optimizeStackIR } from './optimizer/peephole.js';
 import { optimizeEC } from './optimizer/anf-ec.js';
 import { foldConstants } from './optimizer/constant-fold.js';
+import { eliminateDeadBindings } from './optimizer/dce.js';
 import { assembleArtifact } from './artifact/assembler.js';
 import type { CompilerDiagnostic } from './errors.js';
-import type { ContractNode, ANFProgram, RunarArtifact } from './ir/index.js';
+import type { ContractNode, ANFProgram, ANFBinding, RunarArtifact } from './ir/index.js';
 import { InputLimits, CanonicalJsonError } from 'runar-ir-schema';
 
 // ---------------------------------------------------------------------------
@@ -325,10 +326,36 @@ export function compile(source: string, options?: CompileOptions): CompileResult
   // Bake constructor args into ANF properties so stack lowering emits real
   // values instead of OP_0 placeholders.
   if (opts.constructorArgs) {
+    const shapeErrors = validateConstructorArgsShape(anf, opts.constructorArgs);
+    if (shapeErrors.length > 0) {
+      for (const msg of shapeErrors) {
+        diagnostics.push({ message: msg, severity: 'error' } as CompilerDiagnostic);
+      }
+      return {
+        anf: null,
+        contract: parseResult.contract,
+        diagnostics,
+        success: false,
+      };
+    }
+
     for (const prop of anf.properties) {
       if (prop.name in opts.constructorArgs) {
         prop.initialValue = opts.constructorArgs[prop.name];
       }
+    }
+
+    const unbakedErrors = findUnbakedReferencedReadonly(anf);
+    if (unbakedErrors.length > 0) {
+      for (const msg of unbakedErrors) {
+        diagnostics.push({ message: msg, severity: 'error' } as CompilerDiagnostic);
+      }
+      return {
+        anf: null,
+        contract: parseResult.contract,
+        diagnostics,
+        success: false,
+      };
     }
   }
 
@@ -455,10 +482,20 @@ export function compileFromANF(
   // Bake constructor args into ANF properties so stack lowering emits real
   // values instead of OP_0 placeholders.
   if (opts.constructorArgs) {
+    const shapeErrors = validateConstructorArgsShape(anf, opts.constructorArgs);
+    if (shapeErrors.length > 0) {
+      throw new Error(`compileFromANF: ${shapeErrors.join('; ')}`);
+    }
+
     for (const prop of anf.properties) {
       if (prop.name in opts.constructorArgs) {
         prop.initialValue = opts.constructorArgs[prop.name];
       }
+    }
+
+    const unbakedErrors = findUnbakedReferencedReadonly(anf);
+    if (unbakedErrors.length > 0) {
+      throw new Error(`compileFromANF: ${unbakedErrors.join('; ')}`);
     }
   }
 
@@ -632,4 +669,116 @@ export function compileCheck(source: string, fileName?: string, options?: Compil
 
 function hasErrors(diagnostics: CompilerDiagnostic[]): boolean {
   return diagnostics.some(d => d.severity === 'error');
+}
+
+/**
+ * Validate the shape of `constructorArgs` against the contract's properties
+ * BEFORE baking. Returns a list of error messages (empty when valid).
+ *
+ * Rejects:
+ *  (a) positional arrays — `constructorArgs` must be a named record keyed by
+ *      property name. A positional array matches no property names, so
+ *      nothing would be baked and the script would silently keep its OP_0
+ *      placeholders (failing opaquely at runtime).
+ *  (b) keys that do not match any contract property name (typos would
+ *      otherwise silently bake nothing for that key).
+ */
+function validateConstructorArgsShape(
+  anf: ANFProgram,
+  constructorArgs: Record<string, bigint | boolean | string>,
+): string[] {
+  const errors: string[] = [];
+
+  if (Array.isArray(constructorArgs)) {
+    const propNames = anf.properties.map(p => p.name).join(', ');
+    errors.push(
+      `constructorArgs must be a record keyed by property name, not a positional array. ` +
+        `Contract '${anf.contractName}' properties: [${propNames}]. ` +
+        `Example: { ${anf.properties[0]?.name ?? 'propName'}: <value> }`,
+    );
+    return errors;
+  }
+
+  const propNameSet = new Set(anf.properties.map(p => p.name));
+  for (const key of Object.keys(constructorArgs)) {
+    if (!propNameSet.has(key)) {
+      const propNames = anf.properties.map(p => p.name).join(', ');
+      errors.push(
+        `constructorArgs key '${key}' does not match any property of contract ` +
+          `'${anf.contractName}' (properties: [${propNames}]). ` +
+          `Nothing would be baked for this key.`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * After baking `constructorArgs`, find readonly properties that are
+ * REFERENCED by at least one method body but still have no baked
+ * `initialValue`. Such properties would be emitted as OP_0 placeholders,
+ * making the compiled script fail opaquely at runtime (e.g.
+ * `OP_EQUALVERIFY failed` with no hint as to why).
+ *
+ * Only applies when the caller asked for baking — unbaked placeholder
+ * compilation (no `constructorArgs`) is the normal deploy-artifact path
+ * where the SDK substitutes values via `constructorSlots`.
+ */
+function findUnbakedReferencedReadonly(anf: ANFProgram): string[] {
+  const referenced = collectReferencedProps(anf);
+
+  const errors: string[] = [];
+  for (const prop of anf.properties) {
+    if (prop.readonly && prop.initialValue === undefined && referenced.has(prop.name)) {
+      errors.push(
+        `readonly property '${prop.name}' is referenced by a method but has no value ` +
+          `after baking constructorArgs — the emitted script would carry an OP_0 ` +
+          `placeholder that fails at runtime. Provide '${prop.name}' in constructorArgs ` +
+          `(or give the property an initializer).`,
+      );
+    }
+  }
+  return errors;
+}
+
+/**
+ * Collect the property names actually referenced by method bodies.
+ *
+ * The raw ANF from pass 4 loads every property at method entry; only after
+ * dead-binding elimination do the surviving `load_prop` nodes reflect real
+ * references. DCE is a pure function, so running it here on a probe copy
+ * does not perturb the main pipeline.
+ */
+function collectReferencedProps(anf: ANFProgram): Set<string> {
+  const probe = eliminateDeadBindings(anf);
+  const referenced = new Set<string>();
+  for (const method of probe.methods) {
+    // The constructor's super(...) call references every property but is
+    // never emitted as script code — only real method bodies count.
+    if (method.name === 'constructor') continue;
+    collectLoadPropRefs(method.body, referenced);
+  }
+  return referenced;
+}
+
+/** Recursively collect `load_prop` property names from ANF bindings. */
+function collectLoadPropRefs(bindings: ANFBinding[], out: Set<string>): void {
+  for (const binding of bindings) {
+    const v = binding.value;
+    switch (v.kind) {
+      case 'load_prop':
+        out.add(v.name);
+        break;
+      case 'if':
+        collectLoadPropRefs(v.then, out);
+        collectLoadPropRefs(v.else, out);
+        break;
+      case 'loop':
+        collectLoadPropRefs(v.body, out);
+        break;
+      default:
+        break;
+    }
+  }
 }

--- a/packages/runar-compiler/src/passes/05-stack-lower.ts
+++ b/packages/runar-compiler/src/passes/05-stack-lower.ts
@@ -243,6 +243,11 @@ class StackMap {
     this.slots.push(this.slots[this.slots.length - 1]!);
   }
 
+  /** Debug string of the slot names (bottom -> top) for error messages. */
+  debugSlots(): string {
+    return this.slots.join(', ');
+  }
+
   /** Get the set of all named (non-null) slot values. */
   namedSlots(): Set<string> {
     const names = new Set<string>();
@@ -301,6 +306,28 @@ function computeLastUses(bindings: ANFBinding[]): Map<string, number> {
   }
 
   return lastUse;
+}
+
+/**
+ * Collect every binding name defined anywhere in a binding sequence,
+ * recursing into nested if-branches and loop bodies. Used by lowerLoop to
+ * distinguish loop-internal (re)definitions from true outer-scope refs.
+ */
+function collectDeepBindingNames(bindings: ANFBinding[]): Set<string> {
+  const names = new Set<string>();
+  const walk = (bs: ANFBinding[]): void => {
+    for (const b of bs) {
+      names.add(b.name);
+      if (b.value.kind === 'if') {
+        walk(b.value.then);
+        walk(b.value.else);
+      } else if (b.value.kind === 'loop') {
+        walk(b.value.body);
+      }
+    }
+  };
+  walk(bindings);
+  return names;
 }
 
 function collectRefs(value: ANFValue): string[] {
@@ -1042,7 +1069,7 @@ class LoweringContext {
         this.lowerIf(name, value.cond, value.then, value.else, bindingIndex, lastUses);
         break;
       case 'loop':
-        this.lowerLoop(name, value.count, value.body, value.iterVar);
+        this.lowerLoop(name, value.count, value.body, value.iterVar, bindingIndex, lastUses);
         break;
       case 'assert':
         this.lowerAssert(value.value, bindingIndex, lastUses);
@@ -1173,10 +1200,16 @@ class LoweringContext {
       this.stackMap.pop();
       this.stackMap.push(bindingName);
     } else {
-      // Parameter not found - should not happen in well-formed ANF.
-      // Emit a push of zero as a fallback.
-      this.emitOp({ op: 'push', value: 0n });
-      this.stackMap.push(bindingName);
+      // Parameter no longer on the stack — a compiler invariant violation
+      // (historically caused by unrolled loops consuming outer refs; see
+      // lowerLoop). Silently emitting OP_0 here produced scripts that
+      // compiled, passed the env-based interpreter, and then failed on
+      // chain — fail loudly instead.
+      throw new Error(
+        `Stack lowering: method parameter '${paramName}' is not on the stack ` +
+          `at a post-consumption reference (stack: [${this.stackMap.debugSlots()}]). ` +
+          `Refusing to emit a silent OP_0 placeholder.`,
+      );
     }
   }
 
@@ -1240,9 +1273,14 @@ class LoweringContext {
         this.stackMap.pop();
         this.stackMap.push(bindingName);
       } else {
-        // Referenced value not on stack -- push a placeholder
-        this.emitOp({ op: 'push', value: 0n });
-        this.stackMap.push(bindingName);
+        // Referenced value no longer on the stack — a compiler invariant
+        // violation (see lowerLoadParam for the loop-consumption history).
+        // Fail loudly instead of silently emitting OP_0.
+        throw new Error(
+          `Stack lowering: value '${refName}' referenced by '${bindingName}' is not ` +
+            `on the stack (stack: [${this.stackMap.debugSlots()}]). ` +
+            `Refusing to emit a silent OP_0 placeholder.`,
+        );
       }
       return;
     }
@@ -2169,23 +2207,28 @@ class LoweringContext {
     count: number,
     body: ANFBinding[],
     _iterVar: string,
+    loopBindingIndex?: number,
+    enclosingLastUses?: Map<string, number>,
   ): void {
-    // Collect outer-scope names referenced in the loop body.
-    // These must not be consumed in non-final iterations.
+    // Names (re)defined anywhere inside the loop body, nested branches
+    // included. A name the body itself binds is NOT an outer ref —
+    // reassigned locals (e.g. `off = off + ...` inside an if) flow through
+    // lowerIf's branch-reassignment reconciliation, not through protection
+    // here.
+    const deepBodyBindingNames = collectDeepBindingNames(body);
     const bodyBindingNames = new Set(body.map(b => b.name));
+
+    // Collect ALL outer-scope refs used anywhere in the body — including
+    // refs that only occur inside nested if-branches (collectRefs recurses).
+    // The previous top-level-only scan missed nested references: a const
+    // defined before the loop and referenced only inside an if-branch was
+    // consumed by the first iteration, making iteration 2 fail with
+    // "Value 'X' not found on stack".
     const outerRefs = new Set<string>();
     for (const b of body) {
-      if (b.value.kind === 'load_param' && b.value.name !== _iterVar) {
-        outerRefs.add(b.value.name);
-      }
-      // Also protect @ref: targets from outer scope (not redefined in body)
-      if (b.value.kind === 'load_const') {
-        const v = b.value.value;
-        if (typeof v === 'string' && v.startsWith('@ref:')) {
-          const refName = v.slice(5);
-          if (!bodyBindingNames.has(refName)) {
-            outerRefs.add(refName);
-          }
+      for (const ref of collectRefs(b.value)) {
+        if (ref !== _iterVar && !deepBodyBindingNames.has(ref)) {
+          outerRefs.add(ref);
         }
       }
     }
@@ -2203,10 +2246,23 @@ class LoweringContext {
 
       const lastUses = computeLastUses(body);
 
-      // In non-final iterations, prevent outer-scope refs from being
-      // consumed by setting their last-use beyond any body binding index.
-      if (i < count - 1) {
-        for (const refName of outerRefs) {
+      // Prevent outer-scope refs from being consumed by setting their
+      // last-use beyond any body binding index:
+      //  - in non-final iterations: always (the next iteration re-reads them);
+      //  - in the FINAL iteration: when the enclosing scope still references
+      //    them AFTER the loop. Previously the final iteration consumed
+      //    every outer ref at its last body use, so a method param (or
+      //    const) referenced after the loop was gone from the stack and was
+      //    silently lowered to an OP_0/empty push — compilation succeeded,
+      //    the env-based interpreter passed, but the emitted Script failed
+      //    at runtime (silent interpreter <-> Script divergence).
+      const isFinalIteration = i === count - 1;
+      for (const refName of outerRefs) {
+        const usedAfterLoop =
+          enclosingLastUses !== undefined &&
+          loopBindingIndex !== undefined &&
+          (enclosingLastUses.get(refName) ?? -1) > loopBindingIndex;
+        if (!isFinalIteration || usedAfterLoop) {
           lastUses.set(refName, body.length);
         }
       }

--- a/packages/runar-sdk/src/contract.ts
+++ b/packages/runar-sdk/src/contract.ts
@@ -2020,8 +2020,11 @@ function buildNamedArgs(
 
 /**
  * Encode an argument value as a Bitcoin Script push data element.
+ *
+ * Exported so downstream tooling (e.g. runar-testing's mock-preimage
+ * builders) shares this exact encoding instead of maintaining a copy.
  */
-function encodeArg(value: unknown): string {
+export function encodeArg(value: unknown): string {
   if (typeof value === 'bigint') {
     return encodeScriptNumber(value);
   }

--- a/packages/runar-sdk/src/index.ts
+++ b/packages/runar-sdk/src/index.ts
@@ -23,7 +23,7 @@ export { LocalSigner, MockSigner, ExternalSigner, WalletSigner } from './signers
 export type { Signer, SignCallback, WalletSignerOptions } from './signers/index.js';
 
 // Contract
-export { RunarContract } from './contract.js';
+export { RunarContract, encodeArg } from './contract.js';
 
 // Typed SDK errors
 export { ScriptSizeExceededError, assertScriptHexUnderLimit } from './errors.js';

--- a/packages/runar-testing/package.json
+++ b/packages/runar-testing/package.json
@@ -25,6 +25,7 @@
     "runar-lang": "workspace:*",
     "runar-ir-schema": "workspace:*",
     "runar-compiler": "workspace:*",
+    "runar-sdk": "workspace:*",
     "@bsv/sdk": "^2.0.7"
   },
   "devDependencies": {

--- a/packages/runar-testing/src/__tests__/loop-walk-vm.test.ts
+++ b/packages/runar-testing/src/__tests__/loop-walk-vm.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Runtime proof for the unrolled-loop outer-ref fix: a method param
+ * referenced inside AND after a for-loop must compile to a Script that
+ * actually executes correctly in the VM (previously the post-loop
+ * reference was a silent OP_0/empty push — the interpreter passed while
+ * the Script failed with "OP_SPLIT: position N out of range [0, 0]").
+ *
+ * The repro is the multi-input tx walk pattern (V003): walk up to 3
+ * inputs of a serialized tx, advancing a running offset, then read the
+ * byte at the final offset.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from 'runar-compiler';
+import { TestSmartContract, expectScriptSuccess, expectScriptFailure } from '../helpers.js';
+
+const LOOP_WALK_SOURCE = `
+import { SmartContract, assert, substr, cat, bin2num } from 'runar-lang';
+import type { ByteString } from 'runar-lang';
+
+class LoopWalk extends SmartContract {
+  readonly pad00: ByteString = "00" as ByteString;
+
+  constructor() {
+    super();
+  }
+
+  public walk(data: ByteString) {
+    let off = 5n;
+    for (let i = 0n; i < 3n; i++) {
+      if (i < bin2num(cat(substr(data, 4n, 1n), this.pad00))) {
+        const sl = bin2num(cat(substr(data, off + 36n, 1n), this.pad00));
+        assert(sl < 253n);
+        off = off + 36n + 1n + sl + 4n;
+      }
+    }
+    const tail = bin2num(cat(substr(data, off, 1n), this.pad00));
+    assert(tail === 7n);
+  }
+}
+`;
+
+// Serialized-input helpers: outpoint(36) + scriptLen(1) + script + sequence(4)
+const input = (fill: string, scriptLen: number) =>
+  fill.repeat(36) + scriptLen.toString(16).padStart(2, '0') + 'ab'.repeat(scriptLen) + 'ffffffff';
+
+/** version(4) + inputCount(1) + inputs + tail byte */
+const txData = (inputs: string[], tail: string) =>
+  '00'.repeat(4) +
+  inputs.length.toString(16).padStart(2, '0') +
+  inputs.join('') +
+  tail;
+
+describe('compiled loop-walk executes correctly in the VM', () => {
+  const result = compile(LOOP_WALK_SOURCE, { fileName: 'LoopWalk.runar.ts' });
+  expect(result.success).toBe(true);
+  const contract = TestSmartContract.fromArtifact(result.artifact!, []);
+
+  it('walks 1 input', () => {
+    expectScriptSuccess(contract.call('walk', [txData([input('11', 2)], '07')]));
+  });
+
+  it('walks 2 inputs (variable script lengths)', () => {
+    expectScriptSuccess(
+      contract.call('walk', [txData([input('11', 2), input('22', 1)], '07')]),
+    );
+  });
+
+  it('walks 3 inputs', () => {
+    expectScriptSuccess(
+      contract.call('walk', [
+        txData([input('11', 2), input('22', 1), input('33', 3)], '07'),
+      ]),
+    );
+  });
+
+  it('fails when the byte at the walked offset is wrong', () => {
+    expectScriptFailure(
+      contract.call('walk', [txData([input('11', 2), input('22', 1)], '09')]),
+    );
+  });
+});

--- a/packages/runar-testing/src/__tests__/mock-preimage-arg-encoding.test.ts
+++ b/packages/runar-testing/src/__tests__/mock-preimage-arg-encoding.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #122: mock-preimage constructor-arg encoding must be byte-identical
+ * to the SDK's script-building path.
+ *
+ * The old local `encodeConstructorArg` encoded bigints as 8 raw bytes with no
+ * push opcode, booleans as '01' instead of OP_1, and spliced hex strings raw
+ * with no push prefix — so the code part it built (and hashed) never matched
+ * the script the SDK actually deploys. Tests using it stayed internally
+ * consistent (same wrong bytes on both sides of a comparison), which is
+ * exactly why this pin against `RunarContract` exists.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from 'runar-compiler';
+import { RunarContract } from 'runar-sdk';
+import type { RunarArtifact } from 'runar-ir-schema';
+import { buildLockingScript } from '../mock-preimage.js';
+
+const source = `
+import { SmartContract, assert, ByteString } from 'runar-lang';
+
+class Pinned extends SmartContract {
+  readonly a: bigint;
+  readonly b: ByteString;
+  readonly c: boolean;
+
+  constructor(a: bigint, b: ByteString, c: boolean) {
+    super(a, b, c);
+    this.a = a;
+    this.b = b;
+    this.c = c;
+  }
+
+  public spend(x: bigint, y: ByteString) {
+    assert(x === this.a && y === this.b && this.c);
+  }
+}
+`;
+
+function compileArtifact(): RunarArtifact {
+  const result = compile(source);
+  if (!result.success || !result.artifact) {
+    throw new Error(`Compile failed: ${result.diagnostics.map((d) => d.message).join(', ')}`);
+  }
+  return result.artifact as RunarArtifact;
+}
+
+describe('mock-preimage constructor-arg encoding (issue #122)', () => {
+  it('builds a code part byte-identical to RunarContract for bigint, ByteString, and boolean slots', () => {
+    const artifact = compileArtifact();
+    expect(artifact.constructorSlots?.length).toBe(3);
+
+    // 42n exercises script-number push encoding (not OP_N), 'deadbeef'
+    // exercises push-data prefixing, true exercises OP_1.
+    const mockScript = buildLockingScript(
+      artifact,
+      { a: 42n, b: 'deadbeef', c: true },
+      {},
+    );
+    const sdkScript = new RunarContract(artifact, [42n, 'deadbeef', true]).getLockingScript();
+
+    expect(mockScript).toBe(sdkScript);
+  });
+
+  it('agrees with the SDK on OP_N-range and zero bigints', () => {
+    const artifact = compileArtifact();
+
+    for (const n of [0n, 1n, 16n, 17n]) {
+      const mockScript = buildLockingScript(
+        artifact,
+        { a: n, b: '00', c: false },
+        {},
+      );
+      const sdkScript = new RunarContract(artifact, [n, '00', false]).getLockingScript();
+      expect(mockScript).toBe(sdkScript);
+    }
+  });
+});

--- a/packages/runar-testing/src/__tests__/mock-preimage-prevouts.test.ts
+++ b/packages/runar-testing/src/__tests__/mock-preimage-prevouts.test.ts
@@ -1,0 +1,145 @@
+/**
+ * buildStatefulPreimage outpoint / prevouts overrides — multi-input
+ * covenant tests need control over the spent outpoint and hashPrevouts
+ * (contracts verifying companion inputs via extractHashPrevouts /
+ * extractOutpoint). Previously both were hardcoded to a 36-zero-byte
+ * dummy outpoint.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import { compile } from 'runar-compiler';
+import type { RunarArtifact } from 'runar-ir-schema';
+import { buildStatefulPreimage } from '../mock-preimage.js';
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const counterSource = `
+import { StatefulSmartContract, assert } from 'runar-lang';
+
+class Counter extends StatefulSmartContract {
+  count: bigint;
+
+  constructor(count: bigint) {
+    super(count);
+    this.count = count;
+  }
+
+  public increment() {
+    this.count++;
+  }
+}
+`;
+
+let artifact: RunarArtifact;
+{
+  const result = compile(counterSource, { fileName: 'Counter.runar.ts' });
+  if (!result.success || !result.artifact) {
+    throw new Error(
+      result.diagnostics.map((d) => d.message).join('\n') || 'compile failed',
+    );
+  }
+  artifact = result.artifact;
+}
+
+function baseParams() {
+  return {
+    artifact,
+    constructorArgs: { count: 0n },
+    state: { count: 5n },
+    newState: { count: 6n },
+  };
+}
+
+function hash256hex(hex: string): string {
+  const one = createHash('sha256').update(Buffer.from(hex, 'hex')).digest();
+  return createHash('sha256').update(one).digest('hex');
+}
+
+const DUMMY_OUTPOINT = '00'.repeat(36);
+const OUTPOINT_A = 'aa'.repeat(32) + '01000000';
+const OUTPOINT_B = 'bb'.repeat(32) + '00000000';
+
+/** Slice helpers over the BIP-143 preimage layout. */
+function preimageHashPrevouts(preimageHex: string): string {
+  return preimageHex.slice(8, 8 + 64); // after nVersion(4B)
+}
+function preimageOutpoint(preimageHex: string): string {
+  return preimageHex.slice(8 + 64 + 64, 8 + 64 + 64 + 72); // after hashSequence
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('buildStatefulPreimage outpoint/prevouts overrides', () => {
+  it('defaults are backward compatible (dummy outpoint, hashPrevouts = hash256(dummy))', () => {
+    const result = buildStatefulPreimage(baseParams());
+    expect(preimageOutpoint(result.preimageHex)).toBe(DUMMY_OUTPOINT);
+    expect(preimageHashPrevouts(result.preimageHex)).toBe(
+      hash256hex(DUMMY_OUTPOINT),
+    );
+  });
+
+  it('outpoint override lands in the preimage and in hashPrevouts', () => {
+    const result = buildStatefulPreimage({
+      ...baseParams(),
+      outpoint: OUTPOINT_A,
+    });
+    expect(preimageOutpoint(result.preimageHex)).toBe(OUTPOINT_A);
+    expect(preimageHashPrevouts(result.preimageHex)).toBe(
+      hash256hex(OUTPOINT_A),
+    );
+  });
+
+  it('prevouts override: hashPrevouts = hash256(concat(prevouts)), outpoint defaults to first prevout', () => {
+    const result = buildStatefulPreimage({
+      ...baseParams(),
+      prevouts: [OUTPOINT_A, OUTPOINT_B],
+    });
+    expect(preimageOutpoint(result.preimageHex)).toBe(OUTPOINT_A);
+    expect(preimageHashPrevouts(result.preimageHex)).toBe(
+      hash256hex(OUTPOINT_A + OUTPOINT_B),
+    );
+  });
+
+  it('outpoint + prevouts: spent input can be the second prevout', () => {
+    const result = buildStatefulPreimage({
+      ...baseParams(),
+      outpoint: OUTPOINT_B,
+      prevouts: [OUTPOINT_A, OUTPOINT_B],
+    });
+    expect(preimageOutpoint(result.preimageHex)).toBe(OUTPOINT_B);
+    expect(preimageHashPrevouts(result.preimageHex)).toBe(
+      hash256hex(OUTPOINT_A + OUTPOINT_B),
+    );
+  });
+
+  it('default call is byte-identical to the pre-override behaviour', () => {
+    const legacy = buildStatefulPreimage(baseParams());
+    const explicit = buildStatefulPreimage({
+      ...baseParams(),
+      outpoint: DUMMY_OUTPOINT,
+      prevouts: [DUMMY_OUTPOINT],
+    });
+    expect(explicit.preimageHex).toBe(legacy.preimageHex);
+    expect(explicit.signatureHex).toBe(legacy.signatureHex);
+  });
+
+  it('rejects malformed outpoint / prevouts', () => {
+    expect(() =>
+      buildStatefulPreimage({ ...baseParams(), outpoint: 'aa'.repeat(32) }),
+    ).toThrow(/72 hex chars/);
+    expect(() =>
+      buildStatefulPreimage({
+        ...baseParams(),
+        prevouts: [OUTPOINT_A, 'zz'.repeat(36)],
+      }),
+    ).toThrow(/prevouts\[1\]/);
+    expect(() =>
+      buildStatefulPreimage({ ...baseParams(), prevouts: [] }),
+    ).toThrow(/must not be empty/);
+  });
+});

--- a/packages/runar-testing/src/__tests__/test-smart-contract-baking.test.ts
+++ b/packages/runar-testing/src/__tests__/test-smart-contract-baking.test.ts
@@ -1,0 +1,134 @@
+/**
+ * TestSmartContract.fromArtifact constructor-arg baking — previously the
+ * wrapper stored `constructorArgs` but executed the RAW placeholder script,
+ * so any contract whose readonly props are baked at deploy failed with
+ * `OP_EQUALVERIFY failed` (comparing against an OP_0 placeholder).
+ *
+ * Now `constructorSlots` substitution is applied, mirroring runar-sdk's
+ * `RunarContract.buildCodeScript`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import { compile } from 'runar-compiler';
+import {
+  TestSmartContract,
+  expectScriptSuccess,
+  expectScriptFailure,
+} from '../helpers.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Referenced readonly Sha256 — the exact shape that used to fail. */
+const HASH_LOCK_SOURCE = `
+class HashLock extends SmartContract {
+  readonly hashValue: Sha256;
+
+  constructor(hashValue: Sha256) {
+    super(hashValue);
+    this.hashValue = hashValue;
+  }
+
+  public unlock(preimage: ByteString) {
+    assert(sha256(preimage) === this.hashValue);
+  }
+}
+`;
+
+/** Two constructor params: bigint + bytes. */
+const TWO_ARG_SOURCE = `
+class TwoArg extends SmartContract {
+  readonly target: bigint;
+  readonly tag: ByteString;
+
+  constructor(target: bigint, tag: ByteString) {
+    super(target, tag);
+    this.target = target;
+    this.tag = tag;
+  }
+
+  public check(x: bigint, t: ByteString) {
+    assert(x === this.target);
+    assert(t === this.tag);
+  }
+}
+`;
+
+const PREIMAGE_HEX = 'deadbeef';
+const HASH_HEX = createHash('sha256')
+  .update(Buffer.from(PREIMAGE_HEX, 'hex'))
+  .digest('hex');
+
+function compileUnbaked(source: string) {
+  const result = compile(source);
+  expect(result.success).toBe(true);
+  expect(result.artifact!.constructorSlots!.length).toBeGreaterThanOrEqual(1);
+  return result.artifact!;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TestSmartContract.fromArtifact bakes constructorArgs', () => {
+  it('referenced readonly Sha256 passes a VM call with the baked value', () => {
+    const artifact = compileUnbaked(HASH_LOCK_SOURCE);
+    const contract = TestSmartContract.fromArtifact(artifact, [HASH_HEX]);
+
+    // Previously: OP_EQUALVERIFY failed at PC~3 (placeholder OP_0 vs hash).
+    expectScriptSuccess(contract.call('unlock', [PREIMAGE_HEX]));
+  });
+
+  it('wrong preimage still fails against the baked value', () => {
+    const artifact = compileUnbaked(HASH_LOCK_SOURCE);
+    const contract = TestSmartContract.fromArtifact(artifact, [HASH_HEX]);
+
+    expectScriptFailure(contract.call('unlock', ['00112233']));
+  });
+
+  it('bakes multiple positional args (bigint + ByteString)', () => {
+    const artifact = compileUnbaked(TWO_ARG_SOURCE);
+    const contract = TestSmartContract.fromArtifact(artifact, [42n, 'cafe']);
+
+    expectScriptSuccess(contract.call('check', [42n, 'cafe']));
+    expectScriptFailure(contract.call('check', [43n, 'cafe']));
+    expectScriptFailure(contract.call('check', [42n, 'beef']));
+  });
+
+  it('getLockingScriptHex returns the baked script (no OP_0 placeholder)', () => {
+    const artifact = compileUnbaked(HASH_LOCK_SOURCE);
+    const contract = TestSmartContract.fromArtifact(artifact, [HASH_HEX]);
+
+    expect(contract.getLockingScriptHex()).toContain(HASH_HEX);
+    expect(contract.getLockingScriptHex()).not.toBe(artifact.script);
+  });
+
+  it('throws when constructorSlots exist but args are missing', () => {
+    const artifact = compileUnbaked(HASH_LOCK_SOURCE);
+    expect(() => TestSmartContract.fromArtifact(artifact, [])).toThrow(
+      /expects 1 constructor arg/,
+    );
+  });
+
+  it('throws on arg count mismatch', () => {
+    const artifact = compileUnbaked(TWO_ARG_SOURCE);
+    expect(() =>
+      TestSmartContract.fromArtifact(artifact, [42n]),
+    ).toThrow(/expects 2 constructor arg/);
+  });
+
+  it('accepts non-empty args when the artifact has no constructorSlots', () => {
+    // Compile with baked args — no slots remain; passing args again is fine
+    // (matches the pre-fix calling convention).
+    const result = compile(HASH_LOCK_SOURCE, {
+      constructorArgs: { hashValue: HASH_HEX },
+    });
+    expect(result.success).toBe(true);
+    const contract = TestSmartContract.fromArtifact(result.artifact!, [
+      HASH_HEX,
+    ]);
+    expectScriptSuccess(contract.call('unlock', [PREIMAGE_HEX]));
+  });
+});

--- a/packages/runar-testing/src/__tests__/vm-codeseparator.test.ts
+++ b/packages/runar-testing/src/__tests__/vm-codeseparator.test.ts
@@ -1,0 +1,109 @@
+/**
+ * OP_CODESEPARATOR (0xab) — previously the ScriptVM threw
+ * "Unknown or disabled opcode: 0xab", so compiled STATEFUL Rúnar contracts
+ * (which all carry a codeSeparator-trimmed scriptCode) could not be
+ * replayed in the in-house VM at all.
+ *
+ * Post-Genesis BSV semantics: during execution OP_CODESEPARATOR marks the
+ * position after itself as the scriptCode start for subsequent signature
+ * ops. With the mockable checkSigCallback this means: don't throw, track
+ * the offset, keep executing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compile } from 'runar-compiler';
+import { ScriptVM } from '../vm/index.js';
+import { Opcode } from '../vm/opcodes.js';
+
+describe('ScriptVM OP_CODESEPARATOR', () => {
+  it('executes a script containing 0xab instead of throwing', () => {
+    // OP_1 OP_CODESEPARATOR OP_1 OP_ADD  =>  2
+    const vm = new ScriptVM();
+    const result = vm.executeHex('51ab5193');
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('tracks lastCodeSeparator as the offset after the separator', () => {
+    const vm = new ScriptVM();
+    expect(vm.lastCodeSeparator).toBe(-1);
+
+    // bytes: 0x51 @0, 0xab @1, 0x51 @2, 0x93 @3
+    const result = vm.executeHex('51ab5193');
+    expect(result.success).toBe(true);
+    expect(vm.lastCodeSeparator).toBe(2);
+  });
+
+  it('updates lastCodeSeparator on each executed separator', () => {
+    // OP_1 0xab OP_1 0xab OP_ADD => last separator at offset 3, start = 4
+    const vm = new ScriptVM();
+    const result = vm.executeHex('51ab51ab93');
+    expect(result.success).toBe(true);
+    expect(vm.lastCodeSeparator).toBe(4);
+  });
+
+  it('does not track a separator inside a non-executing branch', () => {
+    // OP_0 OP_IF 0xab OP_ENDIF OP_1
+    const vm = new ScriptVM();
+    const result = vm.executeHex('0063ab6851');
+    expect(result.success).toBe(true);
+    expect(vm.lastCodeSeparator).toBe(-1);
+  });
+
+  it('works before a mocked OP_CHECKSIG (stateful scriptCode shape)', () => {
+    // <sig> <pubkey> pushed by unlocking; locking: 0xab OP_CHECKSIG
+    const vm = new ScriptVM();
+    const unlocking = new Uint8Array([0x01, 0xaa, 0x01, 0xbb]); // push 0xaa, push 0xbb
+    const locking = new Uint8Array([Opcode.OP_CODESEPARATOR, Opcode.OP_CHECKSIG]);
+    const result = vm.execute(unlocking, locking);
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('step mode steps over OP_CODESEPARATOR without error', () => {
+    const vm = new ScriptVM();
+    vm.loadHex('', '51ab5193');
+
+    const opcodes: string[] = [];
+    let step = vm.step();
+    while (step !== null) {
+      expect(step.error).toBeUndefined();
+      opcodes.push(step.opcode);
+      step = vm.step();
+    }
+
+    expect(opcodes).toContain('OP_CODESEPARATOR');
+    expect(vm.isComplete).toBe(true);
+    expect(vm.isSuccess).toBe(true);
+    expect(vm.lastCodeSeparator).toBe(2);
+  });
+
+  it('a compiled stateful contract script no longer dies at 0xab', () => {
+    const source = `
+import { StatefulSmartContract, assert } from 'runar-lang';
+
+class Counter extends StatefulSmartContract {
+  count: bigint;
+
+  constructor(count: bigint) {
+    super(count);
+    this.count = count;
+  }
+
+  public increment() {
+    this.count++;
+  }
+}
+`;
+    const result = compile(source, { fileName: 'Counter.runar.ts' });
+    expect(result.success).toBe(true);
+    expect(result.scriptHex).toContain('ab');
+
+    // Without valid preimage args the script fails on its own asserts —
+    // but it must no longer fail with "Unknown or disabled opcode: 0xab".
+    const vm = new ScriptVM();
+    const vmResult = vm.executeHex(result.scriptHex!);
+    expect(vmResult.error ?? '').not.toMatch(/unknown or disabled opcode: 0xab/i);
+  });
+});

--- a/packages/runar-testing/src/helpers.ts
+++ b/packages/runar-testing/src/helpers.ts
@@ -23,6 +23,7 @@ export class TestSmartContract {
   private readonly artifact: RunarArtifact;
   readonly constructorArgs: unknown[];
   private readonly lockingScript: Uint8Array;
+  private readonly lockingScriptHex: string;
   private vmOptions: VMOptions;
 
   private constructor(
@@ -32,7 +33,11 @@ export class TestSmartContract {
   ) {
     this.artifact = artifact;
     this.constructorArgs = constructorArgs;
-    this.lockingScript = hexToBytes(artifact.script);
+    this.lockingScriptHex = bakeConstructorArgsIntoScript(
+      artifact,
+      constructorArgs,
+    );
+    this.lockingScript = hexToBytes(this.lockingScriptHex);
     this.vmOptions = vmOptions;
   }
 
@@ -75,10 +80,10 @@ export class TestSmartContract {
   }
 
   /**
-   * Get the locking script as a hex string.
+   * Get the locking script as a hex string (with constructor args baked in).
    */
   getLockingScriptHex(): string {
-    return this.artifact.script;
+    return this.lockingScriptHex;
   }
 
   /**
@@ -141,6 +146,91 @@ export class TestSmartContract {
   getContractName(): string {
     return this.artifact.contractName;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor arg baking
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the artifact's `constructorSlots` substitution so the locking script
+ * carries the real constructor values instead of OP_0 placeholders (mirrors
+ * runar-sdk's `RunarContract.buildCodeScript`).
+ *
+ * Previously `fromArtifact` stored `constructorArgs` but executed the raw
+ * placeholder script, so any comparison against a baked readonly value
+ * failed with `OP_EQUALVERIFY failed` and no hint as to why.
+ *
+ * - No `constructorSlots`: the raw script is returned unchanged. Passing
+ *   non-empty args is fine when the ABI declares constructor params —
+ *   unreferenced readonly properties are eliminated by the compiler and
+ *   simply have no placeholder to fill.
+ * - `constructorSlots` present: every slot's `paramIndex` must resolve to a
+ *   provided arg, and the arg count must match the ABI constructor's param
+ *   count; otherwise this throws instead of silently running placeholders.
+ */
+function bakeConstructorArgsIntoScript(
+  artifact: RunarArtifact,
+  constructorArgs: unknown[],
+): string {
+  const slots = artifact.constructorSlots;
+  if (!slots || slots.length === 0) {
+    return artifact.script;
+  }
+
+  const abiParams = artifact.abi.constructor?.params ?? [];
+  if (constructorArgs.length !== abiParams.length) {
+    throw new Error(
+      `TestSmartContract.fromArtifact: contract '${artifact.contractName}' ` +
+        `expects ${abiParams.length} constructor arg(s) ` +
+        `(${abiParams.map((p) => p.name).join(', ')}), got ${constructorArgs.length}`,
+    );
+  }
+
+  // Substitute in descending byte-offset order so earlier splices don't
+  // invalidate later offsets.
+  const sorted = [...slots].sort((a, b) => b.byteOffset - a.byteOffset);
+  let script = artifact.script;
+  for (const slot of sorted) {
+    const value = constructorArgs[slot.paramIndex];
+    if (value === undefined) {
+      const paramName = abiParams[slot.paramIndex]?.name ?? `#${slot.paramIndex}`;
+      throw new Error(
+        `TestSmartContract.fromArtifact: missing constructor arg '${paramName}' ` +
+          `(paramIndex ${slot.paramIndex}) required by a constructorSlot of ` +
+          `contract '${artifact.contractName}'`,
+      );
+    }
+    const encoded = encodeConstructorValueHex(value);
+    const hexOffset = slot.byteOffset * 2;
+    // Replace the 1-byte OP_0 placeholder (2 hex chars) with the encoded push.
+    script = script.slice(0, hexOffset) + encoded + script.slice(hexOffset + 2);
+  }
+  return script;
+}
+
+/**
+ * Encode a constructor value as a Bitcoin Script push element (hex).
+ * Mirrors runar-sdk's `encodeArg`.
+ */
+function encodeConstructorValueHex(value: unknown): string {
+  if (typeof value === 'bigint' || typeof value === 'number') {
+    const n = typeof value === 'bigint' ? value : BigInt(value);
+    if (n === 0n) return '00'; // OP_0
+    if (n >= 1n && n <= 16n) return (0x50 + Number(n)).toString(16); // OP_1..OP_16
+    if (n === -1n) return '4f'; // OP_1NEGATE
+    return bytesToHex(encodePushData(encodeScriptNumber(n)));
+  }
+  if (typeof value === 'boolean') {
+    return value ? '51' : '00';
+  }
+  if (typeof value === 'string') {
+    // Hex-encoded data (ByteString / PubKey / Sha256 / ...)
+    return bytesToHex(encodePushData(hexToBytes(value)));
+  }
+  throw new Error(
+    `TestSmartContract.fromArtifact: unsupported constructor arg type '${typeof value}'`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/runar-testing/src/mock-preimage.ts
+++ b/packages/runar-testing/src/mock-preimage.ts
@@ -44,6 +44,20 @@ export interface StatefulPreimageParams {
   version?: number;
   locktime?: number;
   sequence?: number;
+  /**
+   * Outpoint of the input being spent (72 hex chars: 32-byte txid +
+   * 4-byte LE vout). Defaults to the first entry of `prevouts` when that
+   * is given, otherwise to 36 zero bytes (legacy behaviour).
+   */
+  outpoint?: string;
+  /**
+   * All input outpoints of the spending transaction, in input order
+   * (each 72 hex chars). When given,
+   * `hashPrevouts = hash256(concat(prevouts))`, enabling multi-input
+   * covenant tests (`extractHashPrevouts` / companion-input checks).
+   * Defaults to `[outpoint]` (single-input, legacy behaviour).
+   */
+  prevouts?: string[];
 }
 
 export interface StatefulPreimageResult {
@@ -361,7 +375,29 @@ export function buildStatefulPreimage(
     version = 1,
     locktime = 0,
     sequence = 0xffffffff,
+    outpoint,
+    prevouts,
   } = params;
+
+  // Validate outpoint / prevouts overrides (72 hex chars = 36 bytes each).
+  const OUTPOINT_RE = /^[0-9a-fA-F]{72}$/;
+  if (outpoint !== undefined && !OUTPOINT_RE.test(outpoint)) {
+    throw new Error(
+      `buildStatefulPreimage: outpoint must be 72 hex chars (32-byte txid + 4-byte LE vout), got ${outpoint.length} chars`,
+    );
+  }
+  if (prevouts !== undefined) {
+    if (prevouts.length === 0) {
+      throw new Error('buildStatefulPreimage: prevouts must not be empty');
+    }
+    for (const [idx, po] of prevouts.entries()) {
+      if (!OUTPOINT_RE.test(po)) {
+        throw new Error(
+          `buildStatefulPreimage: prevouts[${idx}] must be 72 hex chars (32-byte txid + 4-byte LE vout), got ${po.length} chars`,
+        );
+      }
+    }
+  }
 
   // Build code part and full locking script
   const codePart = buildCodePart(artifact, constructorArgs);
@@ -421,11 +457,18 @@ export function buildStatefulPreimage(
 
   const nVersion = uint32LE(version);
 
-  // Dummy outpoint: 32 zero bytes (txid) + 00000000 (vout 0)
-  const dummyOutpoint = '00'.repeat(32) + '00000000';
+  // Outpoint of the input being spent. Default: first prevout when given,
+  // otherwise 32 zero bytes (txid) + 00000000 (vout 0) — legacy behaviour.
+  const spentOutpoint = (
+    outpoint ?? prevouts?.[0] ?? '00'.repeat(32) + '00000000'
+  ).toLowerCase();
 
-  // hashPrevouts = hash256(outpoint)
-  const hashPrevouts = bytesToHex(hash256(hexToBytes(dummyOutpoint)));
+  // hashPrevouts = hash256(concat(all input outpoints)).
+  // Default (single input): hash256(spent outpoint).
+  const prevoutsHex = prevouts
+    ? prevouts.join('').toLowerCase()
+    : spentOutpoint;
+  const hashPrevouts = bytesToHex(hash256(hexToBytes(prevoutsHex)));
 
   // hashSequence = hash256(sequence as 4-byte LE)
   const hashSequence = bytesToHex(hash256(hexToBytes(uint32LE(sequence))));
@@ -450,7 +493,7 @@ export function buildStatefulPreimage(
     nVersion +
     hashPrevouts +
     hashSequence +
-    dummyOutpoint +
+    spentOutpoint +
     scriptCodePrefixed +
     amountHex +
     nSequence +

--- a/packages/runar-testing/src/mock-preimage.ts
+++ b/packages/runar-testing/src/mock-preimage.ts
@@ -18,6 +18,7 @@ import {
   Hash,
   BigNumber,
 } from '@bsv/sdk';
+import { encodeArg } from 'runar-sdk';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -259,23 +260,16 @@ function encodeVarint(n: number): string {
 }
 
 // ---------------------------------------------------------------------------
-// Constructor arg encoding
-// ---------------------------------------------------------------------------
-
-function encodeConstructorArg(value: bigint | boolean | string): string {
-  if (typeof value === 'bigint') return encodeNum2Bin(value, 8);
-  if (typeof value === 'boolean') return value ? '01' : '00';
-  // Hex string for ByteString/PubKey/etc.
-  return String(value);
-}
-
-// ---------------------------------------------------------------------------
 // Code part building
 // ---------------------------------------------------------------------------
 
 /**
  * Build the code part of the locking script by substituting constructor args
  * into the artifact's script at the specified byte offsets.
+ *
+ * Args are encoded with the SDK's `encodeArg` (minimal script-number /
+ * push-data encodings) so the code part — and anything hashed from it — is
+ * byte-identical to the script `RunarContract` deploys.
  */
 function buildCodePart(
   artifact: RunarArtifact,
@@ -292,7 +286,7 @@ function buildCodePart(
       if (!paramName) continue;
       const value = constructorArgs[paramName];
       if (value === undefined) continue;
-      const encoded = encodeConstructorArg(value);
+      const encoded = encodeArg(value);
       const hexOffset = slot.byteOffset * 2;
       // Replace the OP_0 placeholder (2 hex chars) with the encoded value
       script = script.slice(0, hexOffset) + encoded + script.slice(hexOffset + 2);

--- a/packages/runar-testing/src/vm/opcodes.ts
+++ b/packages/runar-testing/src/vm/opcodes.ts
@@ -126,6 +126,7 @@ export enum Opcode {
   OP_SHA256 = 0xa8,
   OP_HASH160 = 0xa9,
   OP_HASH256 = 0xaa,
+  OP_CODESEPARATOR = 0xab,
   OP_CHECKSIG = 0xac,
   OP_CHECKSIGVERIFY = 0xad,
   OP_CHECKMULTISIG = 0xae,

--- a/packages/runar-testing/src/vm/script-vm.ts
+++ b/packages/runar-testing/src/vm/script-vm.ts
@@ -96,6 +96,15 @@ export class ScriptVM {
   private ifStack: boolean[] = [];
   private opsExecuted = 0;
   private maxStackDepth = 0;
+  /**
+   * Byte offset just AFTER the most recently executed OP_CODESEPARATOR in
+   * the currently running script, or -1 if none has executed. Post-Genesis
+   * BSV semantics: this marks where scriptCode starts for subsequent
+   * signature operations. With the mockable checkSigCallback the offset is
+   * informational — it is tracked and exposed so callers (and a future
+   * real-sighash mode) can compute the trimmed subscript.
+   */
+  private _lastCodeSeparator = -1;
 
   private readonly maxOps: number;
   private readonly maxStackSize: number;
@@ -302,6 +311,14 @@ export class ScriptVM {
   get isSuccess(): boolean { return this._isSuccess; }
 
   /**
+   * Byte offset just after the most recently executed OP_CODESEPARATOR in
+   * the currently running script (-1 if none executed yet). This is the
+   * scriptCode start position for subsequent signature ops per post-Genesis
+   * BSV semantics.
+   */
+  get lastCodeSeparator(): number { return this._lastCodeSeparator; }
+
+  /**
    * Get a human-readable name for the opcode at the given position.
    */
   private getOpcodeName(byte: number): string {
@@ -410,6 +427,15 @@ export class ScriptVM {
     // Skip non-executing opcodes
     if (!this.isExecuting()) return i;
 
+    // OP_CODESEPARATOR: track the scriptCode start position relative to the
+    // CURRENT script (handled here rather than via the single-byte
+    // delegation below, which would lose the real byte offset).
+    if (byte === Opcode.OP_CODESEPARATOR) {
+      this.countOp();
+      this._lastCodeSeparator = i;
+      return i;
+    }
+
     // All remaining opcodes: delegate to runScript on a single-byte script.
     // Save and restore ifStack to bypass the end-of-script balance check.
     const savedIfStack = [...this.ifStack];
@@ -439,6 +465,7 @@ export class ScriptVM {
     this._isComplete = false;
     this._isSuccess = false;
     this._stepError = undefined;
+    this._lastCodeSeparator = -1;
   }
 
   // -------------------------------------------------------------------------
@@ -1352,6 +1379,19 @@ export class ScriptVM {
           const sha1 = createHash('sha256').update(data).digest();
           const sha2 = createHash('sha256').update(sha1).digest();
           this.push(new Uint8Array(sha2));
+          continue;
+        }
+
+        // OP_CODESEPARATOR (0xab) — post-Genesis BSV semantics: marks the
+        // position after itself as the new scriptCode start for subsequent
+        // signature operations. Execution continues; no stack effect.
+        // The offset is tracked so callers (and the mockable checkSig path)
+        // can compute the trimmed subscript. Compiled STATEFUL Rúnar
+        // contracts all carry an OP_CODESEPARATOR, so the VM must not
+        // reject it as unknown.
+        if (byte === Opcode.OP_CODESEPARATOR) {
+          this.countOp();
+          this._lastCodeSeparator = i;
           continue;
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       runar-lang:
         specifier: workspace:*
         version: link:../runar-lang
+      runar-sdk:
+        specifier: workspace:*
+        version: link:../runar-sdk
     devDependencies:
       fast-check:
         specifier: ^3.22.0


### PR DESCRIPTION
> **Note on the diff:** this branch was cut from the #113 branch rather than `main`, so the Files tab currently shows #113's commits too. Only `packages/runar-testing/src/mock-preimage.ts`, the `encodeArg` export in `packages/runar-sdk/src/index.ts`, the `runar-testing` package.json dependency, and `mock-preimage-arg-encoding.test.ts` are new here. Will rebase onto `main` as soon as #113 lands.

## Problem

`mock-preimage.ts`'s local `encodeConstructorArg` encoded bigints as 8 raw bytes with **no push opcode**, booleans as `01` instead of OP_1 (`51`), and spliced hex strings raw with no push prefix. For any artifact with unbaked `constructorSlots`, `buildCodePart` therefore produced a locking script whose "constructor args" execute as random opcodes and whose code-part hash never matches what `RunarContract` deploys — while tests built on it stayed internally consistent (same wrong bytes on both sides of every comparison) and kept passing. Details in #122.

## Fix

Export `encodeArg` from `runar-sdk` and use it in `buildCodePart`, deleting the divergent copy. `runar-testing` gains a workspace dependency on `runar-sdk` (no cycle — runar-sdk does not depend on runar-testing). Note: #114 also exports `encodeArg` for the cross-artifact assembly work; whichever lands second is a trivial rebase.

## Test

New pinning test (failing-first — the pre-fix run shows the divergence bytes, e.g. mock `7c2a000000000000009c…019a` vs SDK `7c012a9c…519a` for the same args): `buildLockingScript(artifact, args, {})` must be byte-identical to `new RunarContract(artifact, args).getLockingScript()` for bigint + ByteString + boolean slots, plus the OP_0/OP_N-range bigint edge encodings (0n, 1n, 16n, 17n).

## Suites run

- `packages/runar-testing`: 596 passed, 91 skipped (vitest)
- `packages/runar-sdk`: 431 passed, 2 skipped
- Full TS suite: 7,309 passed, 202 skipped (single known local-locale Ruby-driver artifact, passes under `LC_ALL=en_US.UTF-8`)

Closes #122
