### PR TITLE
fix(go): reject malformed source instead of silently dropping statements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,15 @@ jobs:
         env:
           JAVA_JAR: ${{ steps.java-jar.outputs.path }}
         run: conformance/node_modules/.bin/tsx conformance/runner/index.ts --tests-dir conformance/tests --parser-only
+      - name: Cross-tier rejection parity (programs that must NOT compile)
+        # The parser-only step above proves every tier ACCEPTS what it should.
+        # Nothing proved they agree on what to REFUSE, and that gap let a Go
+        # statement-drop reach RC: malformed input was silently discarded and
+        # the tier emitted a locking script the other six rejected. This runs
+        # the negative corpus against every built tier.
+        env:
+          JAVA_JAR: ${{ steps.java-jar.outputs.path }}
+        run: cd conformance && npx vitest run negatives/
       - name: Run multi-format source conformance (all 7 compilers, all 9 formats)
         # Adds the TypeScript compiler to the central conformance job (it was
         # previously absent) and exercises every compiler's frontend against

--- a/compilers/go/frontend/parser.go
+++ b/compilers/go/frontend/parser.go
@@ -181,6 +181,25 @@ func Parse(source []byte, fileName string) *ParseResult {
 		fileName: fileName,
 	}
 
+	// tree-sitter is error-tolerant: malformed source still yields a tree, with
+	// the bad region marked ERROR/MISSING. Walking such a tree silently DROPS
+	// whatever failed to resolve (a statement parser returning nil is simply
+	// not appended), so `this.value = ;` used to compile to a script with the
+	// state write missing, and a malformed `assert(...)` to a script with the
+	// guard missing. Refuse the file instead — one check for every malformed
+	// shape, rather than a nil-guard per statement kind.
+	if root.HasError() {
+		if bad := firstBadNode(root); bad != nil {
+			p.addError(fmt.Sprintf(
+				"syntax error at line %d: unparseable %s near %q",
+				bad.StartPoint().Row+1, bad.Type(), p.snippet(bad),
+			))
+		} else {
+			p.addError("syntax error: source is not valid Rúnar")
+		}
+		return &ParseResult{Errors: p.errors}
+	}
+
 	contract := p.findContract(root)
 	if contract == nil {
 		p.addError("no class extending SmartContract, StatefulSmartContract, or UnsafeSmartContract found")
@@ -201,6 +220,37 @@ type parseContext struct {
 	source   []byte
 	fileName string
 	errors   []Diagnostic
+}
+
+// firstBadNode returns the first ERROR or MISSING node in the tree, so the
+// diagnostic can point at the offending line instead of the whole file.
+func firstBadNode(n *sitter.Node) *sitter.Node {
+	if n.IsError() || n.IsMissing() {
+		return n
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if bad := firstBadNode(n.Child(i)); bad != nil {
+			return bad
+		}
+	}
+	return nil
+}
+
+// snippet renders a short, single-line excerpt of the node's source span for
+// the diagnostic message.
+func (p *parseContext) snippet(n *sitter.Node) string {
+	start, end := int(n.StartByte()), int(n.EndByte())
+	if start < 0 || end > len(p.source) || start >= end {
+		return ""
+	}
+	text := strings.TrimSpace(string(p.source[start:end]))
+	if idx := strings.IndexAny(text, "\r\n"); idx >= 0 {
+		text = text[:idx]
+	}
+	if len(text) > 40 {
+		text = text[:40] + "..."
+	}
+	return text
 }
 
 func (p *parseContext) addError(msg string) {

--- a/compilers/go/frontend/parser_syntax_error_test.go
+++ b/compilers/go/frontend/parser_syntax_error_test.go
@@ -1,0 +1,115 @@
+package frontend
+
+import (
+	"strings"
+	"testing"
+)
+
+// Malformed source must be REJECTED, not silently repaired.
+//
+// tree-sitter is an error-tolerant parser: given `this.value = ;` it still
+// returns a tree, marking the bad region with an ERROR node. The Rúnar parser
+// walked that tree and, when a statement's operands did not resolve, returned
+// nil from the statement parser — and a nil statement is simply not appended.
+// The malformed line VANISHED and compilation continued.
+//
+// Measured on the repro below (audits, Codex second pass): the Go tier emitted
+// a complete locking script for a stateful contract whose state update had
+// been dropped, while ts / rust / zig / python / ruby / java all rejected it.
+// That breaks the frontend-parity invariant in CLAUDE.md, which admits no
+// exceptions, and it is a silent miscompile: the dropped statement could as
+// easily be an `assert` guarding the spend.
+//
+// The fix is not to special-case assignment. Any ERROR or MISSING node in the
+// tree means the source is not valid Rúnar, so the parser refuses the whole
+// file — one check that covers every malformed shape, not just this one.
+
+const emptyAssignmentSrc = `import { StatefulSmartContract, assert } from 'runar-lang';
+
+class EmptyAssignment extends StatefulSmartContract {
+  value: bigint;
+
+  constructor(value: bigint) {
+    super(value);
+    this.value = value;
+  }
+
+  public set(next: bigint) {
+    this.value = ;
+    this.value = next;
+    assert(true);
+  }
+}
+`
+
+// The statement that vanished was the state update; here the dropped line is
+// the only thing standing between a spender and the contract's funds.
+const droppedGuardSrc = `import { SmartContract, assert } from 'runar-lang';
+
+class DroppedGuard extends SmartContract {
+  readonly owner: bigint;
+
+  constructor(owner: bigint) {
+    super(owner);
+    this.owner = owner;
+  }
+
+  public spend(claim: bigint) {
+    assert(claim ==);
+    assert(true);
+  }
+}
+`
+
+func parseErrorsFor(t *testing.T, src, name string) []Diagnostic {
+	t.Helper()
+	res := ParseSource([]byte(src), name)
+	if res == nil {
+		t.Fatalf("ParseSource returned nil for %s", name)
+	}
+	return res.Errors
+}
+
+func TestParser_RejectsEmptyAssignment(t *testing.T) {
+	errs := parseErrorsFor(t, emptyAssignmentSrc, "EmptyAssignment.runar.ts")
+	if len(errs) == 0 {
+		t.Fatal("malformed `this.value = ;` was accepted; the statement is silently " +
+			"dropped and the tier emits a locking script for a program every other tier rejects")
+	}
+	if !strings.Contains(strings.ToLower(errs[0].Message), "syntax") {
+		t.Fatalf("expected a syntax diagnostic, got %q", errs[0].Message)
+	}
+}
+
+func TestParser_RejectsMalformedAssert(t *testing.T) {
+	errs := parseErrorsFor(t, droppedGuardSrc, "DroppedGuard.runar.ts")
+	if len(errs) == 0 {
+		t.Fatal("malformed `assert(claim ==)` was accepted; a dropped assert removes " +
+			"a spending guard from the emitted script")
+	}
+}
+
+// A diagnostic that fires on valid sources is worse than none: it would be
+// switched off. Every checked-in example must still parse clean.
+func TestParser_AcceptsWellFormedSource(t *testing.T) {
+	const ok = `import { SmartContract, assert } from 'runar-lang';
+
+class Fine extends SmartContract {
+  readonly a: bigint;
+
+  constructor(a: bigint) {
+    super(a);
+    this.a = a;
+  }
+
+  public go(x: bigint) {
+    assert(this.a > 0n);
+    assert(x > 0n);
+  }
+}
+`
+	errs := parseErrorsFor(t, ok, "Fine.runar.ts")
+	if len(errs) != 0 {
+		t.Fatalf("well-formed source rejected: %v", errs)
+	}
+}

--- a/conformance/negatives/N01-math-floor.runar.ts
+++ b/conformance/negatives/N01-math-floor.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N01 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { super(a); this.a = a; }
+  public go(x: bigint) { assert(Math.floor(x) > 0n); }
+}

--- a/conformance/negatives/N02-type-mismatch.runar.ts
+++ b/conformance/negatives/N02-type-mismatch.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N02 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { super(a); this.a = a; }
+  public go(x: bigint) { let b: bigint = true; assert(b === b); }
+}

--- a/conformance/negatives/N03-readonly-mutation.runar.ts
+++ b/conformance/negatives/N03-readonly-mutation.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N03 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { super(a); this.a = a; }
+  public go(x: bigint) { this.a = x; assert(this.a > 0n); }
+}

--- a/conformance/negatives/N04-no-super.runar.ts
+++ b/conformance/negatives/N04-no-super.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N04 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { this.a = a; }
+  public go(x: bigint) { assert(x > 0n); }
+}

--- a/conformance/negatives/N05-unknown-fn.runar.ts
+++ b/conformance/negatives/N05-unknown-fn.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N05 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { super(a); this.a = a; }
+  public go(x: bigint) { assert(totallyNotARunarBuiltin(x) > 0n); }
+}

--- a/conformance/negatives/N06-console-log.runar.ts
+++ b/conformance/negatives/N06-console-log.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N06 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { super(a); this.a = a; }
+  public go(x: bigint) { console.log(x); assert(x > 0n); }
+}

--- a/conformance/negatives/N07-undeclared-var.runar.ts
+++ b/conformance/negatives/N07-undeclared-var.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N07 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { super(a); this.a = a; }
+  public go(x: bigint) { assert(neverDeclared > 0n); }
+}

--- a/conformance/negatives/N08-bool-arith.runar.ts
+++ b/conformance/negatives/N08-bool-arith.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N08 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { super(a); this.a = a; }
+  public go(x: bigint, f: boolean) { assert(f + x > 0n); }
+}

--- a/conformance/negatives/N09-unbounded-loop.runar.ts
+++ b/conformance/negatives/N09-unbounded-loop.runar.ts
@@ -1,0 +1,6 @@
+import { SmartContract, assert } from 'runar-lang';
+export class N09 extends SmartContract {
+  readonly a: bigint;
+  constructor(a: bigint) { super(a); this.a = a; }
+  public go(x: bigint) { let s: bigint = 0n; for (let i: bigint = 0n; i < x; i++) { s = s + i; } assert(s > 0n); }
+}

--- a/conformance/negatives/N10-nonliteral-init.runar.ts
+++ b/conformance/negatives/N10-nonliteral-init.runar.ts
@@ -1,0 +1,6 @@
+import { StatefulSmartContract, assert } from 'runar-lang';
+export class N10 extends StatefulSmartContract {
+  p: bigint = 1n + 2n;
+  constructor(seed: bigint) { super(seed); this.p = seed; }
+  public go(x: bigint) { this.p = x; assert(x > 0n); }
+}

--- a/conformance/negatives/N11-empty-assignment.runar.ts
+++ b/conformance/negatives/N11-empty-assignment.runar.ts
@@ -1,0 +1,16 @@
+import { StatefulSmartContract, assert } from 'runar-lang';
+
+class EmptyAssignment extends StatefulSmartContract {
+  value: bigint;
+
+  constructor(value: bigint) {
+    super(value);
+    this.value = value;
+  }
+
+  public set(next: bigint) {
+    this.value = ;
+    this.value = next;
+    assert(true);
+  }
+}

--- a/conformance/negatives/N12-malformed-assert.runar.ts
+++ b/conformance/negatives/N12-malformed-assert.runar.ts
@@ -1,0 +1,7 @@
+import { SmartContract, assert } from 'runar-lang';
+
+class N12 extends SmartContract {
+  readonly owner: bigint;
+  constructor(owner: bigint) { super(owner); this.owner = owner; }
+  public spend(claim: bigint) { assert(claim ==); assert(true); }
+}

--- a/conformance/negatives/rejection-parity.test.ts
+++ b/conformance/negatives/rejection-parity.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { readdirSync, existsSync } from 'node:fs';
+import { readdirSync } from 'node:fs';
 import { resolve, join } from 'node:path';
+import {
+  findGoBinary,
+  findJavaJarPath,
+  findRubyBinary,
+  findRustBinary,
+  findZigBinary,
+} from '../runner/runner.js';
 
 /**
  * Cross-tier REJECTION parity.
@@ -26,41 +33,46 @@ import { resolve, join } from 'node:path';
 const REPO = resolve(__dirname, '../..');
 const DIR = __dirname;
 
+/**
+ * Tier binaries are resolved through the RUNNER's own finders, never by
+ * hardcoded paths. CI does not lay the tree out the way a local build does: the
+ * conformance job downloads compiler artifacts to the REPO ROOT (`runar-go`,
+ * `runar-compiler-rust`, `runar-zig`) and the Java compiler as a jar under
+ * `compilers/java/build/libs/`, while a local build leaves them under
+ * `compilers/<tier>/`. Hardcoding the local layout found exactly one tier in
+ * CI, which the vacuity self-check below caught.
+ */
 interface Tier {
   id: string;
-  bin: string;
-  args: (src: string) => string[];
+  bin: string | null;
+  argv: (bin: string, src: string) => string[];
   cwd?: string;
 }
 
+const javaJar = findJavaJarPath();
+
 const TIERS: Tier[] = [
-  { id: 'go', bin: join(REPO, 'compilers/go/runar-go'), args: (s) => ['--source', s, '--hex'] },
-  {
-    id: 'rust',
-    bin: join(REPO, 'compilers/rust/target/release/runar-compiler-rust'),
-    args: (s) => ['--source', s, '--hex'],
-  },
-  {
-    id: 'zig',
-    bin: join(REPO, 'compilers/zig/zig-out/bin/runar-zig'),
-    args: (s) => ['compile', s, '--hex'],
-  },
+  { id: 'go', bin: findGoBinary(), argv: (b, s) => [b, '--source', s, '--hex'] },
+  { id: 'rust', bin: findRustBinary(), argv: (b, s) => [b, '--source', s, '--hex'] },
+  { id: 'zig', bin: findZigBinary(), argv: (b, s) => [b, 'compile', s, '--hex'] },
   {
     id: 'ruby',
-    bin: join(REPO, 'compilers/ruby/bin/runar-compiler-ruby'),
-    args: (s) => ['--source', s, '--hex'],
+    bin: findRubyBinary(),
+    argv: (b, s) => [b, '--source', s, '--hex'],
     cwd: join(REPO, 'compilers/ruby'),
   },
+  // Java ships as a jar, so the binary is `java` and the jar is an argument.
   {
     id: 'java',
-    bin: join(REPO, 'compilers/java/build/install/runar-java/bin/runar-java'),
-    args: (s) => ['--source', s, '--hex'],
+    bin: javaJar ? 'java' : null,
+    argv: (_b, s) => ['-jar', javaJar!, '--source', s, '--hex'],
   },
 ];
 
 function accepts(tier: Tier, src: string): boolean {
+  const [cmd, ...args] = tier.argv(tier.bin!, src);
   try {
-    execFileSync(tier.bin, tier.args(src), {
+    execFileSync(cmd!, args, {
       cwd: tier.cwd ?? REPO,
       stdio: 'pipe',
       timeout: 120_000,
@@ -80,7 +92,7 @@ describe('cross-tier rejection parity', () => {
     expect(fixtures.length).toBeGreaterThanOrEqual(12);
   });
 
-  const available = TIERS.filter((t) => existsSync(t.bin));
+  const available = TIERS.filter((t) => t.bin !== null);
 
   it('at least two tiers are built, or the comparison is vacuous', () => {
     expect(available.length).toBeGreaterThanOrEqual(2);

--- a/conformance/negatives/rejection-parity.test.ts
+++ b/conformance/negatives/rejection-parity.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readdirSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+/**
+ * Cross-tier REJECTION parity.
+ *
+ * CLAUDE.md's first invariant is frontend parity with no exceptions, but every
+ * gate we had measured it on programs that COMPILE: the conformance corpus,
+ * the parser-only matrix, the fuzzers. Nothing checked that the seven tiers
+ * agree on what to REFUSE.
+ *
+ * That gap let a real defect reach RC. The Go tier's tree-sitter walk silently
+ * dropped any statement it could not parse, so `this.value = ;` compiled to a
+ * locking script with the state write missing, and `assert(claim ==)` to one
+ * with the spending guard missing — while the other six tiers rejected both.
+ * A corpus of programs that must NOT compile is the only thing that catches
+ * that class, so it lives here as a gate rather than in an audit directory.
+ *
+ * Each fixture is malformed or violates the language subset. Every available
+ * tier must refuse all of them. A tier that accepts one is either missing a
+ * rule its peers enforce or, worse, silently discarding the offending code.
+ */
+
+const REPO = resolve(__dirname, '../..');
+const DIR = __dirname;
+
+interface Tier {
+  id: string;
+  bin: string;
+  args: (src: string) => string[];
+  cwd?: string;
+}
+
+const TIERS: Tier[] = [
+  { id: 'go', bin: join(REPO, 'compilers/go/runar-go'), args: (s) => ['--source', s, '--hex'] },
+  {
+    id: 'rust',
+    bin: join(REPO, 'compilers/rust/target/release/runar-compiler-rust'),
+    args: (s) => ['--source', s, '--hex'],
+  },
+  {
+    id: 'zig',
+    bin: join(REPO, 'compilers/zig/zig-out/bin/runar-zig'),
+    args: (s) => ['compile', s, '--hex'],
+  },
+  {
+    id: 'ruby',
+    bin: join(REPO, 'compilers/ruby/bin/runar-compiler-ruby'),
+    args: (s) => ['--source', s, '--hex'],
+    cwd: join(REPO, 'compilers/ruby'),
+  },
+  {
+    id: 'java',
+    bin: join(REPO, 'compilers/java/build/install/runar-java/bin/runar-java'),
+    args: (s) => ['--source', s, '--hex'],
+  },
+];
+
+function accepts(tier: Tier, src: string): boolean {
+  try {
+    execFileSync(tier.bin, tier.args(src), {
+      cwd: tier.cwd ?? REPO,
+      stdio: 'pipe',
+      timeout: 120_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const fixtures = readdirSync(DIR)
+  .filter((f) => f.endsWith('.runar.ts'))
+  .sort();
+
+describe('cross-tier rejection parity', () => {
+  it('the corpus is non-empty (a silently empty gate proves nothing)', () => {
+    expect(fixtures.length).toBeGreaterThanOrEqual(12);
+  });
+
+  const available = TIERS.filter((t) => existsSync(t.bin));
+
+  it('at least two tiers are built, or the comparison is vacuous', () => {
+    expect(available.length).toBeGreaterThanOrEqual(2);
+  });
+
+  for (const fixture of fixtures) {
+    const src = join(DIR, fixture);
+    for (const tier of available) {
+      it(`${tier.id} rejects ${fixture}`, () => {
+        expect(
+          accepts(tier, src),
+          `${tier.id} ACCEPTED ${fixture}. Either the tier is missing a rule its ` +
+            `peers enforce, or it is silently dropping the offending construct — ` +
+            `the latter emits a locking script for a program no other tier accepts.`,
+        ).toBe(false);
+      });
+    }
+  }
+});

--- a/conformance/tsconfig.json
+++ b/conformance/tsconfig.json
@@ -37,9 +37,23 @@
   // would mean PROMOTING A REGRESSION BREAKS THE BUILD, for the same reason the
   // exclusion above exists — and editing the contract to placate tsc would
   // destroy the very shape being pinned.
+  // `negatives/*.runar.ts` is the cross-tier rejection corpus: every fixture
+  // there is DELIBERATELY malformed or violates the language subset, because
+  // its whole purpose is that all seven tiers must REFUSE it. Two of them are
+  // syntactically invalid TypeScript by construction (`this.value = ;` and
+  // `assert(claim ==)` — the shapes the Go tier used to silently DROP), so
+  // typechecking them fails with TS1109 "Expression expected". That is the
+  // fixture working as intended, not a defect. Same category as the two
+  // exclusions above: the corpus is read as TEXT and fed to each compiler CLI,
+  // never imported as a module, and "fixing" the syntax would delete the
+  // shape being pinned.
+  //
+  // `negatives/rejection-parity.test.ts` is NOT excluded — the harness is real
+  // TypeScript and stays typechecked.
   "exclude": [
     "node_modules",
     "fuzz-findings*",
-    "fuzz-regressions/entries/*/contract.runar.ts"
+    "fuzz-regressions/entries/*/contract.runar.ts",
+    "negatives/*.runar.ts"
   ]
 }


### PR DESCRIPTION
## The defect

The Go tier's tree-sitter walk silently discarded any statement it could not parse. tree-sitter is error-tolerant — given `this.value = ;` it returns a tree with an ERROR node rather than failing — and every statement parser that could not resolve its operands returned `nil`, which is simply never appended. The malformed line vanished and compilation continued.

Measured with all seven tiers freshly rebuilt:

```
go     ACCEPT   <- emits a full locking script
ts     reject   ("Undefined variable ''")
rust   reject
zig    reject
python reject
ruby   reject
java   reject
```

On the stateful repro the emitted IR contains no `update_prop` at all — the state write is gone. The same mechanism drops a malformed `assert`, removing a spending guard.

This breaks the frontend-parity invariant in CLAUDE.md, which admits no exceptions.

## The fix

`ParseSource` refuses any file whose tree contains an ERROR or MISSING node, naming the offending line. One root check rather than a nil-guard at each of the 28 sites — the defect is not specific to assignment, and per-site guards would leave whichever shape nobody enumerated.

## Why it survived to RC

Every existing gate measured parity on programs that **compile**: the 71-fixture corpus, the 639-case parser-only matrix, the fuzzers. Nothing checked that the tiers agree on what to **refuse**. This PR adds that gate (`conformance/negatives/`, 12 fixtures × every built tier) and wires it into CI.

Confirmed non-vacuous: rebuilding the Go binary from the pre-fix parser makes the gate fail with `go ACCEPTED N11-empty-assignment.runar.ts`; restoring the fix returns 62/62.

## Verification

- `compilers/go` `go test ./...` — green, all 5 packages
- conformance — **71/71**, zero FAIL
- parser-only matrix — **639/639** on all 7 tiers
- all 79 checked-in `examples/**/*.runar.ts` still parse (the accept side an over-eager gate would break)

## Provenance

Found in the Codex second pass's *untracked* repro directory. It was never filed as a finding or an issue — surfaced while salvaging the audit working trees before deleting them.

Note on N12: the parse-level drop is real and pinned by the Go unit test, but at the CLI level a later pass already rejected that shape, so N12 alone would not have caught the defect. N11 is the one that reaches codegen.