### PR TITLE
fix(ci): bump Go workspace toolchain to 1.26.5 (govulncheck GO-2026-5856)

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 use (
 	./compilers/go


### PR DESCRIPTION
## What

Bumps `go.work`'s `toolchain` directive from `go1.26.4` to `go1.26.5`.

## Why

The `Go - govulncheck` CI job has been red on `main` (and every recent PR) with **GO-2026-5856** — *Encrypted Client Hello privacy leak in `crypto/tls`* — a Go **standard-library** vulnerability reachable from `packages/runar-go`'s HTTPS provider code:

```
Vulnerability #1: GO-2026-5856
  Standard library
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
    Example traces:
      sdk_wallet.go:200: WalletProvider.Broadcast -> http.Client.Do -> tls.Conn.HandshakeContext
      sdk_gorillapool.go:434: GorillaPoolProvider.GetBSV21Balance -> io.ReadAll -> tls.Conn.Read
```

`go.work` pinned `toolchain go1.26.4`, forcing the whole workspace — and govulncheck's stdlib analysis — onto the vulnerable 1.26.4 stdlib. The fix version is `go1.26.5`, so bumping the toolchain directive resolves it. The `go 1.26` module directives and the floating `go-version: '1.26'` setup-go pins already accept 1.26.5, so this one line is the whole fix.

## Verification

Locally, govulncheck (rebuilt on 1.26.5) reports **0 vulnerabilities** on all three scanned modules (`compilers/go`, `packages/runar-go`, `conformance`), and the workspace builds clean under 1.26.5.