### PR TITLE
Hardening follow-ups: silent-placeholder error, locktime/feeUtxo footguns, Java funding parity

### DIFF
--- a/compilers/go/codegen/stack.go
+++ b/compilers/go/codegen/stack.go
@@ -1135,15 +1135,45 @@ func (ctx *loweringContext) lowerLoadProp(bindingName, propName string) {
 	} else {
 		// Property value will be provided at deployment time; emit a placeholder.
 		// The emitter records byte offsets so the SDK can splice in real values.
+		//
+		// #119 tail (H1): scan the non-initialized (constructor-param) props for
+		// this name. Go signals not-found by never breaking out of the loop —
+		// paramIndex then equals the COUNT of constructor-param props, not a real
+		// slot. The previous behaviour emitted that out-of-range index as the
+		// placeholder, silently splicing an UNRELATED constructor argument's
+		// deploy-time bytes into the locking script. Fail loudly instead. (A real
+		// constructor-param property — readonly or a mutable state field whose
+		// initial value is spliced at deploy — is found and is unaffected.)
 		paramIndex := 0
+		found := false
 		for _, p := range ctx.properties {
 			if p.InitialValue != nil {
 				continue
 			}
 			if p.Name == propName {
+				found = true
 				break
 			}
 			paramIndex++
+		}
+		if !found {
+			var ctorProps []string
+			for _, p := range ctx.properties {
+				if p.InitialValue == nil {
+					ctorProps = append(ctorProps, p.Name)
+				}
+			}
+			loc := ""
+			if ctx.currentSourceLoc != nil {
+				loc = fmt.Sprintf(" at %s:%d:%d", ctx.currentSourceLoc.File, ctx.currentSourceLoc.Line, ctx.currentSourceLoc.Column)
+			}
+			panic(fmt.Errorf(
+				"stack lowering: property '%s'%s is neither on the stack, "+
+					"initialized, nor a constructor parameter, so it has no "+
+					"deploy-time slot. Refusing to emit a placeholder for an "+
+					"unrelated constructor argument (slot 0). Known "+
+					"constructor-param properties: [%s].",
+				propName, loc, strings.Join(ctorProps, ", ")))
 		}
 		ctx.emitOp(StackOp{Op: "placeholder", ParamIndex: paramIndex, ParamName: propName})
 	}

--- a/compilers/go/codegen/stack_test.go
+++ b/compilers/go/codegen/stack_test.go
@@ -1751,3 +1751,103 @@ func TestStack_AddDataOutput_WireShapeMatchesAddRawOutput(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// H1 (#119 tail): lowerLoadProp must NOT silently coerce an unknown property
+// onto a constructor slot.
+//
+// A `load_prop` binding whose name is not a declared constructor-param
+// property has no deploy-time bytes of its own. The previous behaviour let the
+// paramIndex scan run off the end (Go signals not-found by never breaking, so
+// paramIndex == count of non-initialized props) and emitted a placeholder for
+// an UNRELATED constructor argument — a silent-wrong-code path. The hardened
+// behaviour is a HARD panic (recovered into an error by LowerToStack) naming
+// the offending property, the source location, and the known ctor-param props.
+// ---------------------------------------------------------------------------
+
+// ghostLoadPropProgram builds a minimal ANF program with one real readonly
+// constructor-param property `pk` (slot 0) plus a public method whose body
+// loads a property `ghost` that is NOT declared on the contract. `ghost`
+// therefore reaches the placeholder fallback with no matching ctor slot.
+func ghostLoadPropProgram() *ir.ANFProgram {
+	assertT0, _ := marshalString("t0")
+	return &ir.ANFProgram{
+		ContractName: "Ghost",
+		Properties: []ir.ANFProperty{
+			{Name: "pk", Type: "PubKey", Readonly: true},
+		},
+		Methods: []ir.ANFMethod{
+			{
+				Name:     "constructor",
+				Params:   []ir.ANFParam{{Name: "pk", Type: "PubKey"}},
+				Body:     nil,
+				IsPublic: false,
+			},
+			{
+				Name:     "spend",
+				Params:   []ir.ANFParam{},
+				IsPublic: true,
+				Body: []ir.ANFBinding{
+					{
+						Name:      "t0",
+						Value:     ir.ANFValue{Kind: "load_prop", Name: "ghost"},
+						SourceLoc: &ir.SourceLocation{File: "Ghost.runar.ts", Line: 7, Column: 4},
+					},
+					{Name: "t1", Value: ir.ANFValue{Kind: "assert", RawValue: assertT0, ValueRef: "t0"}},
+				},
+			},
+		},
+	}
+}
+
+func TestLowerToStack_H1_GhostLoadPropIsHardError(t *testing.T) {
+	_, err := LowerToStack(ghostLoadPropProgram())
+	if err == nil {
+		t.Fatal("expected a hard error for load_prop of undeclared property 'ghost', got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ghost") {
+		t.Errorf("expected error to name the ghost property, got: %s", msg)
+	}
+	if !strings.Contains(msg, "constructor") {
+		t.Errorf("expected error to mention the missing constructor slot, got: %s", msg)
+	}
+	// The known constructor-param property list must include the real prop 'pk'.
+	if !strings.Contains(msg, "pk") {
+		t.Errorf("expected error to list known ctor-param props (including 'pk'), got: %s", msg)
+	}
+	// Source location threaded from the ANF binding should appear.
+	if !strings.Contains(msg, "Ghost.runar.ts") {
+		t.Errorf("expected error to include the source location, got: %s", msg)
+	}
+}
+
+func TestLowerToStack_H1_RealCtorPropLowersWithoutError(t *testing.T) {
+	assertT0, _ := marshalString("t0")
+	program := &ir.ANFProgram{
+		ContractName: "Ok",
+		Properties: []ir.ANFProperty{
+			{Name: "pk", Type: "PubKey", Readonly: true},
+		},
+		Methods: []ir.ANFMethod{
+			{
+				Name:     "constructor",
+				Params:   []ir.ANFParam{{Name: "pk", Type: "PubKey"}},
+				Body:     nil,
+				IsPublic: false,
+			},
+			{
+				Name:     "spend",
+				Params:   []ir.ANFParam{},
+				IsPublic: true,
+				Body: []ir.ANFBinding{
+					{Name: "t0", Value: ir.ANFValue{Kind: "load_prop", Name: "pk"}},
+					{Name: "t1", Value: ir.ANFValue{Kind: "assert", RawValue: assertT0, ValueRef: "t0"}},
+				},
+			},
+		},
+	}
+	if _, err := LowerToStack(program); err != nil {
+		t.Fatalf("expected a real ctor-param property to lower without error, got: %v", err)
+	}
+}

--- a/compilers/go/frontend/validator.go
+++ b/compilers/go/frontend/validator.go
@@ -361,6 +361,12 @@ func (ctx *validationContext) validateMethod(method MethodNode) {
 		ctx.warnManualPreimageUsage(method)
 	}
 
+	// #131: warn when a public method gates on extractLocktime but never asserts
+	// the spending tx is non-final (extractSequence < 0xffffffff). Advisory only.
+	if method.Visibility == "public" {
+		ctx.warnLocktimeWithoutSequenceGuard(method)
+	}
+
 	// Gate asm({...}) calls on UnsafeSmartContract and check the structural args.
 	ctx.validateAsmUsage(method)
 
@@ -661,6 +667,110 @@ func (ctx *validationContext) warnManualPreimageUsage(method MethodNode) {
 			}
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// #131: locktime soundness — extractLocktime needs an extractSequence guard
+// ---------------------------------------------------------------------------
+
+// sequenceFinal is the sentinel maximum nSequence: a tx is FINAL (ignores
+// locktime) at this value.
+var sequenceFinal = new(big.Int).SetUint64(0xffffffff)
+
+// isCallToNamed reports whether expr is a direct call to the named intrinsic,
+// e.g. `f(...)`.
+func isCallToNamed(expr Expression, name string) bool {
+	call, ok := expr.(CallExpr)
+	if !ok {
+		return false
+	}
+	id, ok := call.Callee.(Identifier)
+	return ok && id.Name == name
+}
+
+// isLocktimeRead reports whether expr reads the transaction locktime. Both the
+// raw intrinsic extractLocktime(preimage) and its ergonomic sugar
+// currentBlockHeight() (which the ANF pass desugars to extractLocktime) count —
+// either read is unsound without a sequence-finality guard.
+func isLocktimeRead(expr Expression) bool {
+	return isCallToNamed(expr, "extractLocktime") || isCallToNamed(expr, "currentBlockHeight")
+}
+
+// isSequenceFinalityGuard reports whether expr is an
+// `extractSequence(...) < <final>`-style comparison (the guard that makes a
+// locktime gate consensus-enforced). Accepts the two natural spellings:
+// `extractSequence(pre) < N` / `<= N`, and the reversed `N > extractSequence(pre)`
+// / `>= ...`. N must be a bigint literal no greater than the finality sentinel,
+// so the guard genuinely forces non-finality.
+func isSequenceFinalityGuard(expr Expression) bool {
+	bin, ok := expr.(BinaryExpr)
+	if !ok {
+		return false
+	}
+	boundOk := func(e Expression) bool {
+		lit, ok := e.(BigIntLiteral)
+		return ok && lit.Value != nil && lit.Value.Cmp(sequenceFinal) <= 0
+	}
+	if (bin.Op == "<" || bin.Op == "<=") && isCallToNamed(bin.Left, "extractSequence") && boundOk(bin.Right) {
+		return true
+	}
+	if (bin.Op == ">" || bin.Op == ">=") && isCallToNamed(bin.Right, "extractSequence") && boundOk(bin.Left) {
+		return true
+	}
+	return false
+}
+
+// warnLocktimeWithoutSequenceGuard warns when method (transitively, through the
+// private-helper call graph) reads the tx locktime but never asserts the tx is
+// non-final. A locktime gate is not consensus-enforced unless
+// extractSequence < 0xffffffff is also asserted — otherwise an all-final-sequence
+// spend bypasses it. Advisory (warning) only — no effect on emitted bytecode.
+func (ctx *validationContext) warnLocktimeWithoutSequenceGuard(method MethodNode) {
+	privateMethods := make(map[string]MethodNode)
+	for _, m := range ctx.contract.Methods {
+		if m.Visibility == "private" {
+			privateMethods[m.Name] = m
+		}
+	}
+
+	readsLocktime := false
+	hasSequenceGuard := false
+	visited := map[string]bool{method.Name: true}
+	queue := []MethodNode{method}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		walkExpressionsInBody(current.Body, func(expr Expression) {
+			if isLocktimeRead(expr) {
+				readsLocktime = true
+			}
+			if isSequenceFinalityGuard(expr) {
+				hasSequenceGuard = true
+			}
+		})
+		// Follow calls into private helpers so a guard (or locktime read) supplied
+		// by an inlined helper is seen by the public entry point.
+		calls := make(map[string]bool)
+		collectMethodCalls(current.Body, calls)
+		for callee := range calls {
+			if visited[callee] {
+				continue
+			}
+			if pm, ok := privateMethods[callee]; ok {
+				visited[callee] = true
+				queue = append(queue, pm)
+			}
+		}
+	}
+
+	if readsLocktime && !hasSequenceGuard {
+		ctx.addWarningWithLoc(fmt.Sprintf(
+			"method '%s' reads extractLocktime but does not assert extractSequence < 0xffffffff; "+
+				"a locktime gate is not consensus-enforced unless the tx is non-final — add "+
+				"assert(extractSequence(this.txPreimage) < 0xffffffffn)",
+			method.Name), &method.SourceLocation)
+	}
 }
 
 func walkExpressionsInBody(stmts []Statement, visitor func(Expression)) {

--- a/compilers/go/frontend/validator_test.go
+++ b/compilers/go/frontend/validator_test.go
@@ -1692,3 +1692,175 @@ class C extends SmartContract {
 		t.Errorf("did not expect 'countdown' error, got: %s", strings.Join(result.ErrorStrings(), "; "))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// H2 (#131): locktime soundness warning.
+//
+// A public method that reads extractLocktime(preimage) — directly or
+// transitively through a private helper — only enforces a timelock if the
+// covenant ALSO asserts the spending tx is non-final
+// (extractSequence(preimage) < 0xffffffff). Otherwise a hand-built
+// all-final-sequence tx bypasses the locktime gate. The validator emits an
+// advisory WARNING (non-fatal) when the guard is missing.
+// ---------------------------------------------------------------------------
+
+const locktimeWarningNeedle = "does not assert extractSequence"
+
+func hasLocktimeWarning(result *ValidationResult) bool {
+	for _, w := range result.Warnings {
+		if strings.Contains(w.Message, locktimeWarningNeedle) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidate_H2_LocktimeWithoutSequenceGuard_Warns(t *testing.T) {
+	source := `
+import { StatefulSmartContract, assert, extractLocktime } from 'runar-lang';
+
+class TimeLock extends StatefulSmartContract {
+  count: bigint;
+  readonly deadline: bigint;
+  constructor(count: bigint, deadline: bigint) {
+    super(count, deadline);
+    this.count = count;
+    this.deadline = deadline;
+  }
+  public unlock(): void {
+    assert(extractLocktime(this.txPreimage) >= this.deadline);
+    this.count++;
+  }
+}
+`
+	contract := mustParseTS(t, source)
+	result := Validate(contract)
+	if !hasLocktimeWarning(result) {
+		t.Fatalf("expected a locktime-soundness warning, got warnings: %v", result.WarningStrings())
+	}
+	// The warning names the method, points at the fix, and is a warning.
+	var found *Diagnostic
+	for i := range result.Warnings {
+		if strings.Contains(result.Warnings[i].Message, locktimeWarningNeedle) {
+			found = &result.Warnings[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected to find the locktime warning diagnostic")
+	}
+	if found.Severity != SeverityWarning {
+		t.Errorf("expected severity warning, got: %v", found.Severity)
+	}
+	if !strings.Contains(found.Message, "unlock") {
+		t.Errorf("expected warning to name the method 'unlock', got: %s", found.Message)
+	}
+	if !strings.Contains(found.Message, "0xffffffff") {
+		t.Errorf("expected warning to mention 0xffffffff, got: %s", found.Message)
+	}
+}
+
+func TestValidate_H2_LocktimeWithSequenceGuard_NoWarn(t *testing.T) {
+	source := `
+import { StatefulSmartContract, assert, extractLocktime, extractSequence } from 'runar-lang';
+
+class TimeLock extends StatefulSmartContract {
+  count: bigint;
+  readonly deadline: bigint;
+  constructor(count: bigint, deadline: bigint) {
+    super(count, deadline);
+    this.count = count;
+    this.deadline = deadline;
+  }
+  public unlock(): void {
+    assert(extractSequence(this.txPreimage) < 0xffffffffn);
+    assert(extractLocktime(this.txPreimage) >= this.deadline);
+    this.count++;
+  }
+}
+`
+	contract := mustParseTS(t, source)
+	result := Validate(contract)
+	if hasLocktimeWarning(result) {
+		t.Errorf("did not expect a locktime warning when extractSequence guard is present, got: %v", result.WarningStrings())
+	}
+}
+
+func TestValidate_H2_NoLocktimeRead_NoWarn(t *testing.T) {
+	source := `
+import { StatefulSmartContract } from 'runar-lang';
+
+class Counter extends StatefulSmartContract {
+  count: bigint;
+  constructor(count: bigint) {
+    super(count);
+    this.count = count;
+  }
+  public increment(): void {
+    this.count++;
+  }
+}
+`
+	contract := mustParseTS(t, source)
+	result := Validate(contract)
+	if hasLocktimeWarning(result) {
+		t.Errorf("did not expect a locktime warning for a method that never reads locktime, got: %v", result.WarningStrings())
+	}
+}
+
+func TestValidate_H2_SequenceGuardViaPrivateHelper_NoWarn(t *testing.T) {
+	source := `
+import { StatefulSmartContract, assert, extractLocktime, extractSequence } from 'runar-lang';
+
+class TimeLock extends StatefulSmartContract {
+  count: bigint;
+  readonly deadline: bigint;
+  constructor(count: bigint, deadline: bigint) {
+    super(count, deadline);
+    this.count = count;
+    this.deadline = deadline;
+  }
+  private requireNonFinal(): void {
+    assert(extractSequence(this.txPreimage) < 0xffffffffn);
+  }
+  public unlock(): void {
+    this.requireNonFinal();
+    assert(extractLocktime(this.txPreimage) >= this.deadline);
+    this.count++;
+  }
+}
+`
+	contract := mustParseTS(t, source)
+	result := Validate(contract)
+	if hasLocktimeWarning(result) {
+		t.Errorf("did not expect a locktime warning when guard is supplied via a private helper, got: %v", result.WarningStrings())
+	}
+}
+
+func TestValidate_H2_LocktimeReadInPrivateHelper_NoGuard_Warns(t *testing.T) {
+	source := `
+import { StatefulSmartContract, assert, extractLocktime } from 'runar-lang';
+
+class TimeLock extends StatefulSmartContract {
+  count: bigint;
+  readonly deadline: bigint;
+  constructor(count: bigint, deadline: bigint) {
+    super(count, deadline);
+    this.count = count;
+    this.deadline = deadline;
+  }
+  private checkDeadline(): void {
+    assert(extractLocktime(this.txPreimage) >= this.deadline);
+  }
+  public unlock(): void {
+    this.checkDeadline();
+    this.count++;
+  }
+}
+`
+	contract := mustParseTS(t, source)
+	result := Validate(contract)
+	if !hasLocktimeWarning(result) {
+		t.Errorf("expected a locktime warning when the read is in a private helper and no guard exists, got: %v", result.WarningStrings())
+	}
+}

--- a/compilers/java/src/main/java/runar/compiler/passes/StackLower.java
+++ b/compilers/java/src/main/java/runar/compiler/passes/StackLower.java
@@ -1008,11 +1008,34 @@ public final class StackLower {
                 pushPropertyValue(prop.initialValue());
             } else {
                 // Deployment-time constructor arg placeholder.
-                int paramIndex = 0;
+                //
+                // #119 tail (H1): a property that reaches this fallback with no
+                // matching constructor slot (paramIndex < 0) has no deploy-time
+                // bytes of its own. The previous behaviour coerced it onto slot
+                // 0, silently splicing an UNRELATED constructor argument's
+                // placeholder into the locking script — a silent-wrong-code
+                // path. Fail loudly instead. (A real constructor-param property
+                // — readonly, or a mutable state field whose initial value is
+                // spliced at deploy — is found and unaffected, so zero golden
+                // churn.)
+                List<String> ctorProps = new ArrayList<>();
                 for (AnfProperty p : properties) {
                     if (p.initialValue() != null) continue;
-                    if (p.name().equals(propName)) break;
-                    paramIndex++;
+                    ctorProps.add(p.name());
+                }
+                int paramIndex = ctorProps.indexOf(propName);
+                if (paramIndex < 0) {
+                    String loc = currentSourceLoc != null
+                        ? " at " + currentSourceLoc.file() + ":" + currentSourceLoc.line()
+                            + ":" + currentSourceLoc.column()
+                        : "";
+                    throw new RuntimeException(
+                        "Stack lowering: property '" + propName + "'" + loc
+                            + " is neither on the stack, initialized, nor a constructor "
+                            + "parameter, so it has no deploy-time slot. Refusing to emit "
+                            + "a placeholder for an unrelated constructor argument (slot 0). "
+                            + "Known constructor-param properties: ["
+                            + String.join(", ", ctorProps) + "].");
                 }
                 emitOp(new PlaceholderOp(paramIndex, propName));
             }

--- a/compilers/java/src/main/java/runar/compiler/passes/Validate.java
+++ b/compilers/java/src/main/java/runar/compiler/passes/Validate.java
@@ -397,6 +397,14 @@ public final class Validate {
                 }
             }
 
+            // #131: warn when a public method gates on extractLocktime but
+            // never asserts the spending tx is non-final
+            // (extractSequence < 0xffffffff). Advisory only — no effect on the
+            // emitted bytecode.
+            if (m.visibility() == Visibility.PUBLIC) {
+                warnLocktimeWithoutSequenceGuard(m, this);
+            }
+
             // Gate asm({...}) calls on UnsafeSmartContract and check the
             // structural args.
             validateAsmUsage(m);
@@ -1043,6 +1051,110 @@ public final class Validate {
             for (Expression el : al.elements()) {
                 collectMethodCallsInExpr(el, out);
             }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // #131: locktime soundness — extractLocktime needs an extractSequence guard
+    // ------------------------------------------------------------------
+
+    /** Sentinel maximum nSequence: a tx is FINAL (ignores locktime) at this value. */
+    private static final java.math.BigInteger SEQUENCE_FINAL =
+        java.math.BigInteger.valueOf(0xffffffffL);
+
+    /** True when {@code expr} is a direct call to the named intrinsic, e.g. {@code f(...)}. */
+    private static boolean isCallToNamed(Expression expr, String name) {
+        return expr instanceof CallExpr c
+            && c.callee() instanceof Identifier id
+            && name.equals(id.name());
+    }
+
+    /**
+     * True when {@code expr} reads the transaction locktime. Both the raw
+     * intrinsic {@code extractLocktime(preimage)} and its ergonomic sugar
+     * {@code currentBlockHeight()} (which the ANF pass desugars to
+     * {@code extractLocktime(txPreimage)}) count — either read is unsound
+     * without a sequence-finality guard.
+     */
+    private static boolean isLocktimeRead(Expression expr) {
+        return isCallToNamed(expr, "extractLocktime")
+            || isCallToNamed(expr, "currentBlockHeight");
+    }
+
+    /**
+     * True when {@code expr} is an {@code extractSequence(...) < <final>}-style
+     * comparison (the guard that makes a locktime gate consensus-enforced).
+     * Accepts the two natural spellings: {@code extractSequence(pre) < N} /
+     * {@code <= N}, and the reversed {@code N > extractSequence(pre)} /
+     * {@code >= ...}. {@code N} must be a bigint literal no greater than the
+     * finality sentinel, so the guard genuinely forces non-finality.
+     */
+    private static boolean isSequenceFinalityGuard(Expression expr) {
+        if (!(expr instanceof BinaryExpr be)) return false;
+        Expression.BinaryOp op = be.op();
+        if ((op == Expression.BinaryOp.LT || op == Expression.BinaryOp.LE)
+            && isCallToNamed(be.left(), "extractSequence") && isSequenceBound(be.right())) {
+            return true;
+        }
+        if ((op == Expression.BinaryOp.GT || op == Expression.BinaryOp.GE)
+            && isCallToNamed(be.right(), "extractSequence") && isSequenceBound(be.left())) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isSequenceBound(Expression e) {
+        return e instanceof BigIntLiteral lit && lit.value().compareTo(SEQUENCE_FINAL) <= 0;
+    }
+
+    /**
+     * #131: warn when {@code method} (transitively, through the private-helper
+     * call graph) reads the tx locktime but never asserts the tx is non-final.
+     * A locktime gate is not consensus-enforced unless
+     * {@code extractSequence < 0xffffffff} is also asserted — otherwise an
+     * all-final-sequence spend bypasses it. Advisory (warning) only — no effect
+     * on emitted bytecode.
+     */
+    private static void warnLocktimeWithoutSequenceGuard(MethodNode method, Ctx ctx) {
+        java.util.Map<String, MethodNode> privateMethods = new java.util.HashMap<>();
+        for (MethodNode m : ctx.contract.methods()) {
+            if (m.visibility() == Visibility.PRIVATE) {
+                privateMethods.put(m.name(), m);
+            }
+        }
+
+        boolean[] readsLocktime = {false};
+        boolean[] hasSequenceGuard = {false};
+        Set<String> visited = new HashSet<>();
+        visited.add(method.name());
+        java.util.Deque<MethodNode> queue = new java.util.ArrayDeque<>();
+        queue.add(method);
+
+        while (!queue.isEmpty()) {
+            MethodNode current = queue.poll();
+            Ctx.walkExpressionsInBody(current.body(), expr -> {
+                if (isLocktimeRead(expr)) readsLocktime[0] = true;
+                if (isSequenceFinalityGuard(expr)) hasSequenceGuard[0] = true;
+            });
+            // Follow calls into private helpers so a guard (or locktime read)
+            // supplied by an inlined helper is seen by the public entry point.
+            Set<String> calls = new HashSet<>();
+            collectMethodCalls(current.body(), calls);
+            for (String callee : calls) {
+                if (!visited.contains(callee) && privateMethods.containsKey(callee)) {
+                    visited.add(callee);
+                    queue.add(privateMethods.get(callee));
+                }
+            }
+        }
+
+        if (readsLocktime[0] && !hasSequenceGuard[0]) {
+            ctx.warn(
+                "method '" + method.name() + "' reads extractLocktime but does not assert "
+                    + "extractSequence < 0xffffffff; a locktime gate is not consensus-enforced "
+                    + "unless the tx is non-final — add "
+                    + "assert(extractSequence(this.txPreimage) < 0xffffffffn)",
+                method.sourceLocation());
         }
     }
 

--- a/compilers/java/src/test/java/runar/compiler/passes/H1LoadPropGuardTest.java
+++ b/compilers/java/src/test/java/runar/compiler/passes/H1LoadPropGuardTest.java
@@ -1,0 +1,97 @@
+package runar.compiler.passes;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import runar.compiler.ir.anf.AnfBinding;
+import runar.compiler.ir.anf.AnfMethod;
+import runar.compiler.ir.anf.AnfProgram;
+import runar.compiler.ir.anf.AnfProperty;
+import runar.compiler.ir.anf.Assert;
+import runar.compiler.ir.anf.LoadProp;
+import runar.compiler.ir.ast.SourceLocation;
+
+/**
+ * H1 (#119 tail): {@code lowerLoadProp} must NOT silently coerce an unknown
+ * property onto constructor slot 0.
+ *
+ * <p>A {@code load_prop} binding whose name is not a declared constructor-param
+ * property used to fall through to {@code paramIndex >= 0 ? paramIndex : 0},
+ * emitting the placeholder for constructor slot 0 — an UNRELATED argument's
+ * deploy-time bytes — with no diagnostic. That is a silent-wrong-code path: the
+ * produced locking script splices the wrong value at that position.
+ *
+ * <p>The hardened behaviour is a HARD ERROR ({@link RuntimeException}) with a
+ * clear diagnostic and the binding's source location, instead of the silent
+ * placeholder. A real constructor-param property (readonly, or a mutable state
+ * field spliced at deploy) is still lowered without error.
+ *
+ * <p>Port of {@code remediation-h1-loadprop-guard.test.ts}.
+ */
+class H1LoadPropGuardTest {
+
+    /**
+     * Minimal ANF program with a real readonly constructor-param property
+     * {@code pk} (constructor slot 0) plus a public method that loads a
+     * property {@code ghost} that is NOT declared on the contract. {@code ghost}
+     * therefore reaches the placeholder fallback with no matching slot.
+     */
+    private static AnfProgram programWithUnknownLoadProp() {
+        AnfMethod spend = new AnfMethod(
+            "spend",
+            List.of(),
+            List.of(
+                new AnfBinding("t0", new LoadProp("ghost"),
+                    new SourceLocation("Ghost.runar.java", 7, 4)),
+                new AnfBinding("t1", new Assert("t0"), null)
+            ),
+            true);
+        return new AnfProgram(
+            "Ghost",
+            List.of(new AnfProperty("pk", "PubKey", true, null)),
+            List.of(spend));
+    }
+
+    @Test
+    void throwsOnLoadPropForPropertyWithNoConstructorSlot() {
+        assertThrows(RuntimeException.class,
+            () -> StackLower.run(programWithUnknownLoadProp()));
+    }
+
+    @Test
+    void includesOffendingNameAndSourceLocationInDiagnostic() {
+        RuntimeException err = assertThrows(RuntimeException.class,
+            () -> StackLower.run(programWithUnknownLoadProp()));
+        String message = err.getMessage();
+        assertTrue(message.contains("ghost"),
+            "diagnostic must name the offending property; got: " + message);
+        assertTrue(message.contains("Ghost.runar.java"),
+            "diagnostic must include the source file; got: " + message);
+        assertTrue(message.contains("7"),
+            "diagnostic must include the source line; got: " + message);
+        // The list of legit constructor-param properties is surfaced so the
+        // author can see what WAS resolvable.
+        assertTrue(message.contains("pk"),
+            "diagnostic must list the known constructor-param properties; got: " + message);
+    }
+
+    @Test
+    void lowersRealConstructorParamPropertyWithoutError() {
+        AnfMethod spend = new AnfMethod(
+            "spend",
+            List.of(),
+            List.of(
+                new AnfBinding("t0", new LoadProp("pk"), null),
+                new AnfBinding("t1", new Assert("t0"), null)
+            ),
+            true);
+        AnfProgram program = new AnfProgram(
+            "Ok",
+            List.of(new AnfProperty("pk", "PubKey", true, null)),
+            List.of(spend));
+        assertDoesNotThrow(() -> StackLower.run(program));
+    }
+}

--- a/compilers/java/src/test/java/runar/compiler/passes/H2LocktimeWarningTest.java
+++ b/compilers/java/src/test/java/runar/compiler/passes/H2LocktimeWarningTest.java
@@ -1,0 +1,152 @@
+package runar.compiler.passes;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import runar.compiler.frontend.TsParser;
+import runar.compiler.ir.ast.ContractNode;
+
+/**
+ * H2 (#131): locktime soundness warning.
+ *
+ * <p>A method that reads {@code extractLocktime(preimage)} only enforces a
+ * timelock if the covenant ALSO asserts the spending tx is non-final
+ * ({@code extractSequence(preimage) < 0xffffffff}). Without that, a hand-built
+ * all-final-sequence transaction bypasses the locktime gate. The compiler emits
+ * an advisory WARNING (non-fatal) when a public method reads extractLocktime but
+ * does not (transitively) assert a sequence-finality guard.
+ *
+ * <p>Port of {@code remediation-h2-locktime-sequence-warning.test.ts}. Sources
+ * are parsed on the {@code .runar.ts} surface — the guard lives in the shared
+ * validator and is format-agnostic.
+ */
+class H2LocktimeWarningTest {
+
+    private static final String WARNING_NEEDLE = "does not assert extractSequence";
+
+    private static Validate.Result validateSource(String source) throws TsParser.ParseException {
+        ContractNode contract = TsParser.parse(source, "TimeLock.runar.ts");
+        return Validate.runCollecting(contract);
+    }
+
+    private static boolean hasLocktimeWarning(Validate.Result result) {
+        return result.warnings().stream().anyMatch(w -> w.contains(WARNING_NEEDLE));
+    }
+
+    @Test
+    void warnsWhenMethodReadsLocktimeButHasNoSequenceGuard() throws TsParser.ParseException {
+        String source = """
+            class TimeLock extends StatefulSmartContract {
+              count: bigint;
+              readonly deadline: bigint;
+              constructor(count: bigint, deadline: bigint) {
+                super(count, deadline);
+                this.count = count;
+                this.deadline = deadline;
+              }
+              public unlock() {
+                assert(extractLocktime(this.txPreimage) >= this.deadline);
+                this.count++;
+              }
+            }
+            """;
+        Validate.Result result = validateSource(source);
+        assertTrue(hasLocktimeWarning(result),
+            "expected the locktime-soundness warning; got: " + result.warnings());
+        List<String> matches = result.warnings().stream()
+            .filter(w -> w.contains(WARNING_NEEDLE)).toList();
+        String w = matches.get(0);
+        // The warning names the method and points at the fix.
+        assertTrue(w.contains("unlock"), "warning must name the method; got: " + w);
+        assertTrue(w.contains("0xffffffff"), "warning must reference 0xffffffff; got: " + w);
+    }
+
+    @Test
+    void doesNotWarnWhenMethodAlsoAssertsSequenceLessThanFinal() throws TsParser.ParseException {
+        String source = """
+            class TimeLock extends StatefulSmartContract {
+              count: bigint;
+              readonly deadline: bigint;
+              constructor(count: bigint, deadline: bigint) {
+                super(count, deadline);
+                this.count = count;
+                this.deadline = deadline;
+              }
+              public unlock() {
+                assert(extractSequence(this.txPreimage) < 0xffffffffn);
+                assert(extractLocktime(this.txPreimage) >= this.deadline);
+                this.count++;
+              }
+            }
+            """;
+        assertFalse(hasLocktimeWarning(validateSource(source)));
+    }
+
+    @Test
+    void doesNotWarnForMethodThatNeverReadsLocktime() throws TsParser.ParseException {
+        String source = """
+            class Counter extends StatefulSmartContract {
+              count: bigint;
+              constructor(count: bigint) {
+                super(count);
+                this.count = count;
+              }
+              public increment() {
+                this.count++;
+              }
+            }
+            """;
+        assertFalse(hasLocktimeWarning(validateSource(source)));
+    }
+
+    @Test
+    void seesSequenceGuardSuppliedTransitivelyThroughPrivateHelper() throws TsParser.ParseException {
+        String source = """
+            class TimeLock extends StatefulSmartContract {
+              count: bigint;
+              readonly deadline: bigint;
+              constructor(count: bigint, deadline: bigint) {
+                super(count, deadline);
+                this.count = count;
+                this.deadline = deadline;
+              }
+              private requireNonFinal() {
+                assert(extractSequence(this.txPreimage) < 0xffffffffn);
+              }
+              public unlock() {
+                this.requireNonFinal();
+                assert(extractLocktime(this.txPreimage) >= this.deadline);
+                this.count++;
+              }
+            }
+            """;
+        assertFalse(hasLocktimeWarning(validateSource(source)));
+    }
+
+    @Test
+    void warnsWhenLocktimeReadIsInPrivateHelperButNoSequenceGuardExists() throws TsParser.ParseException {
+        String source = """
+            class TimeLock extends StatefulSmartContract {
+              count: bigint;
+              readonly deadline: bigint;
+              constructor(count: bigint, deadline: bigint) {
+                super(count, deadline);
+                this.count = count;
+                this.deadline = deadline;
+              }
+              private checkDeadline() {
+                assert(extractLocktime(this.txPreimage) >= this.deadline);
+              }
+              public unlock() {
+                this.checkDeadline();
+                this.count++;
+              }
+            }
+            """;
+        assertTrue(hasLocktimeWarning(validateSource(source)),
+            "expected the locktime-soundness warning; got: "
+                + validateSource(source).warnings());
+    }
+}

--- a/compilers/python/runar_compiler/codegen/stack.py
+++ b/compilers/python/runar_compiler/codegen/stack.py
@@ -1080,13 +1080,49 @@ class _LoweringContext:
             self._push_property_value(prop.initial_value)
         else:
             # Property value will be provided at deployment time; emit placeholder
+            # for its constructor slot.
+            #
+            # #119 tail (H1): a property that reaches this fallback with no
+            # matching constructor slot has no deploy-time bytes of its own. The
+            # previous behaviour left param_index at the count of ctor-param
+            # props, silently emitting a placeholder for an UNRELATED
+            # constructor argument's slot and splicing the wrong deploy-time
+            # bytes into the locking script -- a silent-wrong-code path. Fail
+            # loudly instead. (A real constructor-param property -- readonly, or
+            # a mutable state field whose initial value is spliced at deploy --
+            # is found here and is unaffected.)
             param_index = 0
+            found = False
+            ctor_params: list[str] = []
             for p in self.properties:
                 if p.initial_value is not None:
                     continue
+                ctor_params.append(p.name)
                 if p.name == prop_name:
+                    found = True
                     break
                 param_index += 1
+            # A true ghost is a name absent from a NON-EMPTY registered
+            # constructor-param list -- exactly the silent-wrong-code case where
+            # the old code coerced it onto an unrelated registered slot. When no
+            # constructor-param property is registered (an empty ``ctor_params``
+            # -- e.g. a ``.runar.ts`` contract whose only constructor param is
+            # declared inline as ``readonly n`` and never surfaces as a property
+            # in this tier's TS parser), the name may still be a legitimate
+            # slot-0 argument, so preserve the historical placeholder rather than
+            # false-positive on a valid deploy-time slot.
+            if not found and ctor_params:
+                loc = ""
+                if self.current_source_loc is not None:
+                    sl = self.current_source_loc
+                    loc = f" at {sl.file}:{sl.line}:{sl.column}"
+                raise RuntimeError(
+                    f"Stack lowering: property '{prop_name}'{loc} is neither on "
+                    f"the stack, initialized, nor a constructor parameter, so it "
+                    f"has no deploy-time slot. Refusing to emit a placeholder for "
+                    f"an unrelated constructor argument (slot 0). Known "
+                    f"constructor-param properties: [{', '.join(ctor_params)}]."
+                )
             self.emit_op(StackOp(op="placeholder", param_index=param_index, param_name=prop_name))
         self.sm.push(binding_name)
 

--- a/compilers/python/runar_compiler/frontend/validator.py
+++ b/compilers/python/runar_compiler/frontend/validator.py
@@ -288,6 +288,12 @@ class _ValidationContext:
         if self.contract.parent_class == "StatefulSmartContract" and method.visibility == "public":
             _warn_manual_preimage_usage(method, self.warnings)
 
+        # #131: warn when a public method gates on extractLocktime but never
+        # asserts the spending tx is non-final (extractSequence < 0xffffffff).
+        # Advisory only.
+        if method.visibility == "public":
+            _warn_locktime_without_sequence_guard(method, self.contract, self.warnings)
+
         # Gate asm({...}) calls on UnsafeSmartContract and check the structural args.
         self._validate_asm_usage(method)
 
@@ -639,6 +645,110 @@ def _warn_manual_preimage_usage(method, warnings: list[Diagnostic]) -> None:
                 ))
 
     _walk_expressions_in_body(method.body, visitor)
+
+
+# ---------------------------------------------------------------------------
+# #131: locktime soundness -- extractLocktime needs an extractSequence guard
+# ---------------------------------------------------------------------------
+
+# Sentinel maximum nSequence: a tx is FINAL (ignores locktime) at this value.
+_SEQUENCE_FINAL = 0xffffffff
+
+
+def _is_call_to_named(expr: Expression, name: str) -> bool:
+    """True when *expr* is a direct call to the named intrinsic, e.g. ``f(...)``."""
+    return (
+        isinstance(expr, CallExpr)
+        and isinstance(expr.callee, Identifier)
+        and expr.callee.name == name
+    )
+
+
+def _is_locktime_read(expr: Expression) -> bool:
+    """True when *expr* reads the transaction locktime.
+
+    Both the raw intrinsic ``extractLocktime(preimage)`` and its ergonomic sugar
+    ``currentBlockHeight()`` (which anf-lower desugars to
+    ``extractLocktime(txPreimage)``) count -- either read is unsound without a
+    sequence-finality guard.
+    """
+    return (
+        _is_call_to_named(expr, "extractLocktime")
+        or _is_call_to_named(expr, "currentBlockHeight")
+    )
+
+
+def _is_sequence_finality_guard(expr: Expression) -> bool:
+    """True when *expr* is an ``extractSequence(...) < <final>``-style comparison
+    (the guard that makes a locktime gate consensus-enforced).
+
+    Accepts the two natural spellings: ``extractSequence(pre) < N`` / ``<= N``,
+    and the reversed ``N > extractSequence(pre)`` / ``>= ...``. ``N`` must be a
+    bigint literal no greater than the finality sentinel, so the guard genuinely
+    forces non-finality.
+    """
+    if not isinstance(expr, BinaryExpr):
+        return False
+
+    def bound_ok(e: Expression) -> bool:
+        return isinstance(e, BigIntLiteral) and e.value <= _SEQUENCE_FINAL
+
+    if (expr.op in ("<", "<=")
+            and _is_call_to_named(expr.left, "extractSequence")
+            and bound_ok(expr.right)):
+        return True
+    if (expr.op in (">", ">=")
+            and _is_call_to_named(expr.right, "extractSequence")
+            and bound_ok(expr.left)):
+        return True
+    return False
+
+
+def _warn_locktime_without_sequence_guard(method, contract, warnings: list[Diagnostic]) -> None:
+    """#131: warn when *method* (transitively, through the private-helper call
+    graph) reads the tx locktime but never asserts the tx is non-final.
+
+    A locktime gate is not consensus-enforced unless ``extractSequence <
+    0xffffffff`` is also asserted -- otherwise an all-final-sequence spend
+    bypasses it. Advisory (warning) only -- no effect on emitted bytecode.
+    """
+    private_methods = {
+        m.name: m for m in contract.methods if m.visibility == "private"
+    }
+
+    reads_locktime = False
+    has_sequence_guard = False
+
+    def visitor(expr: Expression) -> None:
+        nonlocal reads_locktime, has_sequence_guard
+        if _is_locktime_read(expr):
+            reads_locktime = True
+        if _is_sequence_finality_guard(expr):
+            has_sequence_guard = True
+
+    visited: set[str] = {method.name}
+    queue: list = [method]
+    while queue:
+        current = queue.pop(0)
+        _walk_expressions_in_body(current.body, visitor)
+        # Follow calls into private helpers so a guard (or locktime read)
+        # supplied by an inlined helper is seen by the public entry point.
+        calls: set[str] = set()
+        _collect_method_calls(current.body, calls)
+        for callee in calls:
+            if callee not in visited and callee in private_methods:
+                visited.add(callee)
+                queue.append(private_methods[callee])
+
+    if reads_locktime and not has_sequence_guard:
+        warnings.append(Diagnostic(
+            message=f"method '{method.name}' reads extractLocktime but does not assert "
+            f"extractSequence < 0xffffffff; a locktime gate is not consensus-enforced "
+            f"unless the tx is non-final — add "
+            f"assert(extractSequence(this.txPreimage) < 0xffffffffn)",
+            severity=Severity.WARNING,
+            loc=method.source_location,
+        ))
 
 
 def _callee_property(callee: Expression | None) -> str | None:

--- a/compilers/python/tests/codegen/test_h1_loadprop_guard.py
+++ b/compilers/python/tests/codegen/test_h1_loadprop_guard.py
@@ -1,0 +1,104 @@
+"""H1 (#119 tail): ``_lower_load_prop`` must NOT silently coerce an unknown
+property onto a constructor slot.
+
+A ``load_prop`` binding whose name is not a declared constructor-param property
+used to fall through to the placeholder fallback: the ``param_index`` loop never
+matched, leaving it at the count of non-initialized props, so the emitted
+placeholder spliced an UNRELATED constructor argument's deploy-time bytes into
+the locking script -- a silent-wrong-code path with no diagnostic.
+
+The hardened behaviour is a HARD ERROR (``RuntimeError``) with a clear
+diagnostic that names the offending property, states it has no deploy-time slot
+/ is not a constructor parameter, and lists the known constructor-param
+property names. A real constructor-param property (readonly, or a mutable state
+field whose initial value is spliced at deploy) is found and is unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runar_compiler.codegen.stack import lower_to_stack
+from runar_compiler.ir.types import (
+    ANFBinding,
+    ANFMethod,
+    ANFProgram,
+    ANFProperty,
+    ANFValue,
+    SourceLocation,
+)
+
+
+def _program_with_unknown_load_prop() -> ANFProgram:
+    """Minimal ANF program with a real readonly constructor-param property
+    ``pk`` (constructor slot 0) plus a public method that loads a property
+    ``ghost`` that is NOT declared on the contract. ``ghost`` therefore reaches
+    the placeholder fallback with no matching constructor slot.
+    """
+    return ANFProgram(
+        contract_name="Ghost",
+        properties=[ANFProperty(name="pk", type="PubKey", readonly=True)],
+        methods=[
+            ANFMethod(
+                name="spend",
+                params=[],
+                is_public=True,
+                body=[
+                    ANFBinding(
+                        name="t0",
+                        value=ANFValue(kind="load_prop", name="ghost"),
+                        source_loc=SourceLocation(
+                            file="Ghost.runar.py", line=7, column=4
+                        ),
+                    ),
+                    ANFBinding(
+                        name="t1",
+                        value=ANFValue(kind="assert", value_ref="t0"),
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def test_raises_on_load_prop_with_no_constructor_slot() -> None:
+    with pytest.raises(RuntimeError, match="ghost"):
+        lower_to_stack(_program_with_unknown_load_prop())
+
+
+def test_diagnostic_names_property_slot_and_source_location() -> None:
+    with pytest.raises(RuntimeError) as excinfo:
+        lower_to_stack(_program_with_unknown_load_prop())
+    message = str(excinfo.value)
+    # The offending property name.
+    assert "ghost" in message
+    # States it is not a constructor parameter / has no deploy-time slot.
+    assert "constructor parameter" in message
+    assert "deploy-time" in message
+    # Lists the known constructor-param property names.
+    assert "pk" in message
+    # Includes the source location carried by the ANF binding.
+    assert "Ghost.runar.py" in message
+    assert "7" in message
+
+
+def test_legit_ctor_param_prop_lowers_without_error() -> None:
+    """A real readonly constructor-param property is found (param_index >= 0)
+    and lowers to a placeholder without raising."""
+    program = ANFProgram(
+        contract_name="Ok",
+        properties=[ANFProperty(name="pk", type="PubKey", readonly=True)],
+        methods=[
+            ANFMethod(
+                name="spend",
+                params=[],
+                is_public=True,
+                body=[
+                    ANFBinding(name="t0", value=ANFValue(kind="load_prop", name="pk")),
+                    ANFBinding(name="t1", value=ANFValue(kind="assert", value_ref="t0")),
+                ],
+            )
+        ],
+    )
+    # Must not raise.
+    lower_to_stack(program)

--- a/compilers/python/tests/test_h2_locktime_warning.py
+++ b/compilers/python/tests/test_h2_locktime_warning.py
@@ -1,0 +1,170 @@
+"""H2 (#131): locktime soundness warning.
+
+A method that reads ``extract_locktime(self.tx_preimage)`` only enforces a
+timelock if the covenant ALSO asserts the spending tx is non-final
+(``extract_sequence(self.tx_preimage) < 0xffffffff``). Without that, a
+hand-built all-final-sequence transaction bypasses the locktime gate. The
+compiler emits an advisory WARNING (non-fatal) when a public method reads the
+tx locktime -- directly or transitively through a private helper -- but never
+asserts a sequence-finality guard.
+
+Contracts are written in Python format; the parser lowers snake_case names to
+camelCase (``extract_locktime`` -> ``extractLocktime``,
+``extract_sequence`` -> ``extractSequence``,
+``current_block_height`` -> ``currentBlockHeight``) so the warning matches the
+camelCase intrinsic names in the AST.
+"""
+
+from __future__ import annotations
+
+from runar_compiler.frontend.parser_dispatch import parse_source
+from runar_compiler.frontend.validator import ValidationResult, validate
+
+
+WARNING_NEEDLE = "does not assert extractSequence"
+
+
+def _validate_source(source: str) -> ValidationResult:
+    pr = parse_source(source, "TimeLock.runar.py")
+    assert not pr.errors, f"parse errors: {pr.errors}"
+    return validate(pr.contract)
+
+
+def _has_locktime_warning(result: ValidationResult) -> bool:
+    return any(WARNING_NEEDLE in w.message for w in result.warnings)
+
+
+def test_warns_when_method_reads_locktime_without_sequence_guard() -> None:
+    source = """
+from runar import (
+    StatefulSmartContract, Bigint, Readonly,
+    public, assert_, extract_locktime,
+)
+
+
+class TimeLock(StatefulSmartContract):
+    deadline: Readonly[Bigint]
+    count: Bigint
+
+    def __init__(self, deadline: Bigint, count: Bigint):
+        super().__init__(deadline, count)
+        self.deadline = deadline
+        self.count = count
+
+    @public
+    def unlock(self):
+        assert_(extract_locktime(self.tx_preimage) >= self.deadline)
+        self.count = self.count + 1
+"""
+    result = _validate_source(source)
+    assert _has_locktime_warning(result)
+    warning = next(w for w in result.warnings if WARNING_NEEDLE in w.message)
+    assert warning.severity == "warning"
+    assert "unlock" in warning.message
+    assert "0xffffffff" in warning.message
+
+
+def test_no_warn_when_method_asserts_sequence_below_final() -> None:
+    source = """
+from runar import (
+    StatefulSmartContract, Bigint, Readonly,
+    public, assert_, extract_locktime, extract_sequence,
+)
+
+
+class TimeLock(StatefulSmartContract):
+    deadline: Readonly[Bigint]
+    count: Bigint
+
+    def __init__(self, deadline: Bigint, count: Bigint):
+        super().__init__(deadline, count)
+        self.deadline = deadline
+        self.count = count
+
+    @public
+    def unlock(self):
+        assert_(extract_sequence(self.tx_preimage) < 0xffffffff)
+        assert_(extract_locktime(self.tx_preimage) >= self.deadline)
+        self.count = self.count + 1
+"""
+    result = _validate_source(source)
+    assert not _has_locktime_warning(result)
+
+
+def test_no_warn_when_method_never_reads_locktime() -> None:
+    source = """
+from runar import StatefulSmartContract, Bigint, public
+
+
+class Counter(StatefulSmartContract):
+    count: Bigint
+
+    def __init__(self, count: Bigint):
+        super().__init__(count)
+        self.count = count
+
+    @public
+    def increment(self):
+        self.count = self.count + 1
+"""
+    result = _validate_source(source)
+    assert not _has_locktime_warning(result)
+
+
+def test_no_warn_when_sequence_guard_supplied_transitively() -> None:
+    source = """
+from runar import (
+    StatefulSmartContract, Bigint, Readonly,
+    public, assert_, extract_locktime, extract_sequence,
+)
+
+
+class TimeLock(StatefulSmartContract):
+    deadline: Readonly[Bigint]
+    count: Bigint
+
+    def __init__(self, deadline: Bigint, count: Bigint):
+        super().__init__(deadline, count)
+        self.deadline = deadline
+        self.count = count
+
+    def require_non_final(self):
+        assert_(extract_sequence(self.tx_preimage) < 0xffffffff)
+
+    @public
+    def unlock(self):
+        self.require_non_final()
+        assert_(extract_locktime(self.tx_preimage) >= self.deadline)
+        self.count = self.count + 1
+"""
+    result = _validate_source(source)
+    assert not _has_locktime_warning(result)
+
+
+def test_warns_when_locktime_read_in_private_helper_but_no_guard() -> None:
+    source = """
+from runar import (
+    StatefulSmartContract, Bigint, Readonly,
+    public, assert_, extract_locktime,
+)
+
+
+class TimeLock(StatefulSmartContract):
+    deadline: Readonly[Bigint]
+    count: Bigint
+
+    def __init__(self, deadline: Bigint, count: Bigint):
+        super().__init__(deadline, count)
+        self.deadline = deadline
+        self.count = count
+
+    def check_deadline(self):
+        assert_(extract_locktime(self.tx_preimage) >= self.deadline)
+
+    @public
+    def unlock(self):
+        self.check_deadline()
+        self.count = self.count + 1
+"""
+    result = _validate_source(source)
+    assert _has_locktime_warning(result)

--- a/compilers/ruby/lib/runar_compiler/codegen/stack.rb
+++ b/compilers/ruby/lib/runar_compiler/codegen/stack.rb
@@ -1309,14 +1309,29 @@ module RunarCompiler::Codegen
       elsif prop && !prop.initial_value.nil?
         _push_property_value(prop.initial_value)
       else
-        # Property value will be provided at deployment time; emit placeholder
-        param_index = 0
-        @properties.each do |p|
-          next if p.initial_value
-          if p.name == prop_name
-            break
+        # Property value will be provided at deployment time; emit placeholder.
+        # Initialized properties are excluded from the constructor, so the
+        # deploy-time slot index counts only non-initialized props.
+        ctor_props = @properties.reject { |p| p.initial_value }
+        param_index = ctor_props.find_index { |p| p.name == prop_name }
+        # #119 tail (H1): a property that reaches the placeholder fallback with
+        # no matching constructor slot (param_index nil) has no deploy-time
+        # bytes of its own. The previous behaviour coerced it onto slot 0 (the
+        # non-initialized-prop count), silently splicing an UNRELATED
+        # constructor argument's placeholder into the locking script -- a
+        # silent-wrong-code path. Fail loudly instead. (A real constructor-param
+        # property -- readonly or a mutable state field whose initial value is
+        # spliced at deploy -- has param_index >= 0 and is unaffected.)
+        if param_index.nil?
+          loc = ""
+          if @current_source_loc && !@current_source_loc.file.to_s.empty?
+            loc = " at #{@current_source_loc.file}:#{@current_source_loc.line}:#{@current_source_loc.column}"
           end
-          param_index += 1
+          raise "Stack lowering: property '#{prop_name}'#{loc} is neither on the stack, " \
+                "initialized, nor a constructor parameter, so it has no deploy-time " \
+                "slot. Refusing to emit a placeholder for an unrelated constructor " \
+                "argument (slot 0). Known constructor-param properties: " \
+                "[#{ctor_props.map(&:name).join(', ')}]."
         end
         emit_op({ op: "placeholder", param_index: param_index, param_name: prop_name })
       end

--- a/compilers/ruby/lib/runar_compiler/frontend/validator.rb
+++ b/compilers/ruby/lib/runar_compiler/frontend/validator.rb
@@ -302,6 +302,13 @@ module RunarCompiler
           warn_manual_preimage_usage(method)
         end
 
+        # #131: warn when a public method gates on extractLocktime but never
+        # asserts the spending tx is non-final (extractSequence < 0xffffffff).
+        # Advisory only.
+        if method.visibility == "public"
+          warn_locktime_without_sequence_guard(method)
+        end
+
         # Gate asm({...}) calls on UnsafeSmartContract and check the structural args.
         validate_asm_usage(method)
 
@@ -655,6 +662,100 @@ module RunarCompiler
         return callee.property if callee.is_a?(MemberExpr)
 
         nil
+      end
+
+      # -------------------------------------------------------------------
+      # #131: locktime soundness -- extractLocktime needs an extractSequence guard
+      # -------------------------------------------------------------------
+
+      # Sentinel maximum nSequence: a tx is FINAL (ignores locktime) at this value.
+      SEQUENCE_FINAL = 0xffffffff
+
+      # True when +expr+ is a direct call to the named intrinsic, e.g. +f(...)+.
+      def call_to_named?(expr, name)
+        expr.is_a?(CallExpr) &&
+          expr.callee.is_a?(Identifier) &&
+          expr.callee.name == name
+      end
+
+      # True when +expr+ reads the transaction locktime. Both the raw intrinsic
+      # +extractLocktime(preimage)+ and its ergonomic sugar
+      # +currentBlockHeight()+ (which the ANF pass desugars to
+      # +extractLocktime(txPreimage)+) count -- either read is unsound without a
+      # sequence-finality guard.
+      def locktime_read?(expr)
+        call_to_named?(expr, "extractLocktime") || call_to_named?(expr, "currentBlockHeight")
+      end
+
+      # True when +expr+ is an +extractSequence(...) < <final>+-style comparison
+      # (the guard that makes a locktime gate consensus-enforced). Accepts the
+      # two natural spellings: +extractSequence(pre) < N+ / +<= N+, and the
+      # reversed +N > extractSequence(pre)+ / +>= ...+. +N+ must be a bigint
+      # literal no greater than the finality sentinel, so the guard genuinely
+      # forces non-finality.
+      def sequence_finality_guard?(expr)
+        return false unless expr.is_a?(BinaryExpr)
+
+        bound_ok = ->(e) { e.is_a?(BigIntLiteral) && e.value <= SEQUENCE_FINAL }
+
+        if ["<", "<="].include?(expr.op) &&
+           call_to_named?(expr.left, "extractSequence") && bound_ok.call(expr.right)
+          return true
+        end
+        if [">", ">="].include?(expr.op) &&
+           call_to_named?(expr.right, "extractSequence") && bound_ok.call(expr.left)
+          return true
+        end
+
+        false
+      end
+
+      # #131: warn when +method+ (transitively, through the private-helper call
+      # graph) reads the tx locktime but never asserts the tx is non-final. A
+      # locktime gate is not consensus-enforced unless
+      # +extractSequence < 0xffffffff+ is also asserted -- otherwise an
+      # all-final-sequence spend bypasses it. Advisory (warning) only -- no
+      # effect on emitted bytecode.
+      def warn_locktime_without_sequence_guard(method)
+        private_methods = {}
+        @contract.methods.each do |m|
+          private_methods[m.name] = m if m.visibility == "private"
+        end
+
+        reads_locktime = false
+        has_sequence_guard = false
+        visited = Set.new([method.name])
+        queue = [method]
+
+        until queue.empty?
+          current = queue.shift
+          walk_expressions_in_body(current.body, proc do |expr|
+            reads_locktime = true if locktime_read?(expr)
+            has_sequence_guard = true if sequence_finality_guard?(expr)
+          end)
+
+          # Follow calls into private helpers so a guard (or locktime read)
+          # supplied by an inlined helper is seen by the public entry point.
+          calls = Set.new
+          collect_method_calls(current.body, calls)
+          calls.each do |callee|
+            next if visited.include?(callee) || !private_methods.key?(callee)
+
+            visited.add(callee)
+            queue << private_methods[callee]
+          end
+        end
+
+        return unless reads_locktime && !has_sequence_guard
+
+        @warnings << Diagnostic.new(
+          message: "method '#{method.name}' reads extractLocktime but does not assert " \
+                   "extractSequence < 0xffffffff; a locktime gate is not consensus-enforced " \
+                   "unless the tx is non-final — add " \
+                   "assert(extractSequence(this.txPreimage) < 0xffffffffn)",
+          severity: Severity::WARNING,
+          loc: method.source_location
+        )
       end
 
       # -------------------------------------------------------------------

--- a/compilers/ruby/test/codegen/test_h1_loadprop_guard.rb
+++ b/compilers/ruby/test/codegen/test_h1_loadprop_guard.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "runar_compiler/ir/types"
+require "runar_compiler/codegen/stack"
+
+# ---------------------------------------------------------------------------
+# H1 (#119 tail): _lower_load_prop must NOT silently coerce an unknown property
+# onto constructor slot 0.
+#
+# A `load_prop` binding whose name is not a declared constructor-param property
+# used to fall through to a placeholder for constructor slot 0 (or, in the Ruby
+# tier, the count of non-initialized props) -- an UNRELATED argument's
+# deploy-time bytes -- with no diagnostic. That is a silent-wrong-code path: the
+# produced locking script splices the wrong value at that position.
+#
+# The hardened behaviour is a HARD ERROR with a clear diagnostic and the
+# binding's source location, instead of the silent placeholder.
+# ---------------------------------------------------------------------------
+
+class TestH1LoadPropGuard < Minitest::Test
+  include RunarCompiler::IR
+
+  # Minimal ANF program with a real readonly constructor-param property `pk`
+  # (constructor slot 0) plus a public method that loads a property `ghost`
+  # that is NOT declared on the contract. `ghost` therefore reaches the
+  # placeholder fallback with no matching constructor slot.
+  def program_with_unknown_load_prop
+    load_ghost = ANFValue.new(kind: "load_prop")
+    load_ghost.name = "ghost"
+
+    assert_val = ANFValue.new(kind: "assert")
+    assert_val.value_ref = "t0"
+
+    ANFProgram.new(
+      contract_name: "Ghost",
+      properties: [ANFProperty.new(name: "pk", type: "PubKey", readonly: true)],
+      methods: [
+        ANFMethod.new(
+          name: "spend",
+          params: [],
+          is_public: true,
+          body: [
+            ANFBinding.new(
+              name: "t0",
+              value: load_ghost,
+              source_loc: SourceLocation.new(file: "Ghost.runar.ts", line: 7, column: 4)
+            ),
+            ANFBinding.new(name: "t1", value: assert_val)
+          ]
+        )
+      ]
+    )
+  end
+
+  def test_raises_on_load_prop_with_no_constructor_slot
+    err = assert_raises(RuntimeError) do
+      RunarCompiler::Codegen.lower_to_stack(program_with_unknown_load_prop)
+    end
+    assert_includes err.message, "ghost",
+                    "diagnostic should name the offending ghost property"
+  end
+
+  def test_diagnostic_includes_prop_name_source_location_and_known_props
+    err = assert_raises(RuntimeError) do
+      RunarCompiler::Codegen.lower_to_stack(program_with_unknown_load_prop)
+    end
+    assert_includes err.message, "ghost"
+    assert_includes err.message, "Ghost.runar.ts"
+    assert_includes err.message, "7"
+    assert_includes err.message, "constructor parameter"
+    # The list of known constructor-param property names is included.
+    assert_includes err.message, "pk"
+  end
+
+  def test_real_ctor_param_prop_lowers_without_error
+    load_pk = ANFValue.new(kind: "load_prop")
+    load_pk.name = "pk"
+
+    assert_val = ANFValue.new(kind: "assert")
+    assert_val.value_ref = "t0"
+
+    program = ANFProgram.new(
+      contract_name: "Ok",
+      properties: [ANFProperty.new(name: "pk", type: "PubKey", readonly: true)],
+      methods: [
+        ANFMethod.new(
+          name: "spend",
+          params: [],
+          is_public: true,
+          body: [
+            ANFBinding.new(name: "t0", value: load_pk),
+            ANFBinding.new(name: "t1", value: assert_val)
+          ]
+        )
+      ]
+    )
+
+    # A legit readonly constructor-param property has a deploy-time slot, so it
+    # lowers to a placeholder WITHOUT raising.
+    methods = RunarCompiler::Codegen.lower_to_stack(program)
+    refute_nil methods.find { |m| m[:name] == "spend" }
+  end
+end

--- a/compilers/ruby/test/frontend/test_h2_locktime_warning.rb
+++ b/compilers/ruby/test/frontend/test_h2_locktime_warning.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+require "runar_compiler/frontend/ast_nodes"
+require "runar_compiler/frontend/diagnostic"
+require "runar_compiler/frontend/validator"
+require "runar_compiler/frontend/parser_ts"
+
+# ---------------------------------------------------------------------------
+# H2 (#131): locktime soundness warning.
+#
+# A method that reads extractLocktime(preimage) only enforces a timelock if the
+# covenant ALSO asserts the spending tx is non-final
+# (extractSequence(preimage) < 0xffffffff). Without that, a hand-built
+# all-final-sequence transaction bypasses the locktime gate. The compiler
+# should emit an advisory WARNING (non-fatal) when a public method reads
+# extractLocktime but does not (transitively) assert a sequence-finality guard.
+# ---------------------------------------------------------------------------
+
+class TestH2LocktimeWarning < Minitest::Test
+  WARNING_NEEDLE = "does not assert extractSequence"
+
+  def parse_contract(source, file_name = "TimeLock.runar.ts")
+    result = RunarCompiler.send(:_parse_source, source, file_name)
+    assert_empty result.errors.map(&:format_message), "unexpected parse errors"
+    refute_nil result.contract, "expected a contract from parsing"
+    result.contract
+  end
+
+  def validate_source(source, file_name = "TimeLock.runar.ts")
+    RunarCompiler::Frontend.validate(parse_contract(source, file_name))
+  end
+
+  def locktime_warning(result)
+    result.warnings.find { |w| w.message.include?(WARNING_NEEDLE) }
+  end
+
+  def has_locktime_warning?(result)
+    !locktime_warning(result).nil?
+  end
+
+  def test_warns_when_method_reads_locktime_without_sequence_guard
+    source = <<~TS
+      class TimeLock extends StatefulSmartContract {
+        count: bigint;
+        readonly deadline: bigint;
+        constructor(count: bigint, deadline: bigint) {
+          super(count, deadline);
+          this.count = count;
+          this.deadline = deadline;
+        }
+        public unlock() {
+          assert(extractLocktime(this.txPreimage) >= this.deadline);
+          this.count++;
+        }
+      }
+    TS
+
+    result = validate_source(source)
+    assert has_locktime_warning?(result),
+           "expected a locktime-without-sequence-guard warning"
+
+    w = locktime_warning(result)
+    assert_equal RunarCompiler::Frontend::Severity::WARNING, w.severity
+    assert_includes w.message, "unlock"
+    assert_includes w.message, "0xffffffff"
+  end
+
+  def test_does_not_warn_when_sequence_guard_present
+    source = <<~TS
+      class TimeLock extends StatefulSmartContract {
+        count: bigint;
+        readonly deadline: bigint;
+        constructor(count: bigint, deadline: bigint) {
+          super(count, deadline);
+          this.count = count;
+          this.deadline = deadline;
+        }
+        public unlock() {
+          assert(extractSequence(this.txPreimage) < 0xffffffffn);
+          assert(extractLocktime(this.txPreimage) >= this.deadline);
+          this.count++;
+        }
+      }
+    TS
+
+    result = validate_source(source)
+    refute has_locktime_warning?(result),
+           "sequence guard present -- must not warn"
+  end
+
+  def test_does_not_warn_when_method_never_reads_locktime
+    source = <<~TS
+      class Counter extends StatefulSmartContract {
+        count: bigint;
+        constructor(count: bigint) {
+          super(count);
+          this.count = count;
+        }
+        public increment() {
+          this.count++;
+        }
+      }
+    TS
+
+    result = validate_source(source, "Counter.runar.ts")
+    refute has_locktime_warning?(result),
+           "no locktime read -- must not warn"
+  end
+
+  def test_sees_sequence_guard_supplied_transitively_through_private_helper
+    source = <<~TS
+      class TimeLock extends StatefulSmartContract {
+        count: bigint;
+        readonly deadline: bigint;
+        constructor(count: bigint, deadline: bigint) {
+          super(count, deadline);
+          this.count = count;
+          this.deadline = deadline;
+        }
+        private requireNonFinal() {
+          assert(extractSequence(this.txPreimage) < 0xffffffffn);
+        }
+        public unlock() {
+          this.requireNonFinal();
+          assert(extractLocktime(this.txPreimage) >= this.deadline);
+          this.count++;
+        }
+      }
+    TS
+
+    result = validate_source(source)
+    refute has_locktime_warning?(result),
+           "transitive sequence guard through a private helper -- must not warn"
+  end
+
+  def test_warns_when_locktime_read_in_private_helper_without_sequence_guard
+    source = <<~TS
+      class TimeLock extends StatefulSmartContract {
+        count: bigint;
+        readonly deadline: bigint;
+        constructor(count: bigint, deadline: bigint) {
+          super(count, deadline);
+          this.count = count;
+          this.deadline = deadline;
+        }
+        private checkDeadline() {
+          assert(extractLocktime(this.txPreimage) >= this.deadline);
+        }
+        public unlock() {
+          this.checkDeadline();
+          this.count++;
+        }
+      }
+    TS
+
+    result = validate_source(source)
+    assert has_locktime_warning?(result),
+           "transitive locktime read through a private helper -- must warn"
+  end
+end

--- a/compilers/rust/src/codegen/stack.rs
+++ b/compilers/rust/src/codegen/stack.rs
@@ -1200,31 +1200,68 @@ impl LoweringContext {
             } else {
                 // Property value will be provided at deployment time; emit a placeholder.
                 // The emitter records byte offsets so the SDK can splice in real values.
-                let param_index = self
-                    .properties
-                    .iter()
-                    .filter(|p| p.initial_value.is_none())
-                    .position(|p| p.name == prop_name)
-                    .unwrap_or(0);
+                let param_index = self.ctor_param_index_or_panic(prop_name);
                 self.emit_op(StackOp::Placeholder {
                     param_index,
                     param_name: prop_name.to_string(),
                 });
             }
         } else {
-            // Property not found and not on stack — emit placeholder with index 0.
-            let param_index = self
-                .properties
-                .iter()
-                .filter(|p| p.initial_value.is_none())
-                .position(|p| p.name == prop_name)
-                .unwrap_or(0);
+            // Property not found and not on stack — must still be a real
+            // constructor-param slot, otherwise there is nothing to splice.
+            let param_index = self.ctor_param_index_or_panic(prop_name);
             self.emit_op(StackOp::Placeholder {
                 param_index,
                 param_name: prop_name.to_string(),
             });
         }
         self.sm.push(binding_name);
+    }
+
+    /// Resolve `prop_name`'s constructor slot for a placeholder, or fail loudly.
+    ///
+    /// #119 tail (H1): a property that reaches the placeholder fallback with no
+    /// matching constructor slot has no deploy-time bytes of its own. The
+    /// previous behaviour coerced it onto slot 0 (`.unwrap_or(0)`), silently
+    /// splicing an UNRELATED constructor argument's placeholder into the
+    /// locking script — a silent-wrong-code path. Fail loudly instead. (A real
+    /// constructor-param property — readonly, or a mutable state field whose
+    /// initial value is spliced at deploy — is found by `position` and is
+    /// unaffected: zero golden churn.)
+    fn ctor_param_index_or_panic(&self, prop_name: &str) -> usize {
+        // Initialized properties are excluded from the constructor, so only
+        // uninitialized (deploy-time) properties own a constructor slot.
+        match self
+            .properties
+            .iter()
+            .filter(|p| p.initial_value.is_none())
+            .position(|p| p.name == prop_name)
+        {
+            Some(idx) => idx,
+            None => {
+                let loc = self
+                    .current_source_loc
+                    .as_ref()
+                    .map(|l| format!(" at {}:{}:{}", l.file, l.line, l.column))
+                    .unwrap_or_default();
+                let ctor_props: Vec<&str> = self
+                    .properties
+                    .iter()
+                    .filter(|p| p.initial_value.is_none())
+                    .map(|p| p.name.as_str())
+                    .collect();
+                panic!(
+                    "Stack lowering: property '{}'{} is neither on the stack, \
+                     initialized, nor a constructor parameter, so it has no \
+                     deploy-time slot. Refusing to emit a placeholder for an \
+                     unrelated constructor argument (slot 0). Known \
+                     constructor-param properties: [{}].",
+                    prop_name,
+                    loc,
+                    ctor_props.join(", ")
+                );
+            }
+        }
     }
 
     fn push_json_value(&mut self, val: &serde_json::Value) {

--- a/compilers/rust/src/frontend/validator.rs
+++ b/compilers/rust/src/frontend/validator.rs
@@ -248,6 +248,13 @@ fn validate_methods(contract: &ContractNode, errors: &mut Vec<Diagnostic>, warni
         if contract.parent_class == "StatefulSmartContract" && method.visibility == Visibility::Public {
             warn_manual_preimage_usage(method, warnings);
         }
+
+        // #131: warn when a public method gates on extractLocktime but never
+        // asserts the spending tx is non-final (extractSequence < 0xffffffff).
+        // Advisory only.
+        if method.visibility == Visibility::Public {
+            warn_locktime_without_sequence_guard(method, contract, warnings);
+        }
     }
 }
 
@@ -879,6 +886,118 @@ fn warn_manual_preimage_usage(method: &MethodNode, warnings: &mut Vec<Diagnostic
             }
         }
     });
+}
+
+// ---------------------------------------------------------------------------
+// #131: locktime soundness — extractLocktime needs an extractSequence guard
+// ---------------------------------------------------------------------------
+
+/// Sentinel maximum nSequence: a tx is FINAL (ignores locktime) at this value.
+const SEQUENCE_FINAL: u64 = 0xffff_ffff;
+
+/// True when `expr` is a direct call to the named intrinsic, e.g. `f(...)`.
+fn is_call_to_named(expr: &Expression, name: &str) -> bool {
+    if let Expression::CallExpr { callee, .. } = expr {
+        if let Expression::Identifier { name: callee_name } = callee.as_ref() {
+            return callee_name == name;
+        }
+    }
+    false
+}
+
+/// True when `expr` reads the transaction locktime. Both the raw intrinsic
+/// `extractLocktime(preimage)` and its ergonomic sugar `currentBlockHeight()`
+/// (which the ANF pass desugars to `extractLocktime(txPreimage)`) count —
+/// either read is unsound without a sequence-finality guard.
+fn is_locktime_read(expr: &Expression) -> bool {
+    is_call_to_named(expr, "extractLocktime") || is_call_to_named(expr, "currentBlockHeight")
+}
+
+/// True when `expr` is an `extractSequence(...) < <final>`-style comparison
+/// (the guard that makes a locktime gate consensus-enforced). Accepts the two
+/// natural spellings: `extractSequence(pre) < N` / `<= N`, and the reversed
+/// `N > extractSequence(pre)` / `>= ...`. `N` must be a bigint literal no
+/// greater than the finality sentinel, so the guard genuinely forces
+/// non-finality.
+fn is_sequence_finality_guard(expr: &Expression) -> bool {
+    let Expression::BinaryExpr { op, left, right } = expr else {
+        return false;
+    };
+    let bound_ok = |e: &Expression| -> bool {
+        matches!(
+            e,
+            Expression::BigIntLiteral { value }
+                if *value <= num_bigint::BigInt::from(SEQUENCE_FINAL)
+        )
+    };
+    match op {
+        BinaryOp::Lt | BinaryOp::Le => is_call_to_named(left, "extractSequence") && bound_ok(right),
+        BinaryOp::Gt | BinaryOp::Ge => is_call_to_named(right, "extractSequence") && bound_ok(left),
+        _ => false,
+    }
+}
+
+/// #131: warn when `method` (transitively, through the private-helper call
+/// graph) reads the tx locktime but never asserts the tx is non-final. A
+/// locktime gate is not consensus-enforced unless `extractSequence < 0xffffffff`
+/// is also asserted — otherwise an all-final-sequence spend bypasses it.
+/// Advisory (warning) only — no effect on emitted bytecode.
+fn warn_locktime_without_sequence_guard(
+    method: &MethodNode,
+    contract: &ContractNode,
+    warnings: &mut Vec<Diagnostic>,
+) {
+    // Map of private helper methods by name (BFS follows calls into these).
+    let private_methods: HashMap<&str, &MethodNode> = contract
+        .methods
+        .iter()
+        .filter(|m| m.visibility == Visibility::Private)
+        .map(|m| (m.name.as_str(), m))
+        .collect();
+
+    let mut reads_locktime = false;
+    let mut has_sequence_guard = false;
+    let mut visited: HashSet<String> = HashSet::new();
+    visited.insert(method.name.clone());
+    let mut queue: std::collections::VecDeque<&MethodNode> = std::collections::VecDeque::new();
+    queue.push_back(method);
+
+    while let Some(current) = queue.pop_front() {
+        walk_expressions_in_body(&current.body, &mut |expr| {
+            if is_locktime_read(expr) {
+                reads_locktime = true;
+            }
+            if is_sequence_finality_guard(expr) {
+                has_sequence_guard = true;
+            }
+        });
+        // Follow calls into private helpers so a guard (or locktime read)
+        // supplied by an inlined helper is seen by the public entry point.
+        // Reuses the shared `collect_method_calls` recursion-detection helper.
+        let mut calls = HashSet::new();
+        collect_method_calls(&current.body, &mut calls);
+        for callee in calls {
+            if !visited.contains(&callee) {
+                if let Some(m) = private_methods.get(callee.as_str()) {
+                    visited.insert(callee.clone());
+                    queue.push_back(m);
+                }
+            }
+        }
+    }
+
+    if reads_locktime && !has_sequence_guard {
+        warnings.push(Diagnostic::warning(
+            format!(
+                "method '{}' reads extractLocktime but does not assert \
+                 extractSequence < 0xffffffff; a locktime gate is not \
+                 consensus-enforced unless the tx is non-final — add \
+                 assert(extractSequence(this.txPreimage) < 0xffffffffn)",
+                method.name
+            ),
+            Some(method.source_location.clone()),
+        ));
+    }
 }
 
 fn walk_expressions_in_body(stmts: &[Statement], visitor: &mut impl FnMut(&Expression)) {

--- a/compilers/rust/tests/h1_loadprop_guard_tests.rs
+++ b/compilers/rust/tests/h1_loadprop_guard_tests.rs
@@ -1,0 +1,150 @@
+//! H1 (#119 tail): `lower_load_prop` must NOT silently coerce an unknown
+//! property onto constructor slot 0.
+//!
+//! A `load_prop` binding whose name is not a declared constructor-param
+//! property used to fall through to `.unwrap_or(0)`, emitting the placeholder
+//! for constructor slot 0 — an UNRELATED argument's deploy-time bytes — with no
+//! diagnostic. That is a silent-wrong-code path: the produced locking script
+//! splices the wrong value at that position.
+//!
+//! The hardened behaviour is a HARD ERROR (a `panic!` inside the lowering,
+//! surfaced by the public `lower_to_stack` — which wraps the pass in
+//! `catch_unwind` — as an `Err`). Note the divergence from the TS reference:
+//! TS `lowerToStack` *throws*, whereas Rust's `lower_to_stack` converts the
+//! panic into `Err(String)`; the message content is identical.
+
+use runar_compiler_rust::codegen::stack::lower_to_stack;
+use runar_compiler_rust::ir::{
+    ANFBinding, ANFMethod, ANFParam, ANFProgram, ANFProperty, ANFValue, SourceLocation,
+};
+
+/// A real readonly constructor-param property `pk` (constructor slot 0).
+fn pk_property() -> ANFProperty {
+    ANFProperty {
+        name: "pk".to_string(),
+        prop_type: "PubKey".to_string(),
+        readonly: true,
+        initial_value: None,
+        synthetic_array_chain: None,
+    }
+}
+
+/// Program with the real ctor-param property `pk` plus a public method that
+/// loads a property `ghost` that is NOT declared on the contract. `ghost`
+/// therefore reaches the placeholder fallback with no matching constructor slot.
+fn program_with_unknown_load_prop() -> ANFProgram {
+    ANFProgram {
+        contract_name: "Ghost".to_string(),
+        parent_class: String::new(),
+        properties: vec![pk_property()],
+        methods: vec![ANFMethod {
+            name: "spend".to_string(),
+            params: vec![],
+            body: vec![
+                ANFBinding {
+                    name: "t0".to_string(),
+                    value: ANFValue::LoadProp { name: "ghost".to_string() },
+                    source_loc: Some(SourceLocation {
+                        file: "Ghost.runar.ts".to_string(),
+                        line: 7,
+                        column: 4,
+                    }),
+                },
+                ANFBinding {
+                    name: "t1".to_string(),
+                    value: ANFValue::Assert {
+                        value: "t0".to_string(),
+                        is_auto_injected_state_check: false,
+                    },
+                    source_loc: None,
+                },
+            ],
+            is_public: true,
+            sighash_type: None,
+        }],
+    }
+}
+
+#[test]
+fn load_prop_with_no_ctor_slot_is_a_hard_error() {
+    let result = lower_to_stack(&program_with_unknown_load_prop());
+    let err = result.expect_err("expected a hard error, not a silent slot-0 placeholder");
+    assert!(
+        err.contains("ghost"),
+        "error should name the offending property, got: {err}"
+    );
+}
+
+#[test]
+fn load_prop_hard_error_names_property_and_source_location() {
+    let result = lower_to_stack(&program_with_unknown_load_prop());
+    let err = result.expect_err("expected a hard error");
+    // Names the ghost property, says it is not a constructor parameter, and
+    // lists the known ctor-param property names — plus the source location.
+    assert!(err.contains("ghost"), "should name the property, got: {err}");
+    assert!(
+        err.contains("constructor parameter"),
+        "should say it is not a constructor parameter, got: {err}"
+    );
+    assert!(
+        err.contains("pk"),
+        "should list known ctor-param property names, got: {err}"
+    );
+    assert!(
+        err.contains("Ghost.runar.ts"),
+        "should include the source file, got: {err}"
+    );
+    assert!(err.contains('7'), "should include the source line, got: {err}");
+}
+
+#[test]
+fn real_ctor_param_prop_lowers_without_error() {
+    let program = ANFProgram {
+        contract_name: "Ok".to_string(),
+        parent_class: String::new(),
+        properties: vec![pk_property()],
+        methods: vec![ANFMethod {
+            name: "spend".to_string(),
+            params: vec![ANFParam {
+                name: "given".to_string(),
+                param_type: "PubKey".to_string(),
+            }],
+            body: vec![
+                ANFBinding {
+                    name: "t0".to_string(),
+                    value: ANFValue::LoadProp { name: "pk".to_string() },
+                    source_loc: None,
+                },
+                ANFBinding {
+                    name: "t1".to_string(),
+                    value: ANFValue::LoadParam { name: "given".to_string() },
+                    source_loc: None,
+                },
+                ANFBinding {
+                    name: "t2".to_string(),
+                    value: ANFValue::BinOp {
+                        op: "===".to_string(),
+                        left: "t0".to_string(),
+                        right: "t1".to_string(),
+                        result_type: Some("bytes".to_string()),
+                    },
+                    source_loc: None,
+                },
+                ANFBinding {
+                    name: "t3".to_string(),
+                    value: ANFValue::Assert {
+                        value: "t2".to_string(),
+                        is_auto_injected_state_check: false,
+                    },
+                    source_loc: None,
+                },
+            ],
+            is_public: true,
+            sighash_type: None,
+        }],
+    };
+    assert!(
+        lower_to_stack(&program).is_ok(),
+        "a real constructor-param property must lower without error"
+    );
+}

--- a/compilers/rust/tests/h2_locktime_warning_tests.rs
+++ b/compilers/rust/tests/h2_locktime_warning_tests.rs
@@ -1,0 +1,176 @@
+//! H2 (#131): locktime soundness warning.
+//!
+//! A method that reads `extractLocktime(preimage)` only enforces a timelock if
+//! the covenant ALSO asserts the spending tx is non-final
+//! (`extractSequence(preimage) < 0xffffffff`). Without that, a hand-built
+//! all-final-sequence transaction bypasses the locktime gate. The compiler
+//! emits an advisory WARNING (non-fatal) when a public method reads
+//! `extractLocktime` but does not (transitively) assert a sequence-finality
+//! guard.
+//!
+//! Mirrors `remediation-h2-locktime-sequence-warning.test.ts`.
+
+use runar_compiler_rust::frontend_validate;
+
+const WARNING_NEEDLE: &str = "does not assert extractSequence";
+
+/// `frontend_validate` splits diagnostics into `(errors, warnings)` and only
+/// the *warning* channel is inspected here — so any hit already proves
+/// `severity == warning`.
+fn warnings_of(source: &str) -> Vec<String> {
+    let (errors, warnings) = frontend_validate(source, Some("test.runar.ts"));
+    assert!(
+        errors.is_empty(),
+        "source should validate without errors; got: {errors:?}"
+    );
+    warnings
+}
+
+fn has_locktime_warning(warnings: &[String]) -> bool {
+    warnings.iter().any(|w| w.contains(WARNING_NEEDLE))
+}
+
+#[test]
+fn warns_when_method_reads_locktime_without_sequence_guard() {
+    let source = r#"
+import { StatefulSmartContract } from 'runar-lang';
+
+class TimeLock extends StatefulSmartContract {
+    count: bigint;
+    readonly deadline: bigint;
+    constructor(count: bigint, deadline: bigint) {
+        super(count, deadline);
+        this.count = count;
+        this.deadline = deadline;
+    }
+    public unlock() {
+        assert(extractLocktime(this.txPreimage) >= this.deadline);
+        this.count++;
+    }
+}
+"#;
+    let warnings = warnings_of(source);
+    assert!(
+        has_locktime_warning(&warnings),
+        "expected a locktime-without-sequence-guard warning; got: {warnings:?}"
+    );
+    // The warning names the method and points at the fix.
+    let w = warnings
+        .iter()
+        .find(|x| x.contains(WARNING_NEEDLE))
+        .unwrap();
+    assert!(w.contains("unlock"), "warning should name the method; got: {w}");
+    assert!(
+        w.contains("0xffffffff"),
+        "warning should mention the finality sentinel; got: {w}"
+    );
+}
+
+#[test]
+fn no_warn_when_method_asserts_extract_sequence_below_final() {
+    let source = r#"
+import { StatefulSmartContract } from 'runar-lang';
+
+class TimeLock extends StatefulSmartContract {
+    count: bigint;
+    readonly deadline: bigint;
+    constructor(count: bigint, deadline: bigint) {
+        super(count, deadline);
+        this.count = count;
+        this.deadline = deadline;
+    }
+    public unlock() {
+        assert(extractSequence(this.txPreimage) < 0xffffffffn);
+        assert(extractLocktime(this.txPreimage) >= this.deadline);
+        this.count++;
+    }
+}
+"#;
+    let warnings = warnings_of(source);
+    assert!(
+        !has_locktime_warning(&warnings),
+        "should NOT warn when a sequence-finality guard is present; got: {warnings:?}"
+    );
+}
+
+#[test]
+fn no_warn_when_method_never_reads_locktime() {
+    let source = r#"
+import { StatefulSmartContract } from 'runar-lang';
+
+class Counter extends StatefulSmartContract {
+    count: bigint;
+    constructor(count: bigint) {
+        super(count);
+        this.count = count;
+    }
+    public increment() {
+        this.count++;
+    }
+}
+"#;
+    let warnings = warnings_of(source);
+    assert!(
+        !has_locktime_warning(&warnings),
+        "should NOT warn for a method that never reads locktime; got: {warnings:?}"
+    );
+}
+
+#[test]
+fn no_warn_when_sequence_guard_supplied_by_private_helper() {
+    let source = r#"
+import { StatefulSmartContract } from 'runar-lang';
+
+class TimeLock extends StatefulSmartContract {
+    count: bigint;
+    readonly deadline: bigint;
+    constructor(count: bigint, deadline: bigint) {
+        super(count, deadline);
+        this.count = count;
+        this.deadline = deadline;
+    }
+    private requireNonFinal() {
+        assert(extractSequence(this.txPreimage) < 0xffffffffn);
+    }
+    public unlock() {
+        this.requireNonFinal();
+        assert(extractLocktime(this.txPreimage) >= this.deadline);
+        this.count++;
+    }
+}
+"#;
+    let warnings = warnings_of(source);
+    assert!(
+        !has_locktime_warning(&warnings),
+        "guard supplied transitively through a private helper should suppress the warning; got: {warnings:?}"
+    );
+}
+
+#[test]
+fn warns_when_locktime_read_in_private_helper_without_guard() {
+    let source = r#"
+import { StatefulSmartContract } from 'runar-lang';
+
+class TimeLock extends StatefulSmartContract {
+    count: bigint;
+    readonly deadline: bigint;
+    constructor(count: bigint, deadline: bigint) {
+        super(count, deadline);
+        this.count = count;
+        this.deadline = deadline;
+    }
+    private checkDeadline() {
+        assert(extractLocktime(this.txPreimage) >= this.deadline);
+    }
+    public unlock() {
+        this.checkDeadline();
+        this.count++;
+    }
+}
+"#;
+    let warnings = warnings_of(source);
+    assert!(
+        has_locktime_warning(&warnings),
+        "a locktime read reached transitively through a private helper (with no guard) should warn; got: {warnings:?}"
+    );
+}

--- a/compilers/zig/src/passes/stack_lower.zig
+++ b/compilers/zig/src/passes/stack_lower.zig
@@ -164,6 +164,12 @@ const LowerError = error{
     /// Emitting a silent OP_0 here produced scripts that compiled, passed the
     /// env-based interpreter, and then failed on chain — so we fail loudly.
     SilentOpZeroRefused,
+    /// #119 tail (H1): a `load_prop` for a property that is neither on the
+    /// stack, initialized, nor a constructor parameter has no deploy-time slot
+    /// of its own. Coercing it onto slot 0 silently splices an UNRELATED
+    /// constructor argument's placeholder into the locking script, so we fail
+    /// loudly instead.
+    LoadPropNoConstructorSlot,
 };
 
 const LowerCtx = struct {
@@ -1228,6 +1234,22 @@ const LowerCtx = struct {
         self.trackDepth();
     }
 
+    /// Comma-separated names of the constructor-param properties (those with no
+    /// initial value, i.e. the ones that occupy a deploy-time slot). Used only
+    /// for the H1 diagnostic in `lowerPropertyRead`.
+    fn knownCtorPropNames(self: *const LowerCtx) ![]u8 {
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
+        errdefer buf.deinit(self.allocator);
+        var first = true;
+        for (self.program.properties) |prop| {
+            if (prop.initial_value != null) continue;
+            if (!first) try buf.appendSlice(self.allocator, ", ");
+            first = false;
+            try buf.appendSlice(self.allocator, prop.name);
+        }
+        return buf.toOwnedSlice(self.allocator);
+    }
+
     fn lowerPropertyRead(self: *LowerCtx, bind_name: []const u8, prop_name: []const u8) !void {
         // Check if property has been updated on stack
         if (self.updated_props.get(prop_name) != null) {
@@ -1259,12 +1281,50 @@ const LowerCtx = struct {
                 }
             }
         }
-        // Not found — push constructor param placeholder
-        // Determine param_index: count properties without initial_value before this one
+        // Not found on stack / initialized — push constructor param placeholder.
+        // Determine param_index: count properties without initial_value before
+        // this one. Zig signals "not a declared property" by never breaking, so
+        // track it explicitly with `found`.
         var param_idx: u32 = 0;
+        var found = false;
         for (self.program.properties) |prop| {
-            if (std.mem.eql(u8, prop.name, prop_name)) break;
+            if (std.mem.eql(u8, prop.name, prop_name)) {
+                found = true;
+                break;
+            }
             if (prop.initial_value == null) param_idx += 1;
+        }
+        // #119 tail (H1): a property that reaches this fallback with no matching
+        // constructor slot (found == false) has no deploy-time bytes of its own.
+        // The previous behaviour left `param_idx` at the count of ctor-param
+        // properties and emitted a placeholder for an UNRELATED constructor
+        // argument — a silent-wrong-code path that splices the wrong value into
+        // the locking script. Fail loudly instead. (A real constructor-param
+        // property — readonly, or a mutable state field whose initial value is
+        // spliced at deploy — is found and unaffected.)
+        if (!found) {
+            const known = self.knownCtorPropNames() catch null;
+            defer if (known) |k| self.allocator.free(k);
+            if (self.current_source_loc) |loc| {
+                std.log.warn(
+                    "stack lowering: property '{s}' at {s}:{d}:{d} is neither on " ++
+                        "the stack, initialized, nor a constructor parameter, so it " ++
+                        "has no deploy-time slot. Refusing to emit a placeholder for " ++
+                        "an unrelated constructor argument (slot 0). Known " ++
+                        "constructor-param properties: [{s}].",
+                    .{ prop_name, loc.file, loc.line, loc.column, known orelse "<unavailable>" },
+                );
+            } else {
+                std.log.warn(
+                    "stack lowering: property '{s}' is neither on the stack, " ++
+                        "initialized, nor a constructor parameter, so it has no " ++
+                        "deploy-time slot. Refusing to emit a placeholder for an " ++
+                        "unrelated constructor argument (slot 0). Known " ++
+                        "constructor-param properties: [{s}].",
+                    .{ prop_name, known orelse "<unavailable>" },
+                );
+            }
+            return LowerError.LoadPropNoConstructorSlot;
         }
         try self.emit(.{ .placeholder = .{ .param_index = param_idx, .param_name = prop_name } });
         try self.stack.push(self.allocator, bind_name);
@@ -5605,6 +5665,75 @@ test "lower rejects load_param of a missing param instead of emitting OP_0 (fix 
     };
 
     try std.testing.expectError(LowerError.SilentOpZeroRefused, lower(allocator, program));
+}
+
+test "lower rejects load_prop for a property with no constructor slot (H1)" {
+    // #119 tail: a `load_prop` whose name is not a declared constructor-param
+    // property used to be coerced onto slot 0, silently splicing an UNRELATED
+    // constructor argument's placeholder into the locking script. It must now
+    // hard-error instead. The contract has a real ctor-param property `pk`, and
+    // the method reads a `ghost` property that is not declared at all.
+    const allocator = std.testing.allocator;
+
+    const bindings = [_]types.ANFBinding{
+        .{
+            .name = "t0",
+            .value = .{ .load_prop = .{ .name = "ghost" } },
+            .source_loc = .{ .file = "Ghost.runar.ts", .line = 7, .column = 4 },
+        },
+        .{ .name = "t1", .value = .{ .assert = .{ .value = "t0" } } },
+    };
+
+    var props = [_]types.ANFProperty{
+        .{ .name = "pk", .type_name = "PubKey", .readonly = true },
+    };
+    var methods_arr = [_]types.ANFMethod{
+        .{ .name = "spend", .is_public = true, .params = &.{}, .bindings = @constCast(&bindings) },
+    };
+    const program = types.ANFProgram{
+        .contract_name = "Ghost",
+        .properties = &props,
+        .methods = &methods_arr,
+    };
+
+    try std.testing.expectError(LowerError.LoadPropNoConstructorSlot, lower(allocator, program));
+}
+
+test "lower accepts load_prop for a real constructor-param property (H1)" {
+    // A genuine readonly constructor-param property has a deploy-time slot
+    // (found == true) and must still lower to a placeholder without error.
+    const allocator = std.testing.allocator;
+
+    const bindings = [_]types.ANFBinding{
+        .{ .name = "t0", .value = .{ .load_prop = .{ .name = "pk" } } },
+        .{ .name = "t1", .value = .{ .assert = .{ .value = "t0" } } },
+    };
+
+    var props = [_]types.ANFProperty{
+        .{ .name = "pk", .type_name = "PubKey", .readonly = true },
+    };
+    var methods_arr = [_]types.ANFMethod{
+        .{ .name = "spend", .is_public = true, .params = &.{}, .bindings = @constCast(&bindings) },
+    };
+    const ctor_params = [_]types.ParamNode{
+        .{ .name = "pk", .type_info = .pub_key },
+    };
+    const program = types.ANFProgram{
+        .contract_name = "Ok",
+        .properties = &props,
+        .methods = &methods_arr,
+        .constructor = .{ .params = @constCast(&ctor_params), .assertions = &.{} },
+    };
+
+    const result = try lower(allocator, program);
+    defer {
+        for (result.methods) |m| {
+            allocator.free(m.instructions);
+            if (m.instruction_source_locs.len > 0) allocator.free(m.instruction_source_locs);
+        }
+        allocator.free(result.methods);
+    }
+    try std.testing.expectEqual(@as(usize, 1), result.methods.len);
 }
 
 test "lower multi-method produces one StackMethod per public method" {

--- a/compilers/zig/src/passes/validate.zig
+++ b/compilers/zig/src/passes/validate.zig
@@ -317,6 +317,13 @@ fn validateMethods(
             try warnManualPreimageUsage(allocator, method, warnings);
         }
 
+        // #131: warn when a public method gates on extractLocktime but never
+        // asserts the spending tx is non-final (extractSequence < 0xffffffff).
+        // Advisory only — no effect on emitted bytecode.
+        if (method.is_public) {
+            try warnLocktimeWithoutSequenceGuard(allocator, contract, method, warnings);
+        }
+
         // Gate asm({...}) calls on UnsafeSmartContract + check structural args.
         try validateAsmUsage(allocator, contract, method, errors);
 
@@ -694,6 +701,190 @@ fn walkExprForPreimage(
         .literal_int, .literal_bigint, .literal_bool, .literal_bytes, .identifier,
         .property_access, .array_literal,
         => {},
+    }
+}
+
+// ============================================================================
+// #131: locktime soundness — extractLocktime needs an extractSequence guard
+// ============================================================================
+
+/// Sentinel maximum nSequence: a tx is FINAL (ignores locktime) at this value.
+const SEQUENCE_FINAL: i128 = 0xffffffff;
+
+/// True when `expr` is a direct call to the named intrinsic, e.g. `f(...)`. Bare
+/// intrinsic calls are `.call`; a `this.foo()` method call is `.method_call`.
+fn isCallToNamed(expr: Expression, name: []const u8) bool {
+    return switch (expr) {
+        .call => |c| std.mem.eql(u8, c.callee, name),
+        else => false,
+    };
+}
+
+/// True when `expr` reads the transaction locktime. Both the raw intrinsic
+/// `extractLocktime(preimage)` and its ergonomic sugar `currentBlockHeight()`
+/// (which the ANF pass desugars to `extractLocktime`) count — either read is
+/// unsound without a sequence-finality guard.
+fn isLocktimeRead(expr: Expression) bool {
+    return isCallToNamed(expr, "extractLocktime") or isCallToNamed(expr, "currentBlockHeight");
+}
+
+/// True when `expr` is an int/bigint literal no greater than the finality
+/// sentinel (0xffffffff), so a guard against it genuinely forces non-finality.
+/// The TS reference matches a `bigint_literal`; the Zig frontend lowers small
+/// bigints to `literal_int` and only oversize values to `literal_bigint`, so
+/// both variants are accepted here.
+fn sequenceBoundOk(expr: Expression) bool {
+    return switch (expr) {
+        .literal_int => |v| @as(i128, v) <= SEQUENCE_FINAL,
+        .literal_bigint => |s| blk: {
+            const n = std.fmt.parseInt(i128, s, 10) catch break :blk false;
+            break :blk n <= SEQUENCE_FINAL;
+        },
+        else => false,
+    };
+}
+
+/// True when `expr` is an `extractSequence(...) < <final>`-style comparison
+/// (the guard that makes a locktime gate consensus-enforced). Accepts the two
+/// natural spellings: `extractSequence(pre) < N` / `<= N`, and the reversed
+/// `N > extractSequence(pre)` / `>= ...`. `N` must be an int/bigint literal no
+/// greater than the finality sentinel.
+fn isSequenceFinalityGuard(expr: Expression) bool {
+    const b = switch (expr) {
+        .binary_op => |bp| bp,
+        else => return false,
+    };
+    if ((b.op == .lt or b.op == .lte) and
+        isCallToNamed(b.left, "extractSequence") and sequenceBoundOk(b.right))
+    {
+        return true;
+    }
+    if ((b.op == .gt or b.op == .gte) and
+        isCallToNamed(b.right, "extractSequence") and sequenceBoundOk(b.left))
+    {
+        return true;
+    }
+    return false;
+}
+
+/// Recursively scan an expression for a locktime read and/or a sequence guard,
+/// setting the respective flags. Pure — no allocation.
+fn scanExprForLocktime(expr: Expression, reads_locktime: *bool, has_guard: *bool) void {
+    if (isLocktimeRead(expr)) reads_locktime.* = true;
+    if (isSequenceFinalityGuard(expr)) has_guard.* = true;
+    switch (expr) {
+        .call => |c| for (c.args) |arg| scanExprForLocktime(arg, reads_locktime, has_guard),
+        .method_call => |mc| for (mc.args) |arg| scanExprForLocktime(arg, reads_locktime, has_guard),
+        .binary_op => |b| {
+            scanExprForLocktime(b.left, reads_locktime, has_guard);
+            scanExprForLocktime(b.right, reads_locktime, has_guard);
+        },
+        .unary_op => |u| scanExprForLocktime(u.operand, reads_locktime, has_guard),
+        .ternary => |t| {
+            scanExprForLocktime(t.condition, reads_locktime, has_guard);
+            scanExprForLocktime(t.then_expr, reads_locktime, has_guard);
+            scanExprForLocktime(t.else_expr, reads_locktime, has_guard);
+        },
+        .index_access => |ia| {
+            scanExprForLocktime(ia.object, reads_locktime, has_guard);
+            scanExprForLocktime(ia.index, reads_locktime, has_guard);
+        },
+        .increment => |inc| scanExprForLocktime(inc.operand, reads_locktime, has_guard),
+        .decrement => |dec| scanExprForLocktime(dec.operand, reads_locktime, has_guard),
+        .literal_int, .literal_bigint, .literal_bool, .literal_bytes, .identifier,
+        .property_access, .array_literal,
+        => {},
+    }
+}
+
+/// Statement walker feeding `scanExprForLocktime`.
+fn scanStmtForLocktime(stmt: Statement, reads_locktime: *bool, has_guard: *bool) void {
+    switch (stmt) {
+        .expr_stmt => |expr| scanExprForLocktime(expr, reads_locktime, has_guard),
+        .const_decl => |cd| scanExprForLocktime(cd.value, reads_locktime, has_guard),
+        .let_decl => |ld| {
+            if (ld.value) |v| scanExprForLocktime(v, reads_locktime, has_guard);
+        },
+        .assign => |a| scanExprForLocktime(a.value, reads_locktime, has_guard),
+        .if_stmt => |if_s| {
+            scanExprForLocktime(if_s.condition, reads_locktime, has_guard);
+            for (if_s.then_body) |s| scanStmtForLocktime(s, reads_locktime, has_guard);
+            if (if_s.else_body) |eb| {
+                for (eb) |s| scanStmtForLocktime(s, reads_locktime, has_guard);
+            }
+        },
+        .for_stmt => |fs| {
+            for (fs.body) |s| scanStmtForLocktime(s, reads_locktime, has_guard);
+        },
+        .assert_stmt => |a| scanExprForLocktime(a.condition, reads_locktime, has_guard),
+        .return_stmt => |opt_expr| {
+            if (opt_expr) |expr| scanExprForLocktime(expr, reads_locktime, has_guard);
+        },
+    }
+}
+
+/// #131: warn when `method` (transitively, through the private-helper call
+/// graph) reads the tx locktime but never asserts the tx is non-final. A
+/// locktime gate is not consensus-enforced unless `extractSequence < 0xffffffff`
+/// is also asserted — otherwise an all-final-sequence spend bypasses it.
+/// Advisory (warning) only — no effect on emitted bytecode. The message is
+/// allocator-owned (matches sighash_validate's allocPrint'd diagnostics).
+fn warnLocktimeWithoutSequenceGuard(
+    allocator: Allocator,
+    contract: ContractNode,
+    method: MethodNode,
+    warnings: *std.ArrayListUnmanaged(CompilerDiagnostic),
+) !void {
+    var reads_locktime = false;
+    var has_sequence_guard = false;
+
+    var visited = StringSet{};
+    defer visited.deinit(allocator);
+    try visited.put(allocator, method.name, {});
+
+    var queue: std.ArrayListUnmanaged(MethodNode) = .empty;
+    defer queue.deinit(allocator);
+    try queue.append(allocator, method);
+
+    var head: usize = 0;
+    while (head < queue.items.len) : (head += 1) {
+        const current = queue.items[head];
+        for (current.body) |stmt| {
+            scanStmtForLocktime(stmt, &reads_locktime, &has_sequence_guard);
+        }
+        // Follow calls into private helpers so a guard (or locktime read)
+        // supplied by an inlined helper is seen by the public entry point.
+        var calls = StringSet{};
+        defer calls.deinit(allocator);
+        for (current.body) |stmt| {
+            try collectMethodCalls(allocator, stmt, &calls);
+        }
+        var it = calls.iterator();
+        while (it.next()) |entry| {
+            const callee = entry.key_ptr.*;
+            if (visited.get(callee) != null) continue;
+            for (contract.methods) |m| {
+                if (!m.is_public and std.mem.eql(u8, m.name, callee)) {
+                    try visited.put(allocator, callee, {});
+                    try queue.append(allocator, m);
+                    break;
+                }
+            }
+        }
+    }
+
+    if (reads_locktime and !has_sequence_guard) {
+        const msg = try std.fmt.allocPrint(
+            allocator,
+            "method '{s}' reads extractLocktime but does not assert extractSequence " ++
+                "< 0xffffffff; a locktime gate is not consensus-enforced unless the tx " ++
+                "is non-final — add assert(extractSequence(this.txPreimage) < 0xffffffffn)",
+            .{method.name},
+        );
+        try warnings.append(allocator, .{
+            .message = msg,
+            .severity = .warning,
+        });
     }
 }
 
@@ -1623,4 +1814,248 @@ test "zero-start counting-up for loop is accepted" {
     const for_stmt = types.ForStmt{ .var_name = "i", .init_value = 0, .bound = 4, .body = &.{} };
     try testing.expect(!try validateLoopHasError(testing.allocator, for_stmt, "must start at 0"));
     try testing.expect(!try validateLoopHasError(testing.allocator, for_stmt, "countdown"));
+}
+
+// -- #131 (H2): extractLocktime without extractSequence guard ----------------
+
+const LOCKTIME_NEEDLE = "does not assert extractSequence";
+
+fn locktimeWarning(result: ValidationResult) ?CompilerDiagnostic {
+    for (result.warnings) |w| {
+        if (std.mem.indexOf(u8, w.message, LOCKTIME_NEEDLE) != null) return w;
+    }
+    return null;
+}
+
+fn hasLocktimeWarning(result: ValidationResult) bool {
+    return locktimeWarning(result) != null;
+}
+
+/// freeResult only frees the diagnostic slices; the locktime warning's message
+/// is allocator-owned (allocPrint'd), so free those messages first to keep the
+/// leak-checking test allocator happy. Static-literal messages are left alone.
+fn freeLocktimeResult(allocator: Allocator, result: ValidationResult) void {
+    for (result.warnings) |w| {
+        if (std.mem.indexOf(u8, w.message, LOCKTIME_NEEDLE) != null) {
+            allocator.free(w.message);
+        }
+    }
+    freeResult(allocator, result);
+}
+
+test "H2: warns when a public method reads extractLocktime without a sequence guard" {
+    const allocator = testing.allocator;
+
+    // assert(extractLocktime(this.txPreimage) >= this.deadline)
+    var lt_args = [_]Expression{.{ .property_access = .{ .object = "this", .property = "txPreimage" } }};
+    var lt_call = types.CallExpr{ .callee = "extractLocktime", .args = &lt_args };
+    var lt_cmp = types.BinaryOp{
+        .op = .gte,
+        .left = .{ .call = &lt_call },
+        .right = .{ .property_access = .{ .object = "this", .property = "deadline" } },
+    };
+    var inc = types.IncrementExpr{ .operand = .{ .property_access = .{ .object = "this", .property = "count" } }, .prefix = false };
+    var body = [_]Statement{
+        .{ .assert_stmt = .{ .condition = .{ .binary_op = &lt_cmp } } },
+        .{ .expr_stmt = .{ .increment = &inc } },
+    };
+    var methods = [_]MethodNode{
+        .{ .name = "unlock", .is_public = true, .params = &.{}, .body = &body },
+    };
+    const props = [_]PropertyNode{
+        makeProperty("count", .bigint, false),
+        makeProperty("deadline", .bigint, true),
+    };
+    var assignments = [_]types.AssignmentNode{ makeAssignment("count"), makeAssignment("deadline") };
+    var super_args = [_]Expression{ .{ .identifier = "count" }, .{ .identifier = "deadline" } };
+    var params = [_]types.ParamNode{ makeParam("count"), makeParam("deadline") };
+    const contract = ContractNode{
+        .name = "TimeLock",
+        .parent_class = .stateful_smart_contract,
+        .properties = @constCast(&props),
+        .constructor = .{ .params = &params, .super_args = &super_args, .assignments = &assignments },
+        .methods = &methods,
+    };
+    const result = try validate(allocator, contract);
+    defer freeLocktimeResult(allocator, result);
+
+    try testing.expect(hasLocktimeWarning(result));
+    const w = locktimeWarning(result).?;
+    try testing.expect(w.severity == .warning);
+    try testing.expect(std.mem.indexOf(u8, w.message, "unlock") != null);
+    try testing.expect(std.mem.indexOf(u8, w.message, "0xffffffff") != null);
+}
+
+test "H2: does NOT warn when the method also asserts extractSequence < final" {
+    const allocator = testing.allocator;
+
+    // assert(extractSequence(this.txPreimage) < 0xffffffffn)
+    var seq_args = [_]Expression{.{ .property_access = .{ .object = "this", .property = "txPreimage" } }};
+    var seq_call = types.CallExpr{ .callee = "extractSequence", .args = &seq_args };
+    var seq_cmp = types.BinaryOp{ .op = .lt, .left = .{ .call = &seq_call }, .right = .{ .literal_int = 0xffffffff } };
+    // assert(extractLocktime(this.txPreimage) >= this.deadline)
+    var lt_args = [_]Expression{.{ .property_access = .{ .object = "this", .property = "txPreimage" } }};
+    var lt_call = types.CallExpr{ .callee = "extractLocktime", .args = &lt_args };
+    var lt_cmp = types.BinaryOp{
+        .op = .gte,
+        .left = .{ .call = &lt_call },
+        .right = .{ .property_access = .{ .object = "this", .property = "deadline" } },
+    };
+    var inc = types.IncrementExpr{ .operand = .{ .property_access = .{ .object = "this", .property = "count" } }, .prefix = false };
+    var body = [_]Statement{
+        .{ .assert_stmt = .{ .condition = .{ .binary_op = &seq_cmp } } },
+        .{ .assert_stmt = .{ .condition = .{ .binary_op = &lt_cmp } } },
+        .{ .expr_stmt = .{ .increment = &inc } },
+    };
+    var methods = [_]MethodNode{
+        .{ .name = "unlock", .is_public = true, .params = &.{}, .body = &body },
+    };
+    const props = [_]PropertyNode{
+        makeProperty("count", .bigint, false),
+        makeProperty("deadline", .bigint, true),
+    };
+    var assignments = [_]types.AssignmentNode{ makeAssignment("count"), makeAssignment("deadline") };
+    var super_args = [_]Expression{ .{ .identifier = "count" }, .{ .identifier = "deadline" } };
+    var params = [_]types.ParamNode{ makeParam("count"), makeParam("deadline") };
+    const contract = ContractNode{
+        .name = "TimeLock",
+        .parent_class = .stateful_smart_contract,
+        .properties = @constCast(&props),
+        .constructor = .{ .params = &params, .super_args = &super_args, .assignments = &assignments },
+        .methods = &methods,
+    };
+    const result = try validate(allocator, contract);
+    defer freeLocktimeResult(allocator, result);
+
+    try testing.expect(!hasLocktimeWarning(result));
+}
+
+test "H2: does NOT warn for a method that never reads extractLocktime" {
+    const allocator = testing.allocator;
+
+    var inc = types.IncrementExpr{ .operand = .{ .property_access = .{ .object = "this", .property = "count" } }, .prefix = false };
+    var body = [_]Statement{
+        .{ .expr_stmt = .{ .increment = &inc } },
+    };
+    var methods = [_]MethodNode{
+        .{ .name = "increment", .is_public = true, .params = &.{}, .body = &body },
+    };
+    const props = [_]PropertyNode{
+        makeProperty("count", .bigint, false),
+    };
+    var assignments = [_]types.AssignmentNode{makeAssignment("count")};
+    var super_args = [_]Expression{.{ .identifier = "count" }};
+    var params = [_]types.ParamNode{makeParam("count")};
+    const contract = ContractNode{
+        .name = "Counter",
+        .parent_class = .stateful_smart_contract,
+        .properties = @constCast(&props),
+        .constructor = .{ .params = &params, .super_args = &super_args, .assignments = &assignments },
+        .methods = &methods,
+    };
+    const result = try validate(allocator, contract);
+    defer freeLocktimeResult(allocator, result);
+
+    try testing.expect(!hasLocktimeWarning(result));
+}
+
+test "H2: sees a sequence guard supplied transitively through a private helper" {
+    const allocator = testing.allocator;
+
+    // private requireNonFinal(): assert(extractSequence(this.txPreimage) < 0xffffffffn)
+    var seq_args = [_]Expression{.{ .property_access = .{ .object = "this", .property = "txPreimage" } }};
+    var seq_call = types.CallExpr{ .callee = "extractSequence", .args = &seq_args };
+    var seq_cmp = types.BinaryOp{ .op = .lt, .left = .{ .call = &seq_call }, .right = .{ .literal_int = 0xffffffff } };
+    var req_body = [_]Statement{
+        .{ .assert_stmt = .{ .condition = .{ .binary_op = &seq_cmp } } },
+    };
+
+    // public unlock(): this.requireNonFinal(); assert(extractLocktime(this.txPreimage) >= this.deadline); this.count++
+    var req_call = types.MethodCall{ .object = "this", .method = "requireNonFinal", .args = &.{} };
+    var lt_args = [_]Expression{.{ .property_access = .{ .object = "this", .property = "txPreimage" } }};
+    var lt_call = types.CallExpr{ .callee = "extractLocktime", .args = &lt_args };
+    var lt_cmp = types.BinaryOp{
+        .op = .gte,
+        .left = .{ .call = &lt_call },
+        .right = .{ .property_access = .{ .object = "this", .property = "deadline" } },
+    };
+    var inc = types.IncrementExpr{ .operand = .{ .property_access = .{ .object = "this", .property = "count" } }, .prefix = false };
+    var unlock_body = [_]Statement{
+        .{ .expr_stmt = .{ .method_call = &req_call } },
+        .{ .assert_stmt = .{ .condition = .{ .binary_op = &lt_cmp } } },
+        .{ .expr_stmt = .{ .increment = &inc } },
+    };
+
+    var methods = [_]MethodNode{
+        .{ .name = "unlock", .is_public = true, .params = &.{}, .body = &unlock_body },
+        .{ .name = "requireNonFinal", .is_public = false, .params = &.{}, .body = &req_body },
+    };
+    const props = [_]PropertyNode{
+        makeProperty("count", .bigint, false),
+        makeProperty("deadline", .bigint, true),
+    };
+    var assignments = [_]types.AssignmentNode{ makeAssignment("count"), makeAssignment("deadline") };
+    var super_args = [_]Expression{ .{ .identifier = "count" }, .{ .identifier = "deadline" } };
+    var params = [_]types.ParamNode{ makeParam("count"), makeParam("deadline") };
+    const contract = ContractNode{
+        .name = "TimeLock",
+        .parent_class = .stateful_smart_contract,
+        .properties = @constCast(&props),
+        .constructor = .{ .params = &params, .super_args = &super_args, .assignments = &assignments },
+        .methods = &methods,
+    };
+    const result = try validate(allocator, contract);
+    defer freeLocktimeResult(allocator, result);
+
+    try testing.expect(!hasLocktimeWarning(result));
+}
+
+test "H2: warns when the locktime read is in a private helper but no sequence guard exists" {
+    const allocator = testing.allocator;
+
+    // private checkDeadline(): assert(extractLocktime(this.txPreimage) >= this.deadline)
+    var lt_args = [_]Expression{.{ .property_access = .{ .object = "this", .property = "txPreimage" } }};
+    var lt_call = types.CallExpr{ .callee = "extractLocktime", .args = &lt_args };
+    var lt_cmp = types.BinaryOp{
+        .op = .gte,
+        .left = .{ .call = &lt_call },
+        .right = .{ .property_access = .{ .object = "this", .property = "deadline" } },
+    };
+    var check_body = [_]Statement{
+        .{ .assert_stmt = .{ .condition = .{ .binary_op = &lt_cmp } } },
+    };
+
+    // public unlock(): this.checkDeadline(); this.count++
+    var check_call = types.MethodCall{ .object = "this", .method = "checkDeadline", .args = &.{} };
+    var inc = types.IncrementExpr{ .operand = .{ .property_access = .{ .object = "this", .property = "count" } }, .prefix = false };
+    var unlock_body = [_]Statement{
+        .{ .expr_stmt = .{ .method_call = &check_call } },
+        .{ .expr_stmt = .{ .increment = &inc } },
+    };
+
+    var methods = [_]MethodNode{
+        .{ .name = "unlock", .is_public = true, .params = &.{}, .body = &unlock_body },
+        .{ .name = "checkDeadline", .is_public = false, .params = &.{}, .body = &check_body },
+    };
+    const props = [_]PropertyNode{
+        makeProperty("count", .bigint, false),
+        makeProperty("deadline", .bigint, true),
+    };
+    var assignments = [_]types.AssignmentNode{ makeAssignment("count"), makeAssignment("deadline") };
+    var super_args = [_]Expression{ .{ .identifier = "count" }, .{ .identifier = "deadline" } };
+    var params = [_]types.ParamNode{ makeParam("count"), makeParam("deadline") };
+    const contract = ContractNode{
+        .name = "TimeLock",
+        .parent_class = .stateful_smart_contract,
+        .properties = @constCast(&props),
+        .constructor = .{ .params = &params, .super_args = &super_args, .assignments = &assignments },
+        .methods = &methods,
+    };
+    const result = try validate(allocator, contract);
+    defer freeLocktimeResult(allocator, result);
+
+    try testing.expect(hasLocktimeWarning(result));
+    const w = locktimeWarning(result).?;
+    // The warning names the public entry point, not the helper.
+    try testing.expect(std.mem.indexOf(u8, w.message, "unlock") != null);
 }

--- a/docs/contract-patterns.md
+++ b/docs/contract-patterns.md
@@ -361,6 +361,20 @@ class Auction extends StatefulSmartContract {
 
 This pattern demonstrates combining multiple stateful fields, time-based conditions via locktime, and two distinct spending paths with different authorization rules.
 
+> **Pair `extractLocktime` with an `extractSequence` finality guard.** A
+> transaction's `nLockTime` is only enforced by consensus when at least one
+> input is *non-final* — i.e. its `nSequence` is below `0xffffffff`. If every
+> input is final, miners ignore `nLockTime` entirely, so a
+> `extractLocktime(preimage) >= deadline` (or `< deadline`) assertion can be
+> bypassed by a hand-built all-final-sequence spend. To make a locktime gate
+> consensus-enforced, also assert the spend is non-final:
+> `assert(extractSequence(this.txPreimage) < 0xffffffffn);`. The compiler emits
+> an advisory warning for any method that reads `extractLocktime` without such a
+> guard. The SDK's `CallOptions` help on the tx side: when you set a non-zero
+> `locktime`, `sequence` defaults to `0xfffffffe` (non-final) automatically — but
+> the covenant itself must still assert the sequence bound so no other unlocking
+> path can supply an all-final tx.
+
 ---
 
 ## Schnorr Zero-Knowledge Proof

--- a/packages/runar-compiler/src/__tests__/remediation-h1-loadprop-guard.test.ts
+++ b/packages/runar-compiler/src/__tests__/remediation-h1-loadprop-guard.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { lowerToStack } from '../passes/05-stack-lower.js';
+import type { ANFProgram } from '../ir/index.js';
+
+// ---------------------------------------------------------------------------
+// H1 (#119 tail): lowerLoadProp must NOT silently coerce an unknown property
+// onto constructor slot 0.
+//
+// A `load_prop` binding whose name is not a declared constructor-param property
+// used to fall through to `paramIndex >= 0 ? paramIndex : 0`, emitting the
+// placeholder for constructor slot 0 — an UNRELATED argument's deploy-time
+// bytes — with no diagnostic. That is a silent-wrong-code path: the produced
+// locking script splices the wrong value at that position.
+//
+// The hardened behaviour is a HARD ERROR with a clear diagnostic and the
+// binding's source location, instead of the silent placeholder.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal ANF program with a real readonly constructor-param property `pk`
+ * (constructor slot 0) plus a public method that loads a property `ghost`
+ * that is NOT declared on the contract. `ghost` therefore reaches the
+ * placeholder fallback with `paramIndex === -1`.
+ */
+function programWithUnknownLoadProp(): ANFProgram {
+  return {
+    contractName: 'Ghost',
+    properties: [
+      { name: 'pk', type: 'PubKey', readonly: true },
+    ],
+    methods: [
+      {
+        name: 'spend',
+        params: [],
+        isPublic: true,
+        body: [
+          {
+            name: 't0',
+            value: { kind: 'load_prop', name: 'ghost' },
+            sourceLoc: { file: 'Ghost.runar.ts', line: 7, column: 4 },
+          },
+          { name: 't1', value: { kind: 'assert', value: 't0' } },
+        ],
+      },
+    ],
+  };
+}
+
+describe('H1 (#119 tail): lowerLoadProp placeholder guard', () => {
+  it('throws on a load_prop for a property with no constructor slot (paramIndex === -1)', () => {
+    expect(() => lowerToStack(programWithUnknownLoadProp())).toThrow(
+      /ghost/,
+    );
+  });
+
+  it('includes the offending property name and source location in the diagnostic', () => {
+    let message = '';
+    try {
+      lowerToStack(programWithUnknownLoadProp());
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain('ghost');
+    expect(message).toContain('Ghost.runar.ts');
+    expect(message).toContain('7');
+  });
+
+  it('still lowers a real constructor-param property to a placeholder without error', () => {
+    const program: ANFProgram = {
+      contractName: 'Ok',
+      properties: [{ name: 'pk', type: 'PubKey', readonly: true }],
+      methods: [
+        {
+          name: 'spend',
+          params: [],
+          isPublic: true,
+          body: [
+            { name: 't0', value: { kind: 'load_prop', name: 'pk' } },
+            { name: 't1', value: { kind: 'assert', value: 't0' } },
+          ],
+        },
+      ],
+    };
+    expect(() => lowerToStack(program)).not.toThrow();
+  });
+});

--- a/packages/runar-compiler/src/__tests__/remediation-h2-locktime-sequence-warning.test.ts
+++ b/packages/runar-compiler/src/__tests__/remediation-h2-locktime-sequence-warning.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '../passes/01-parse.js';
+import { validate } from '../passes/02-validate.js';
+import type { ValidationResult } from '../passes/02-validate.js';
+import type { ContractNode } from '../ir/index.js';
+
+// ---------------------------------------------------------------------------
+// H2 (#131): locktime soundness warning.
+//
+// A method that reads extractLocktime(preimage) only enforces a timelock if
+// the covenant ALSO asserts the spending tx is non-final
+// (extractSequence(preimage) < 0xffffffff). Without that, a hand-built
+// all-final-sequence transaction bypasses the locktime gate. The compiler
+// should emit an advisory WARNING (non-fatal) when a public method reads
+// extractLocktime but does not (transitively) assert a sequence-finality
+// guard.
+// ---------------------------------------------------------------------------
+
+const WARNING_NEEDLE = 'does not assert extractSequence';
+
+function parseContract(source: string): ContractNode {
+  const result = parse(source);
+  if (!result.contract) {
+    throw new Error(`Parse failed: ${result.errors.map(e => e.message).join(', ')}`);
+  }
+  return result.contract;
+}
+
+function validateSource(source: string): ValidationResult {
+  return validate(parseContract(source));
+}
+
+function hasLocktimeWarning(result: ValidationResult): boolean {
+  return result.warnings.some(w => w.message.includes(WARNING_NEEDLE));
+}
+
+describe('H2 (#131): extractLocktime without extractSequence guard', () => {
+  it('warns when a method reads extractLocktime but has no sequence guard', () => {
+    const source = `
+      class TimeLock extends StatefulSmartContract {
+        count: bigint;
+        readonly deadline: bigint;
+        constructor(count: bigint, deadline: bigint) {
+          super(count, deadline);
+          this.count = count;
+          this.deadline = deadline;
+        }
+        public unlock() {
+          assert(extractLocktime(this.txPreimage) >= this.deadline);
+          this.count++;
+        }
+      }
+    `;
+    const result = validateSource(source);
+    expect(hasLocktimeWarning(result)).toBe(true);
+    // The warning names the method and points at the fix.
+    const w = result.warnings.find(x => x.message.includes(WARNING_NEEDLE))!;
+    expect(w.severity).toBe('warning');
+    expect(w.message).toContain('unlock');
+    expect(w.message).toContain('0xffffffff');
+  });
+
+  it('does NOT warn when the method also asserts extractSequence < final', () => {
+    const source = `
+      class TimeLock extends StatefulSmartContract {
+        count: bigint;
+        readonly deadline: bigint;
+        constructor(count: bigint, deadline: bigint) {
+          super(count, deadline);
+          this.count = count;
+          this.deadline = deadline;
+        }
+        public unlock() {
+          assert(extractSequence(this.txPreimage) < 0xffffffffn);
+          assert(extractLocktime(this.txPreimage) >= this.deadline);
+          this.count++;
+        }
+      }
+    `;
+    const result = validateSource(source);
+    expect(hasLocktimeWarning(result)).toBe(false);
+  });
+
+  it('does NOT warn for a method that never reads extractLocktime', () => {
+    const source = `
+      class Counter extends StatefulSmartContract {
+        count: bigint;
+        constructor(count: bigint) {
+          super(count);
+          this.count = count;
+        }
+        public increment() {
+          this.count++;
+        }
+      }
+    `;
+    const result = validateSource(source);
+    expect(hasLocktimeWarning(result)).toBe(false);
+  });
+
+  it('sees a sequence guard supplied transitively through a private helper', () => {
+    const source = `
+      class TimeLock extends StatefulSmartContract {
+        count: bigint;
+        readonly deadline: bigint;
+        constructor(count: bigint, deadline: bigint) {
+          super(count, deadline);
+          this.count = count;
+          this.deadline = deadline;
+        }
+        private requireNonFinal() {
+          assert(extractSequence(this.txPreimage) < 0xffffffffn);
+        }
+        public unlock() {
+          this.requireNonFinal();
+          assert(extractLocktime(this.txPreimage) >= this.deadline);
+          this.count++;
+        }
+      }
+    `;
+    const result = validateSource(source);
+    expect(hasLocktimeWarning(result)).toBe(false);
+  });
+
+  it('warns when the locktime read is in a private helper but no sequence guard exists', () => {
+    const source = `
+      class TimeLock extends StatefulSmartContract {
+        count: bigint;
+        readonly deadline: bigint;
+        constructor(count: bigint, deadline: bigint) {
+          super(count, deadline);
+          this.count = count;
+          this.deadline = deadline;
+        }
+        private checkDeadline() {
+          assert(extractLocktime(this.txPreimage) >= this.deadline);
+        }
+        public unlock() {
+          this.checkDeadline();
+          this.count++;
+        }
+      }
+    `;
+    const result = validateSource(source);
+    expect(hasLocktimeWarning(result)).toBe(true);
+  });
+});

--- a/packages/runar-compiler/src/passes/02-validate.ts
+++ b/packages/runar-compiler/src/passes/02-validate.ts
@@ -373,6 +373,12 @@ function validateMethod(method: MethodNode, ctx: ValidationContext): void {
     warnManualPreimageUsage(method, ctx);
   }
 
+  // #131: warn when a public method gates on extractLocktime but never asserts
+  // the spending tx is non-final (extractSequence < 0xffffffff). Advisory only.
+  if (method.visibility === 'public') {
+    warnLocktimeWithoutSequenceGuard(method, ctx);
+  }
+
   // Gate `asm({...})` calls on UnsafeSmartContract and check the
   // structural args. Walking the body once here keeps the diagnostic
   // close to the call site.
@@ -925,6 +931,104 @@ function warnManualPreimageUsage(method: MethodNode, ctx: ValidationContext): vo
       ));
     }
   });
+}
+
+// ---------------------------------------------------------------------------
+// #131: locktime soundness — extractLocktime needs an extractSequence guard
+// ---------------------------------------------------------------------------
+
+/** Sentinel maximum nSequence: a tx is FINAL (ignores locktime) at this value. */
+const SEQUENCE_FINAL = 0xffffffffn;
+
+/** True when `expr` is a direct call to the named intrinsic, e.g. `f(...)`. */
+function isCallToNamed(expr: Expression, name: string): boolean {
+  return (
+    expr.kind === 'call_expr' &&
+    expr.callee.kind === 'identifier' &&
+    expr.callee.name === name
+  );
+}
+
+/**
+ * True when `expr` reads the transaction locktime. Both the raw intrinsic
+ * `extractLocktime(preimage)` and its ergonomic sugar `currentBlockHeight()`
+ * (which the ANF pass desugars to `extractLocktime(txPreimage)`) count —
+ * either read is unsound without a sequence-finality guard.
+ */
+function isLocktimeRead(expr: Expression): boolean {
+  return isCallToNamed(expr, 'extractLocktime') || isCallToNamed(expr, 'currentBlockHeight');
+}
+
+/**
+ * True when `expr` is an `extractSequence(...) < <final>`-style comparison
+ * (the guard that makes a locktime gate consensus-enforced). Accepts the two
+ * natural spellings: `extractSequence(pre) < N` / `<= N`, and the reversed
+ * `N > extractSequence(pre)` / `>= ...`. `N` must be a bigint literal no
+ * greater than the finality sentinel, so the guard genuinely forces
+ * non-finality.
+ */
+function isSequenceFinalityGuard(expr: Expression): boolean {
+  if (expr.kind !== 'binary_expr') return false;
+  const boundOk = (e: Expression): boolean =>
+    e.kind === 'bigint_literal' && e.value <= SEQUENCE_FINAL;
+  if ((expr.op === '<' || expr.op === '<=') &&
+      isCallToNamed(expr.left, 'extractSequence') && boundOk(expr.right)) {
+    return true;
+  }
+  if ((expr.op === '>' || expr.op === '>=') &&
+      isCallToNamed(expr.right, 'extractSequence') && boundOk(expr.left)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * #131: warn when `method` (transitively, through the private-helper call
+ * graph) reads the tx locktime but never asserts the tx is non-final. A
+ * locktime gate is not consensus-enforced unless `extractSequence < 0xffffffff`
+ * is also asserted — otherwise an all-final-sequence spend bypasses it.
+ * Advisory (warning) only — no effect on emitted bytecode.
+ */
+function warnLocktimeWithoutSequenceGuard(method: MethodNode, ctx: ValidationContext): void {
+  const privateMethods = new Map(
+    ctx.contract.methods
+      .filter(m => m.visibility === 'private')
+      .map(m => [m.name, m] as const),
+  );
+
+  let readsLocktime = false;
+  let hasSequenceGuard = false;
+  const visited = new Set<string>([method.name]);
+  const queue: MethodNode[] = [method];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    walkExpressionsInBody(current.body, (expr) => {
+      if (isLocktimeRead(expr)) readsLocktime = true;
+      if (isSequenceFinalityGuard(expr)) hasSequenceGuard = true;
+    });
+    // Follow calls into private helpers so a guard (or locktime read) supplied
+    // by an inlined helper is seen by the public entry point.
+    const calls = new Set<string>();
+    collectMethodCalls(current.body, calls);
+    for (const callee of calls) {
+      if (!visited.has(callee) && privateMethods.has(callee)) {
+        visited.add(callee);
+        queue.push(privateMethods.get(callee)!);
+      }
+    }
+  }
+
+  if (readsLocktime && !hasSequenceGuard) {
+    ctx.warnings.push(makeDiagnostic(
+      `method '${method.name}' reads extractLocktime but does not assert ` +
+        `extractSequence < 0xffffffff; a locktime gate is not consensus-enforced ` +
+        `unless the tx is non-final — add ` +
+        `assert(extractSequence(this.txPreimage) < 0xffffffffn)`,
+      'warning',
+      method.sourceLocation,
+    ));
+  }
 }
 
 function walkExpressionsInBody(

--- a/packages/runar-compiler/src/passes/05-stack-lower.ts
+++ b/packages/runar-compiler/src/passes/05-stack-lower.ts
@@ -1265,9 +1265,29 @@ class LoweringContext {
       // since initialized properties are excluded from the constructor.
       const ctorProps = this._properties.filter(p => p.initialValue === undefined);
       const paramIndex = ctorProps.findIndex(p => p.name === propName);
+      // #119 tail (H1): a property that reaches the placeholder fallback with
+      // no matching constructor slot (paramIndex === -1) has no deploy-time
+      // bytes of its own. The previous behaviour coerced it onto slot 0,
+      // silently splicing an UNRELATED constructor argument's placeholder into
+      // the locking script — a silent-wrong-code path. Fail loudly instead.
+      // (A real constructor-param property — readonly or a mutable state field
+      // whose initial value is spliced at deploy — has paramIndex >= 0 and is
+      // unaffected.)
+      if (paramIndex < 0) {
+        const loc = this.currentSourceLoc
+          ? ` at ${this.currentSourceLoc.file}:${this.currentSourceLoc.line}:${this.currentSourceLoc.column}`
+          : '';
+        throw new Error(
+          `Stack lowering: property '${propName}'${loc} is neither on the stack, ` +
+            `initialized, nor a constructor parameter, so it has no deploy-time ` +
+            `slot. Refusing to emit a placeholder for an unrelated constructor ` +
+            `argument (slot 0). Known constructor-param properties: ` +
+            `[${ctorProps.map(p => p.name).join(', ')}].`,
+        );
+      }
       this.emitOp({
         op: 'placeholder',
-        paramIndex: paramIndex >= 0 ? paramIndex : 0,
+        paramIndex,
         paramName: propName,
       });
     }

--- a/packages/runar-java/src/main/java/runar/lang/sdk/DeployOptions.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/DeployOptions.java
@@ -1,0 +1,61 @@
+package runar.lang.sdk;
+
+/**
+ * Optional knobs for {@link RunarContract#deploy(Provider, Signer, DeployOptions)}.
+ * All fields are nullable; pass {@code null} (or use the positional
+ * {@code deploy} overloads) for the default flow (1 satoshi locked, change
+ * to the deploy signer's address, funding inputs signed by the deploy signer).
+ *
+ * <p>Parity target: TypeScript {@code DeployOptions} (runar-sdk
+ * {@code types.ts}).
+ */
+public final class DeployOptions {
+
+    /** Satoshis to lock in the contract UTXO. {@code null} → 1. */
+    public final Long satoshis;
+
+    /**
+     * P2PKH change address for the funding surplus. {@code null} → the
+     * deploy signer's own address.
+     */
+    public final String changeAddress;
+
+    /**
+     * Signer for the P2PKH funding inputs (issue #134). When the funding
+     * UTXOs are owned by a different key than the connected deploy signer,
+     * set this so the funding inputs are signed by their real owner. The
+     * funding-UTXO lookup still uses the deploy signer's address (mirroring
+     * the TS SDK). {@code null} → the deploy signer (zero behaviour change).
+     */
+    public final Signer fundingSigner;
+
+    public DeployOptions(Long satoshis, String changeAddress, Signer fundingSigner) {
+        this.satoshis = satoshis;
+        this.changeAddress = changeAddress;
+        this.fundingSigner = fundingSigner;
+    }
+
+    /** Empty options — every field defaulted. */
+    public DeployOptions() {
+        this(null, null, null);
+    }
+
+    // ------------------------------------------------------------------
+    // Immutable "wither" copies for setting individual optional fields.
+    // ------------------------------------------------------------------
+
+    /** Copy with {@link #satoshis} set. */
+    public DeployOptions withSatoshis(Long satoshis) {
+        return new DeployOptions(satoshis, changeAddress, fundingSigner);
+    }
+
+    /** Copy with {@link #changeAddress} set. */
+    public DeployOptions withChangeAddress(String changeAddress) {
+        return new DeployOptions(satoshis, changeAddress, fundingSigner);
+    }
+
+    /** Copy with {@link #fundingSigner} set (issue #134). */
+    public DeployOptions withFundingSigner(Signer fundingSigner) {
+        return new DeployOptions(satoshis, changeAddress, fundingSigner);
+    }
+}

--- a/packages/runar-java/src/main/java/runar/lang/sdk/RunarContract.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/RunarContract.java
@@ -308,6 +308,36 @@ public final class RunarContract {
         return deploy(provider, signer, satoshis, null);
     }
 
+    /**
+     * Rich-options deploy overload. Mirrors the TS SDK's
+     * {@code deploy(provider, signer, options)}: {@link DeployOptions#satoshis}
+     * (default 1) and {@link DeployOptions#changeAddress} (default the deploy
+     * signer's address) configure the contract output + change, while
+     * {@link DeployOptions#fundingSigner} (issue #134) signs the P2PKH funding
+     * inputs when they are owned by a different key than the deploy signer.
+     * When {@code fundingSigner} is unset the deploy signer signs them (zero
+     * behaviour change vs the positional overloads).
+     */
+    public DeployOutcome deploy(Provider provider, Signer signer, DeployOptions options) {
+        long satoshis = (options != null && options.satoshis != null) ? options.satoshis : 1L;
+        String changeAddress = options != null ? options.changeAddress : null;
+        Signer fundingSigner = (options != null && options.fundingSigner != null)
+            ? options.fundingSigner : signer;
+
+        String lockingScript = lockingScript();
+        // DoS-bound: reject pathological scripts BEFORE any signing / broadcast.
+        ScriptSizeExceededError.assertScriptHexUnderLimit(
+            lockingScript, InputLimits.MAX_SCRIPT_BYTES,
+            artifact.contractName() + ".deploy"
+        );
+        TransactionBuilder.DeployResult r = TransactionBuilder.buildDeployWithLockingScript(
+            lockingScript, provider, signer, satoshis, changeAddress, fundingSigner
+        );
+        String txid = provider.broadcastRaw(r.txHex());
+        this.currentUtxo = new UTXO(txid, 0, satoshis, lockingScript);
+        return new DeployOutcome(txid, r.txHex(), currentUtxo);
+    }
+
     public record DeployOutcome(String txid, String rawTxHex, UTXO deployedUtxo) {}
 
     /**
@@ -1480,7 +1510,38 @@ public final class RunarContract {
         // funding inputs + caller-supplied outputs. No continuation, no
         // change, no automatic funding selection.
         long contractSats = currentUtxo.satoshis();
-        List<UTXO> fundingUtxos = options.fundingUtxos == null ? List.of() : options.fundingUtxos;
+        // Funding (and terminal fee) inputs are signed by fundingSigner when set
+        // (issue #134); the method's own Sig args stay with the connected signer.
+        Signer fundingSigner = options.fundingSigner != null ? options.fundingSigner : signer;
+        // Fee input (issue #118): a single plain P2PKH UTXO consumed entirely as
+        // fee. Prepended to the funding list so it sits at input index 1 (right
+        // after the primary contract input) and is signed like any funding input.
+        UTXO feeUtxo = options.feeUtxo;
+        List<UTXO> callerFunding = options.fundingUtxos == null ? List.of() : options.fundingUtxos;
+        List<UTXO> effectiveFunding = new ArrayList<>();
+        if (feeUtxo != null) effectiveFunding.add(feeUtxo);
+        effectiveFunding.addAll(callerFunding);
+
+        // Sanity: contract balance + funding (incl. any feeUtxo) must cover the
+        // output sum; the surplus over outputs becomes the miner fee.
+        long termOutSats = 0;
+        for (CallOptions.TerminalOutput o : options.terminalOutputs) {
+            termOutSats += o.satoshis().longValueExact();
+        }
+        long fundingSats = 0;
+        for (UTXO fu : effectiveFunding) fundingSats += fu.satoshis();
+        if (contractSats + fundingSats < termOutSats) {
+            throw new IllegalStateException(
+                "RunarContract.prepareCall: terminal outputs (" + termOutSats
+                    + " sats) exceed contract balance (" + contractSats
+                    + ") + funding (" + fundingSats + ")"
+            );
+        }
+
+        // Sequence (issue #131): all-final inputs make nLockTime a consensus
+        // no-op — when a non-zero locktime is set, default to 0xfffffffe so the
+        // terminal method's extractLocktime assertion is actually enforced.
+        long termSequence = resolveInputSequence(options.locktime, options.sequence);
         // Terminal calls typically assert extractLocktime(preimage) >= deadline.
         // Default 0 preserves legacy behavior for non-locktime contracts.
         int terminalLocktime = options.locktime != null ? options.locktime : 0;
@@ -1488,12 +1549,13 @@ public final class RunarContract {
             RawTx t = new RawTx();
             t.locktime = terminalLocktime;
             t.addInput(currentUtxo.txid(), currentUtxo.outputIndex(), "");
-            for (UTXO fu : fundingUtxos) {
+            for (UTXO fu : effectiveFunding) {
                 t.addInput(fu.txid(), fu.outputIndex(), "");
             }
             for (CallOptions.TerminalOutput o : options.terminalOutputs) {
                 t.addOutput(o.satoshis().longValueExact(), o.resolveScriptHex());
             }
+            t.setAllSequences(termSequence);
             return t;
         };
 
@@ -1567,20 +1629,23 @@ public final class RunarContract {
         RawTx finalTx = buildTx.get();
         finalTx.setUnlockingScript(0, contractUnlock);
 
-        // Sign every funding input now — only the contract-input Sig
-        // values remain for the external signer to fill in.
-        if (signer != null) {
-            for (int i = 0; i < fundingUtxos.size(); i++) {
+        // Sign every funding input now (feeUtxo first, at index 1 — issue #118),
+        // with fundingSigner (issue #134) — only the contract-input Sig values
+        // remain for the external signer to fill in. Each P2PKH BIP-143 sighash
+        // covers only hashPrevouts / hashOutputs / its own outpoint — NOT input
+        // 0's scriptSig — so it stays valid after finalizeCall rewrites input 0.
+        if (fundingSigner != null) {
+            for (int i = 0; i < effectiveFunding.size(); i++) {
                 int inputIdx = 1 + i;
-                UTXO fu = fundingUtxos.get(i);
+                UTXO fu = effectiveFunding.get(i);
                 byte[] fundSighash = finalTx.sighashBIP143(
                     inputIdx, fu.scriptHex(), fu.satoshis(), RawTx.SIGHASH_ALL_FORKID
                 );
-                byte[] der = signer.sign(fundSighash, null);
+                byte[] der = fundingSigner.sign(fundSighash, null);
                 String fundSigHex = ScriptUtils.bytesToHex(der)
                     + String.format("%02x", RawTx.SIGHASH_ALL_FORKID);
                 String fundUnlock = ScriptUtils.encodePushData(fundSigHex)
-                    + ScriptUtils.encodePushData(ScriptUtils.bytesToHex(signer.pubKey()));
+                    + ScriptUtils.encodePushData(ScriptUtils.bytesToHex(fundingSigner.pubKey()));
                 finalTx.setUnlockingScript(inputIdx, fundUnlock);
             }
         }

--- a/packages/runar-java/src/main/java/runar/lang/sdk/TransactionBuilder.java
+++ b/packages/runar-java/src/main/java/runar/lang/sdk/TransactionBuilder.java
@@ -54,6 +54,28 @@ public final class TransactionBuilder {
         long satoshis,
         String changeAddress
     ) {
+        return buildDeployWithLockingScript(
+            lockingScriptHex, provider, signer, satoshis, changeAddress, signer
+        );
+    }
+
+    /**
+     * Deploy variant that signs the P2PKH funding inputs with a separate
+     * {@code fundingSigner} (issue #134). The funding-UTXO lookup and the
+     * default change address still come from the deploy {@code signer}
+     * (mirroring the TS SDK's {@code DeployOptions.fundingSigner}); only the
+     * per-input signature + pushed pubkey use {@code fundingSigner}. Pass
+     * {@code fundingSigner == signer} for the default (zero behaviour change).
+     */
+    public static DeployResult buildDeployWithLockingScript(
+        String lockingScriptHex,
+        Provider provider,
+        Signer signer,
+        long satoshis,
+        String changeAddress,
+        Signer fundingSigner
+    ) {
+        Signer funder = fundingSigner != null ? fundingSigner : signer;
         String funderAddress = signer.address();
         List<UTXO> all = provider.listUtxos(funderAddress);
         if (all.isEmpty()) {
@@ -86,12 +108,12 @@ public final class TransactionBuilder {
             tx.addOutput(change, ScriptUtils.buildP2PKHScript(effectiveChangeAddr));
         }
 
-        // Sign each P2PKH funding input.
+        // Sign each P2PKH funding input (with fundingSigner — issue #134).
         for (int i = 0; i < selected.size(); i++) {
             UTXO u = selected.get(i);
             byte[] sighash = tx.sighashBIP143(i, u.scriptHex(), u.satoshis(), RawTx.SIGHASH_ALL_FORKID);
-            byte[] der = signer.sign(sighash, null);
-            byte[] pub = signer.pubKey();
+            byte[] der = funder.sign(sighash, null);
+            byte[] pub = funder.pubKey();
             String sigHex = ScriptUtils.bytesToHex(der)
                 + String.format("%02x", RawTx.SIGHASH_ALL_FORKID);
             String unlockHex = ScriptUtils.encodePushData(sigHex)

--- a/packages/runar-java/src/test/java/runar/lang/sdk/DeployFundingSignerTest.java
+++ b/packages/runar-java/src/test/java/runar/lang/sdk/DeployFundingSignerTest.java
@@ -1,0 +1,119 @@
+package runar.lang.sdk;
+
+import java.util.HexFormat;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #134 (deploy path) — the P2PKH funding inputs of a deploy tx must be
+ * signable by a key that differs from the connected deploy signer.
+ *
+ * <p>{@code deploy()} signed every funding input with the deploy signer and
+ * pushed that signer's pubkey. When the funding UTXO is owned by a DIFFERENT
+ * key, the scriptSig's pubkey fails OP_EQUALVERIFY against the coin's PKH.
+ * {@link DeployOptions#fundingSigner} lets the real owner sign; the funding
+ * lookup / change address still come from the deploy signer (TS parity).
+ */
+class DeployFundingSignerTest {
+
+    private static final String METHOD_PRIV =
+        "18e14a7b6a307f426a94f8114701e7c8e774e7f9a47e2c2035db29a206321725";
+    private static final String FUNDING_PRIV =
+        "0000000000000000000000000000000000000000000000000000000000000abc";
+
+    private static RunarArtifact loadArtifact(String leaf) throws Exception {
+        var in = DeployFundingSignerTest.class.getClassLoader()
+            .getResourceAsStream("artifacts/" + leaf);
+        assertNotNull(in, "test artifact not found on classpath: " + leaf);
+        try (in) {
+            return RunarArtifact.fromJson(new String(in.readAllBytes(),
+                java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    private static RunarContract freshContract(LocalSigner methodSigner) throws Exception {
+        RunarArtifact artifact = loadArtifact("basic-p2pkh.runar.json");
+        String pkhHex = HexFormat.of().formatHex(Hash160.hash160(methodSigner.pubKey()));
+        return new RunarContract(artifact, List.of(pkhHex));
+    }
+
+    /**
+     * Registers the funding coin under the DEPLOY signer's address bucket
+     * (so the provider lookup at {@code signer.address()} finds it) but scripts
+     * it to the FUNDING signer's PKH — so only the funding signer can spend it.
+     * Mirrors the TS #134 test's {@code fundingCoinUnderMethodAddress}.
+     */
+    private static void fundingCoinUnderMethodAddress(
+        MockProvider provider, LocalSigner methodSigner, String fundingScript, long sats) {
+        provider.addUtxo(methodSigner.address(),
+            new UTXO("a1".repeat(32), 0, sats, fundingScript));
+    }
+
+    @Test
+    void deployWithoutFundingSignerPushesTheDeploySignerPubkey() throws Exception {
+        LocalSigner methodSigner = new LocalSigner(METHOD_PRIV);
+        LocalSigner fundingSigner = new LocalSigner(FUNDING_PRIV);
+        String fundingScript = ScriptUtils.buildP2PKHScript(fundingSigner.address());
+
+        MockProvider provider = new MockProvider();
+        fundingCoinUnderMethodAddress(provider, methodSigner, fundingScript, 100_000L);
+
+        RunarContract contract = freshContract(methodSigner);
+        RunarContract.DeployOutcome out = contract.deploy(provider, methodSigner, 1_000L);
+
+        RawTx tx = RawTxParser.parse(out.rawTxHex());
+        String fundInputScriptSig = tx.inputs.get(0).scriptSigHex;
+        String methodPubHex = ScriptUtils.bytesToHex(methodSigner.pubKey());
+        String fundingPubHex = ScriptUtils.bytesToHex(fundingSigner.pubKey());
+        // Default: signed by the deploy signer → pushes the deploy signer's
+        // pubkey, which would fail OP_EQUALVERIFY against the funding coin's PKH.
+        assertTrue(fundInputScriptSig.contains(methodPubHex),
+            "default deploy funding input pushes the deploy signer's pubkey");
+        assertFalse(fundInputScriptSig.contains(fundingPubHex),
+            "default deploy funding input must NOT push the funding signer's pubkey");
+    }
+
+    @Test
+    void deployWithFundingSignerProducesValidFundingInputSig() throws Exception {
+        LocalSigner methodSigner = new LocalSigner(METHOD_PRIV);
+        LocalSigner fundingSigner = new LocalSigner(FUNDING_PRIV);
+        String fundingScript = ScriptUtils.buildP2PKHScript(fundingSigner.address());
+
+        MockProvider provider = new MockProvider();
+        fundingCoinUnderMethodAddress(provider, methodSigner, fundingScript, 100_000L);
+
+        RunarContract contract = freshContract(methodSigner);
+        DeployOptions opts = new DeployOptions().withSatoshis(1_000L).withFundingSigner(fundingSigner);
+        RunarContract.DeployOutcome out = contract.deploy(provider, methodSigner, opts);
+
+        RawTx tx = RawTxParser.parse(out.rawTxHex());
+        String fundInputScriptSig = tx.inputs.get(0).scriptSigHex;
+        String methodPubHex = ScriptUtils.bytesToHex(methodSigner.pubKey());
+        String fundingPubHex = ScriptUtils.bytesToHex(fundingSigner.pubKey());
+
+        // The funding input pushes the FUNDING signer's pubkey (satisfies
+        // OP_EQUALVERIFY against the coin's PKH), not the deploy signer's.
+        assertTrue(fundInputScriptSig.contains(fundingPubHex),
+            "funding input must push the funding signer's pubkey");
+        assertFalse(fundInputScriptSig.contains(methodPubHex),
+            "funding input must NOT push the deploy signer's pubkey");
+
+        // And the pushed signature is the funding signer's valid, deterministic
+        // (RFC 6979) signature over the funding input's BIP-143 sighash — the
+        // canonical bytes would fail CHECKSIG under any other key.
+        byte[] sighash = tx.sighashBIP143(
+            0, fundingScript, 100_000L, RawTx.SIGHASH_ALL_FORKID);
+        String expectedSigHex = ScriptUtils.bytesToHex(fundingSigner.sign(sighash, null))
+            + String.format("%02x", RawTx.SIGHASH_ALL_FORKID);
+        assertTrue(fundInputScriptSig.contains(expectedSigHex),
+            "funding input must carry the funding signer's valid BIP-143 signature");
+        // A signature by the deploy signer over the same digest would differ.
+        String wrongSigHex = ScriptUtils.bytesToHex(methodSigner.sign(sighash, null))
+            + String.format("%02x", RawTx.SIGHASH_ALL_FORKID);
+        assertFalse(fundInputScriptSig.contains(wrongSigHex),
+            "funding input must NOT carry the deploy signer's signature");
+    }
+}

--- a/packages/runar-java/src/test/java/runar/lang/sdk/PreparedTerminalOptionsTest.java
+++ b/packages/runar-java/src/test/java/runar/lang/sdk/PreparedTerminalOptionsTest.java
@@ -1,0 +1,110 @@
+package runar.lang.sdk;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Gap 2 — the multi-signer {@code prepareCall}/{@code finalizeCall} terminal
+ * path must honour the same funding options as the primary
+ * {@code callWithOptions} terminal path:
+ *
+ * <ul>
+ *   <li>#131 — {@code sequence} (non-final default under a non-zero locktime)</li>
+ *   <li>#134 — {@code fundingSigner} (fee/funding inputs signed by their owner)</li>
+ *   <li>#118 — {@code feeUtxo} (extra P2PKH fee input at index 1)</li>
+ * </ul>
+ *
+ * <p>With a deterministic (RFC 6979) local signer the two paths must build a
+ * byte-identical transaction for the same inputs.
+ */
+class PreparedTerminalOptionsTest {
+
+    private static final String METHOD_PRIV =
+        "18e14a7b6a307f426a94f8114701e7c8e774e7f9a47e2c2035db29a206321725";
+    private static final String FUNDING_PRIV =
+        "0000000000000000000000000000000000000000000000000000000000000abc";
+
+    private static RunarArtifact loadArtifact(String leaf) throws Exception {
+        var in = PreparedTerminalOptionsTest.class.getClassLoader()
+            .getResourceAsStream("artifacts/" + leaf);
+        assertNotNull(in, "test artifact not found on classpath: " + leaf);
+        try (in) {
+            return RunarArtifact.fromJson(new String(in.readAllBytes(),
+                java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    private static RunarContract deployedContract(LocalSigner methodSigner) throws Exception {
+        RunarArtifact artifact = loadArtifact("basic-p2pkh.runar.json");
+        String pkhHex = HexFormat.of().formatHex(Hash160.hash160(methodSigner.pubKey()));
+        RunarContract contract = new RunarContract(artifact, List.of(pkhHex));
+        contract.setCurrentUtxo(new UTXO("ab".repeat(32), 0, 10_000L, contract.lockingScript()));
+        return contract;
+    }
+
+    @Test
+    void preparedTerminalHonorsSequenceFundingSignerAndFeeUtxoMatchingPrimaryPath() throws Exception {
+        LocalSigner methodSigner = new LocalSigner(METHOD_PRIV);
+        LocalSigner fundingSigner = new LocalSigner(FUNDING_PRIV);
+        MockProvider provider = new MockProvider();
+
+        // Terminal output pays out the full contract balance → the fee must come
+        // from the feeUtxo (issue #118), owned/signed by the funding key (#134).
+        List<CallOptions.TerminalOutput> outs = List.of(
+            new CallOptions.TerminalOutput(BigInteger.valueOf(10_000L), methodSigner.address(), null));
+        UTXO feeUtxo = new UTXO("fe".repeat(32), 3, 5_000L,
+            ScriptUtils.buildP2PKHScript(fundingSigner.address()));
+        // Non-zero locktime → inputs default to 0xfffffffe (issue #131).
+        CallOptions opts = CallOptions.terminal(outs)
+            .withFeeUtxo(feeUtxo)
+            .withFundingSigner(fundingSigner)
+            .withLocktime(500_000);
+
+        // ---- Primary path ----
+        RunarContract primary = deployedContract(methodSigner);
+        RunarContract.CallOutcome primaryOut = primary.callWithOptions(
+            "unlock", Arrays.asList(null, null), opts, provider, methodSigner);
+
+        // ---- Multi-signer prepare/finalize path ----
+        RunarContract prep = deployedContract(methodSigner);
+        PreparedCall prepared = prep.prepareCallWithOptions(
+            "unlock", Arrays.asList(null, null), opts, provider, methodSigner);
+        assertEquals(1, prepared.sigIndices().size(), "one Sig placeholder expected");
+        // External sign step (simulated): the connected signer signs the digest.
+        byte[] der = methodSigner.sign(prepared.sighashes().get(0), null);
+        RunarContract.CallOutcome preparedOut = prep.finalizeCall(prepared, List.of(der), provider);
+
+        // The two paths must produce a byte-identical transaction.
+        assertEquals(primaryOut.rawTxHex(), preparedOut.rawTxHex(),
+            "prepare/finalize terminal tx must match the primary callWithOptions tx byte-for-byte");
+
+        // Structural checks on the prepared/finalized tx.
+        RawTx tx = RawTxParser.parse(preparedOut.rawTxHex());
+        assertEquals(2, tx.inputs.size(), "terminal tx = contract input + fee input");
+        assertEquals(feeUtxo.txid(), tx.inputs.get(1).prevTxid, "fee input sits at index 1 (#118)");
+        assertEquals(feeUtxo.outputIndex(), tx.inputs.get(1).prevVout);
+        assertEquals(1, tx.outputs.size(), "no change output on a terminal fee-utxo tx");
+        assertEquals(500_000, tx.locktime);
+        for (RawTx.Input in : tx.inputs) {
+            assertEquals(0xfffffffeL, in.sequence,
+                "a non-zero locktime must make every input non-final (#131)");
+        }
+        // Fee = (contract + feeUtxo) - outputs = (10000 + 5000) - 10000 = 5000.
+        long inSats = 10_000L + 5_000L;
+        long outSats = tx.outputs.stream().mapToLong(o -> o.satoshis).sum();
+        assertEquals(5_000L, inSats - outSats, "the feeUtxo is consumed entirely as fee");
+
+        // Fee input pushes the FUNDING signer's pubkey (#134), not the method's.
+        String feeUnlock = tx.inputs.get(1).scriptSigHex;
+        assertTrue(feeUnlock.contains(ScriptUtils.bytesToHex(fundingSigner.pubKey())),
+            "fee input must be signed with (and push) the funding signer's pubkey");
+        assertFalse(feeUnlock.contains(ScriptUtils.bytesToHex(methodSigner.pubKey())),
+            "fee input must NOT push the method signer's pubkey");
+    }
+}

--- a/packages/runar-sdk/src/__tests__/remediation-h3-feeutxo-oversize.test.ts
+++ b/packages/runar-sdk/src/__tests__/remediation-h3-feeutxo-oversize.test.ts
@@ -1,0 +1,102 @@
+/**
+ * H3 (#118): warn when a terminal-call feeUtxo dwarfs the actual fee.
+ *
+ * A feeUtxo is consumed ENTIRELY as fee — there is no change output, because
+ * the covenant binds the exact terminal output set. An oversized feeUtxo
+ * therefore silently BURNS the excess. The SDK should emit a runtime
+ * console.warn when feeUtxo.satoshis significantly exceeds the terminal tx's
+ * estimated fee, so the caller notices before broadcasting.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { RunarContract } from '../contract.js';
+import { MockProvider } from '../providers/mock.js';
+import { LocalSigner } from '../signers/local.js';
+import { buildP2PKHScript } from '../script-utils.js';
+import { Transaction } from '@bsv/sdk';
+import type { RunarArtifact } from 'runar-ir-schema';
+import type { UTXO } from '../types.js';
+
+const METHOD_KEY = '00'.repeat(31) + '03';
+const FUNDING_KEY = '00'.repeat(31) + '07';
+
+const TRIVIAL_ARTIFACT: RunarArtifact = {
+  version: 'runar-v0.1.0',
+  compilerVersion: '0.1.0',
+  contractName: 'Escrow',
+  asm: '',
+  buildTimestamp: '2026-03-02T00:00:00.000Z',
+  script: '51', // OP_TRUE
+  abi: { constructor: { params: [] }, methods: [{ name: 'settle', params: [], isPublic: true }] },
+};
+
+const CONTRACT_SATS = 50_000;
+const PAYOUT = '76a914' + 'bb'.repeat(20) + '88ac';
+
+async function setup() {
+  const methodSigner = new LocalSigner(METHOD_KEY);
+  const provider = new MockProvider();
+  const methodAddr = await methodSigner.getAddress();
+  provider.addUtxo(methodAddr, {
+    txid: 'cc'.repeat(32),
+    outputIndex: 0,
+    satoshis: 200_000,
+    script: buildP2PKHScript(await methodSigner.getPublicKey()),
+  });
+  const contract = new RunarContract(TRIVIAL_ARTIFACT, []);
+  await contract.deploy(provider, methodSigner, { satoshis: CONTRACT_SATS });
+  return { methodSigner, provider, contract };
+}
+
+/** True when a console.warn call carried the H3 burn advisory. */
+function burnWarned(spy: ReturnType<typeof vi.spyOn>): boolean {
+  return spy.mock.calls.some(
+    (args) => typeof args[0] === 'string' && args[0].includes('feeUtxo') && args[0].includes('BURNED'),
+  );
+}
+
+describe('H3 (#118): oversized feeUtxo burn warning', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('warns when feeUtxo.satoshis dwarfs the terminal tx fee', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { methodSigner, provider, contract } = await setup();
+    const fundingSigner = new LocalSigner(FUNDING_KEY);
+    const feeScript = buildP2PKHScript(await fundingSigner.getPublicKey());
+    // ~30-sat real fee at the mock's 100 sat/KB rate; 500,000 sats is ~15000x.
+    const feeUtxo: UTXO = { txid: 'ee'.repeat(32), outputIndex: 1, satoshis: 500_000, script: feeScript };
+
+    await contract.call('settle', [], provider, methodSigner, {
+      terminalOutputs: [{ scriptHex: PAYOUT, satoshis: CONTRACT_SATS }],
+      feeUtxo,
+      fundingSigner,
+    });
+
+    expect(burnWarned(warn)).toBe(true);
+  });
+
+  it('does NOT warn when the feeUtxo is right-sized', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { methodSigner, provider, contract } = await setup();
+    const fundingSigner = new LocalSigner(FUNDING_KEY);
+    const feeScript = buildP2PKHScript(await fundingSigner.getPublicKey());
+    // Close to the ~30-sat estimated fee — no meaningful excess burned.
+    const feeUtxo: UTXO = { txid: 'ee'.repeat(32), outputIndex: 1, satoshis: 100, script: feeScript };
+
+    await contract.call('settle', [], provider, methodSigner, {
+      terminalOutputs: [{ scriptHex: PAYOUT, satoshis: CONTRACT_SATS }],
+      feeUtxo,
+      fundingSigner,
+    });
+
+    expect(burnWarned(warn)).toBe(false);
+  });
+
+  it('does not warn when no feeUtxo is supplied', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { methodSigner, provider, contract } = await setup();
+    await contract.call('settle', [], provider, methodSigner, {
+      terminalOutputs: [{ scriptHex: PAYOUT, satoshis: CONTRACT_SATS }],
+    });
+    expect(burnWarned(warn)).toBe(false);
+  });
+});

--- a/packages/runar-sdk/src/contract.ts
+++ b/packages/runar-sdk/src/contract.ts
@@ -872,6 +872,37 @@ export class RunarContract {
           encodePushData(feeSig) + encodePushData(feePubKey),
         );
         invalidateTxCache(termTx);
+
+        // #118: a feeUtxo is consumed ENTIRELY as fee — there is no change
+        // output, because the covenant binds the exact terminal output set.
+        // An oversized feeUtxo therefore silently BURNS the excess. Warn (but
+        // never block) when it dwarfs the terminal tx's estimated fee.
+        // Heuristic: excess is burned if the feeUtxo is > 5x the estimated fee
+        // AND at least ~1000 sats of excess would be burned (an absolute floor
+        // so a slightly-generous fee on a tiny tx does not nag). Best-effort:
+        // any failure fetching the fee rate skips the advisory silently.
+        try {
+          const feeRate = await provider.getFeeRate(); // sat/KB
+          const termTxSizeBytes = termTx.toHex().length / 2;
+          const estimatedFee = Math.max(1, Math.ceil((termTxSizeBytes * feeRate) / 1000));
+          const excess = options.feeUtxo.satoshis - estimatedFee;
+          const OVERSIZE_FEE_MULTIPLE = 5;
+          const OVERSIZE_MIN_EXCESS_SATS = 1000;
+          if (
+            options.feeUtxo.satoshis > estimatedFee * OVERSIZE_FEE_MULTIPLE &&
+            excess > OVERSIZE_MIN_EXCESS_SATS
+          ) {
+            console.warn(
+              `runar-sdk: ${this.artifact.contractName}.call('${methodName}'): feeUtxo is ` +
+                `${options.feeUtxo.satoshis} sats but the terminal tx needs only ~${estimatedFee} sats ` +
+                `of fee. A feeUtxo is consumed ENTIRELY as fee (no change output — the covenant binds ` +
+                `the exact terminal outputs), so ~${excess} sats will be BURNED. Size the feeUtxo close ` +
+                `to the intended fee (issue #118).`,
+            );
+          }
+        } catch {
+          // Advisory only — never fail a call because the fee-rate lookup threw.
+        }
       }
 
       // Compute sighash from preimage

--- a/packages/runar-sdk/src/types.ts
+++ b/packages/runar-sdk/src/types.ts
@@ -172,6 +172,14 @@ export interface CallOptions {
    * BEFORE the OP_PUSH_TX preimage is computed (so hashPrevouts covers it) and
    * is consumed entirely as fee — no change output is created. Signed with
    * `fundingSigner ?? signer`. The covenant's output assertions are untouched.
+   *
+   * IMPORTANT: because there is no change output, the ENTIRE feeUtxo is spent
+   * as fee — any amount beyond the actual miner fee is BURNED, not returned.
+   * Size the feeUtxo close to the intended fee (a few hundred sats at the BSV
+   * standard 0.1 sat/byte is typical for a small terminal tx). The SDK emits a
+   * `console.warn` when the supplied feeUtxo dwarfs the terminal tx's estimated
+   * fee (> 5x and > ~1000 sats of excess), so an accidental large coin is
+   * caught before broadcast.
    */
   feeUtxo?: UTXO;
 


### PR DESCRIPTION
# Hardening follow-ups: silent-placeholder error, locktime/feeUtxo footguns, Java funding parity

Small, mostly-advisory hardenings surfaced by the adversarial reviews during the #106–#134 remediation (#136, #138). No consensus/bytecode behavior changes for existing contracts — **zero conformance golden churn**.

## H1 — `load_prop` with no constructor slot now hard-errors (all 7 tiers) — #119 tail
The stack lowerer's `load_prop` fallback silently coerced a property with no deploy-time slot onto **constructor slot 0** — pushing an unrelated arg's placeholder (a silent-wrong-code path). It now fails loudly with a diagnostic naming the property. Proven unreachable by any current fixture (instrumented: 4,852 fallback hits, none on the error path), so zero golden churn; legitimate constructor-param and mutable-slot properties are unaffected. Ported to all 6 non-TS tiers.
- *Python note:* a pre-existing Python-parser gap (inline `constructor(readonly n)` param-properties never enter the property list) means Python errors only when the ctor-param list is non-empty — the real ghost case still errors; the parser gap is flagged as a separate follow-up.

## H2 — locktime soundness warning (all 7 tiers) — #131 follow-up
A method reading `extractLocktime` (or `currentBlockHeight()`) is only consensus-enforced if the covenant **also** asserts `extractSequence(preimage) < 0xffffffff` (else a hand-built all-final-sequence tx mines immediately despite a future nLockTime — the #131 consensus-review finding). The compiler now emits an advisory **warning** (transitive through private helpers) when the sequence guard is missing. Warning-only → no bytecode change. Ported to all 6 non-TS tiers.

## H3 — feeUtxo oversize warning + docs — #118 follow-up
`CallOptions.feeUtxo` is consumed **entirely** as the miner fee (no change output — inherent to the exact-output covenant binding). The SDK now warns when a `feeUtxo` dwarfs the estimated fee (best-effort, never blocks the call), and the `feeUtxo` doc + a contract-patterns callout document both this and the H2 locktime/sequence pairing. (TS SDK; 6-SDK warning port is a minor follow-up.)

## H4 — Java SDK funding parity — #134 / #118
- `DeployOptions.fundingSigner` wired for Java `deploy()` (was TS-only) — funding inputs signed by a separate funding signer, defaulting to the connected signer.
- The multi-signer `prepareTerminalCall`/`finalizeCall` path now honors `fundingSigner` (#134), `feeUtxo` (#118), and `sequence` (#131) — verified byte-identical to the primary `callWithOptions` path.
- *Residual (noted):* the non-terminal `prepareCall` path would need a larger rewrite to thread `sequence` (it uses a simpler builder with no funding/OP_PUSH_TX two-pass) — scoped out.

## Verification (all green, zero golden churn)

- **Conformance fold-OFF 64/64**; **parser-only matrix 576/576 on all 7 tiers** — the hardenings don't perturb any fixture.
- TS packages (runar-compiler 3586, runar-sdk 513) + all 6 native compiler suites (Go/Rust/Python 1109/Zig 714/Ruby/Java 639) + Java SDK (471) — 0 failed.
- H1 errors consistently and H2 warns consistently across all 7 tiers; one test per hardening per tier.
