### PR TITLE
fix(py-sdk): give every input a locking_script for bsv-sdk 2.4.0

### DIFF
--- a/conformance/sdk-bip143/fixtures.json
+++ b/conformance/sdk-bip143/fixtures.json
@@ -30,6 +30,19 @@
       "digestHex": "efe39a2e99d3eba8c03298cb8f4a056289236dc17ccbefee0d31e11cc8841bf0",
       "sigHex": "3044022071d117a425787845d18393dfa5467bfd7aa4407bbca4b03785914e73007c279c022069b45940ecbc59f803f2649e2d99dbcad9d7674fb78f60fed6f19ee4eb93399341",
       "pubkeyHex": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    },
+    {
+      "scenario": "multi_input_spend",
+      "description": "Multi-input spend: 2 inputs with distinct sequences, signing input INDEX 1 (not 0), SIGHASH_ALL|FORKID. Pins hashPrevouts/hashSequence over more than one input and a non-zero signing index.",
+      "unsignedTxHex": "0100000002cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc0000000000fdffffffdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd0200000000ffffffff01b80b0000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000",
+      "inputIndex": 1,
+      "prevScriptHex": "76a914751e76e8199196d454941c45d1b3a323f1433bd688ac",
+      "prevValueSats": 7000,
+      "sighashFlags": 65,
+      "preimageHex": "01000000e6414cd0c5253a5c7dfaf98b5ff27fb26978d1fe7ad91bd0c6a17c7881f03eebe8421900817cfe6d5377a71cb681de004f52792ef448ff3c41d15a233e230b0adddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd020000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac581b000000000000ffffffff277c99349f87eff64ad8e7dce41085421f19fac2c57c8d5947aa794ade1e21c50000000041000000",
+      "digestHex": "704e41a2d7faf8160cb908e3408bcb97e2ced03a3de6b5ae2b18b8c61e45d63d",
+      "sigHex": "30440220514aa8427269e8d94dc6063484cb2544dad2cab73a99eafe4c326d386f7bd9d702202a078bb8e0ddae8762725d0c05c5d2fd353d7494da9de8419cd1d7d8f555595941",
+      "pubkeyHex": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
     }
   ]
 }

--- a/conformance/sdk-bip143/generate-fixtures.ts
+++ b/conformance/sdk-bip143/generate-fixtures.ts
@@ -336,6 +336,47 @@ async function buildScenarios(): Promise<Scenario[]> {
     ),
   );
 
+  // ---- Scenario 3: multi-input spend — signing input 1 of 2 ----
+  // Both prior scenarios sign input 0 of a SINGLE-input transaction, so
+  // nothing pinned the two things a second input changes:
+  //   * hashPrevouts / hashSequence become digests over MORE than one
+  //     outpoint / sequence, and
+  //   * the signing index is non-zero, so a tier that assumed index 0 (or
+  //     that indexed the wrong input's value / scriptCode) still passed.
+  // That gap is not hypothetical: bsv-sdk 2.4.0 began requiring a
+  // locking_script on EVERY input, and packages/runar-py only populated the
+  // one it was signing — a break that only a multi-input spend can surface.
+  // The funding input deliberately carries a DIFFERENT sequence so a tier that
+  // hashed one sequence twice diverges here.
+  const s3Inputs: TxIn[] = [
+    {
+      prevTxid: 'c'.repeat(64), // funding input, NOT the one being signed
+      prevVout: 0,
+      sequence: 0xfffffffd,
+    },
+    {
+      prevTxid: 'd'.repeat(64), // contract input — the signing input
+      prevVout: 2,
+      sequence: 0xffffffff,
+    },
+  ];
+  const s3Outputs: TxOut[] = [
+    { satoshis: 3000, scriptHex: p2pkhScript(pkh) },
+  ];
+  scenarios.push(
+    buildScenario(
+      'multi_input_spend',
+      'Multi-input spend: 2 inputs with distinct sequences, signing input INDEX 1 ' +
+        '(not 0), SIGHASH_ALL|FORKID. Pins hashPrevouts/hashSequence over more ' +
+        'than one input and a non-zero signing index.',
+      s3Inputs,
+      s3Outputs,
+      1,
+      p2pkhPrevScript,
+      7000,
+    ),
+  );
+
   return scenarios;
 }
 

--- a/packages/runar-py/runar/sdk/local_signer.py
+++ b/packages/runar-py/runar/sdk/local_signer.py
@@ -155,6 +155,27 @@ class LocalSigner(Signer):
         tx.inputs[input_index].locking_script = locking_script
         tx.inputs[input_index].satoshis = satoshis
 
+        # bsv-sdk 2.4.0 (2026-08-28) tightened the batch preimage path:
+        # `transaction_preimage._inputs_to_tuples` now dereferences
+        # `inp.locking_script.serialize()` for EVERY input, and its docstring
+        # calls a missing one "a caller error". `tx_hex` is a serialized
+        # transaction, which carries no source-output data, so every input we
+        # did not just populate has `locking_script = None` — on a 2-input call
+        # (contract UTXO + funding UTXO) that raised
+        # `AttributeError: 'NoneType' object has no attribute 'serialize'`.
+        #
+        # An empty placeholder is sound here, not a papering-over: BIP-143
+        # binds only the SIGNING input's scriptCode into its digest. The other
+        # inputs reach that digest exclusively through `hashPrevouts` and
+        # `hashSequence`, which hash outpoints and sequence numbers — never
+        # scripts. So the signature this method extracts for `input_index` is
+        # byte-identical with or without these placeholders; they exist purely
+        # to let the batch path serialize.
+        empty_script = Script()
+        for i, inp in enumerate(tx.inputs):
+            if i != input_index and inp.locking_script is None:
+                inp.locking_script = empty_script
+
         # Clear existing unlocking script so sign() processes this input
         tx.inputs[input_index].unlocking_script = None
 


### PR DESCRIPTION
Fixes the `Python SDK` job, currently the only red check on `main`.

## Not a code regression — a same-day dependency release

`bsv-sdk 2.4.0` was published **2026-08-28**, and `packages/runar-py/pyproject.toml` declares `bsv-sdk>=1.0` with no ceiling:

| Run | Resolved | Result |
|---|---|---|
| #147 PR run | ≤ 2.3.3 | SUCCESS |
| #147 merge run on `main` (`a3fc34d2`), minutes later | 2.4.0 | FAILURE |

Same commit content, different dependency. Nothing in that merge touched the Python SDK.

```
bsv/transaction_preimage.py:77
AttributeError: 'NoneType' object has no attribute 'serialize'
```

Five tests affected: `test_c19_prepared_sighash` (×3), `test_continuation_satoshis`, `test_g1_raw_outputs_spend`.

## The defect is ours, so this fixes rather than pins

2.4.0 tightened the batch preimage path — `_inputs_to_tuples` now dereferences `inp.locking_script.serialize()` for **every** input, and its docstring calls a missing one *"a caller error"*. That's a legitimate tightening.

`_sign_with_bsv` receives a **serialized** transaction, which carries no source-output data, so it populated `locking_script` only on the input it was signing. Probing the failing path shows the shape exactly:

```
inputs=2 signing=1
  [0] locking=None sats=None srctx=None    <-- raised here
  [1] locking=None sats=None srctx=None
```

Every input now gets one, with an empty `Script()` placeholder where unknown.

## Why the placeholder cannot change a signature

BIP-143 binds only the **signing** input's `scriptCode` into its digest. Other inputs reach that digest solely through `hashPrevouts` and `hashSequence`, which hash outpoints and sequence numbers — never scripts.

Verified rather than argued. Signing the exact 2-input shape that broke yields a **byte-identical** signature on both versions:

```
2.3.3  30450221008c7345754faa4fda6ec9589734205dab67a22af441aff0eaf6583501453a5dc0...
2.4.0  30450221008c7345754faa4fda6ec9589734205dab67a22af441aff0eaf6583501453a5dc0...
```

## Verification

- Full `packages/runar-py` suite: **746 passed under 2.4.0** and **746 passed under 2.3.3** — the fix doesn't trade the new break for an old one
- The 5 originally-failing tests pass under both

## Follow-up worth considering (not in this PR)

This is the third unpinned-floor incident recently (`GO-2026-5972`, the Rust `bsv-sdk` floor, now this). `packages/runar-rs/Cargo.toml` already pins `>=0.2.89, <0.3` with a comment explaining why. A ceiling here wouldn't have prevented this bug — the code was genuinely wrong — but it would stop CI flipping red on an unrelated PR with no code change.