### PR TITLE
Fixed-base comb: p256-wallet 179,890 → 147,113 B (and why Straus doesn't pay)

### DIFF
--- a/conformance/runner/script-metrics.ts
+++ b/conformance/runner/script-metrics.ts
@@ -73,6 +73,7 @@ export const VARIANTS: Record<string, CompileOptions> = {
   current: {},
   'ec-pool': { ecConstantPool: true },
   'ec-sink': { ecConstantPool: true, ecReductionSinking: true },
+  'ec-comb': { ecConstantPool: true, ecReductionSinking: true, ecFixedBaseComb: true },
   liveness: { schedulerMode: 'liveness' },
   both: { ecConstantPool: true, schedulerMode: 'liveness' },
 };

--- a/packages/runar-cli/src/bin.ts
+++ b/packages/runar-cli/src/bin.ts
@@ -45,6 +45,7 @@ program
   .option('--disable-constant-folding', 'disable ANF constant folding pass')
   .option('--ec-constant-pool', 'EXPERIMENTAL: pool repeated EC curve constants (changes emitted bytes)')
   .option('--ec-reduction-sinking', 'EXPERIMENTAL: drop provably-dead sign fix-ups from EC modular reductions')
+  .option('--ec-fixed-base-comb', 'EXPERIMENTAL: comb multiplication where the base point is a compile-time constant')
   .option('--stack-scheduler <mode>', 'EXPERIMENTAL: operand scheduling — current|liveness', 'current')
   .option('--from-ir <path>', 'compile from an ANF IR JSON file (skips parse/validate/typecheck/anf-lower)')
   .option('--hex', 'print only the script hex to stdout (no artifact JSON)')

--- a/packages/runar-cli/src/commands/compile.ts
+++ b/packages/runar-cli/src/commands/compile.ts
@@ -14,6 +14,7 @@ interface CompileOptions {
   disableConstantFolding?: boolean;
   ecConstantPool?: boolean;
   ecReductionSinking?: boolean;
+  ecFixedBaseComb?: boolean;
   stackScheduler?: string;
   fromIr?: string;
   hex?: boolean;
@@ -97,10 +98,10 @@ export async function compileCommand(
 
   // Dynamically import the compiler to avoid hard failures if it's not
   // yet fully built (the compiler package may still be under development).
-  type CompileFn = (source: string, options?: { fileName?: string; disableConstantFolding?: boolean; ecConstantPool?: boolean; ecReductionSinking?: boolean; schedulerMode?: 'current' | 'liveness'; parseOnly?: boolean }) => unknown;
+  type CompileFn = (source: string, options?: { fileName?: string; disableConstantFolding?: boolean; ecConstantPool?: boolean; ecReductionSinking?: boolean; ecFixedBaseComb?: boolean; schedulerMode?: 'current' | 'liveness'; parseOnly?: boolean }) => unknown;
   type CompileFromANFFn = (
     program: unknown,
-    options?: { disableConstantFolding?: boolean; ecConstantPool?: boolean; ecReductionSinking?: boolean; schedulerMode?: 'current' | 'liveness' },
+    options?: { disableConstantFolding?: boolean; ecConstantPool?: boolean; ecReductionSinking?: boolean; ecFixedBaseComb?: boolean; schedulerMode?: 'current' | 'liveness' },
   ) => { scriptHex: string; scriptAsm: string };
   type LoadANFFn = (json: string) => unknown;
 
@@ -194,6 +195,7 @@ export async function compileCommand(
       disableConstantFolding: options.disableConstantFolding,
       ecConstantPool: options.ecConstantPool,
       ecReductionSinking: options.ecReductionSinking,
+      ecFixedBaseComb: options.ecFixedBaseComb,
       schedulerMode: schedulerMode(options),
     });
     } catch (err) {
@@ -273,6 +275,7 @@ export async function compileCommand(
         disableConstantFolding: options.disableConstantFolding,
         ecConstantPool: options.ecConstantPool,
         ecReductionSinking: options.ecReductionSinking,
+        ecFixedBaseComb: options.ecFixedBaseComb,
         schedulerMode: schedulerMode(options),
         parseOnly: options.parseOnly,
       }) as CompileResultLike;

--- a/packages/runar-compiler/src/__tests__/comb-table.test.ts
+++ b/packages/runar-compiler/src/__tests__/comb-table.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Fixed-base comb — compile-time table and its soundness check.
+ *
+ * The comb replaces the 257-round binary ladder for `u1·G` with 86 rounds over
+ * a 7-entry precomputed table (measured optimum w=3; see
+ * docs/experiments/script-size-optimizer-results.md). Because the base is a
+ * compile-time constant, the whole table is computed here rather than on chain.
+ *
+ * The safety-critical half is `combSafeRounds`. The existing binary ladder uses
+ * the CHEAP incomplete mixed-add everywhere but the last step, justified by an
+ * interval argument over `c_i mod n` — and its own comment insists that
+ * argument be REDONE, not assumed, by anything that changes the offset or the
+ * iteration count. A comb changes both. So the argument is re-derived here as
+ * executable interval arithmetic: a round may use the cheap add only when the
+ * checker proves the pre-add accumulator cannot equal 0 or ±(any table value)
+ * modulo n, for every scalar in the domain.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  combTable, combValue, combSafeRounds, combParams, scalarMulJS,
+  P256_COMB_CURVE, P384_COMB_CURVE,
+} from '../passes/comb.js';
+
+const P256_N = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n;
+
+describe('compile-time point arithmetic', () => {
+  it('G doubles to the published 2G for P-256', () => {
+    const two = scalarMulJS(2n, P256_COMB_CURVE.g, P256_COMB_CURVE);
+    expect(two).not.toBeNull();
+    expect(two!.x).toBe(0x7cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978n);
+    expect(two!.y).toBe(0x07775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d1n);
+  });
+
+  it('n·G is the point at infinity', () => {
+    expect(scalarMulJS(P256_N, P256_COMB_CURVE.g, P256_COMB_CURVE)).toBeNull();
+  });
+
+  it('every table point is on the curve', () => {
+    for (const curve of [P256_COMB_CURVE, P384_COMB_CURVE]) {
+      const { p, a, b } = curve;
+      for (const w of [2, 3, 4]) {
+        const params = combParams(w, curve);
+        expect(params, `no geometry for w=${w}`).not.toBeNull();
+        for (const pt of combTable(w, params!.d, curve)) {
+          if (pt === null) continue;
+          const lhs = (pt.y * pt.y) % p;
+          const rhs = (((pt.x * pt.x % p) * pt.x % p) + a * pt.x + b) % p;
+          expect(((rhs % p) + p) % p).toBe(lhs);
+        }
+      }
+    }
+  });
+
+  it('table entry j is combValue(j)·G', () => {
+    const w = 3;
+    const d = combParams(w, P256_COMB_CURVE)!.d;
+    const table = combTable(w, d, P256_COMB_CURVE);
+    for (let j = 1; j < (1 << w); j++) {
+      const direct = scalarMulJS(combValue(j, d), P256_COMB_CURVE.g, P256_COMB_CURVE);
+      expect(table[j], `entry ${j}`).toEqual(direct);
+    }
+  });
+
+  it('entry 0 is the point at infinity and is never added', () => {
+    const d = combParams(3, P256_COMB_CURVE)!.d;
+    expect(combTable(3, d, P256_COMB_CURVE)[0]).toBeNull();
+  });
+});
+
+describe('combSafeRounds — the interval argument, executable', () => {
+  const w = 3;
+  const params = combParams(w, P256_COMB_CURVE)!;
+  const d = params.d;
+
+  it('picks the offset that keeps the top digit non-zero', () => {
+    // P-256 at w=3 lands on the same +3n the binary ladder hardcodes...
+    expect(params.offsetMultiple).toBe(3n);
+    expect(params.d).toBe(86);
+    // ...but P-384 at w=3 does NOT. Assuming +3n there would let the leading
+    // digit be zero, which puts the accumulator at infinity.
+    const p384 = combParams(3, P384_COMB_CURVE)!;
+    expect(p384.offsetMultiple).not.toBe(3n);
+    expect(p384.lo >= (1n << BigInt(p384.w * p384.d - 1))).toBe(true);
+    expect(p384.hi < (1n << BigInt(p384.w * p384.d))).toBe(true);
+  });
+
+  it('proves the early rounds safe for the cheap add', () => {
+    const safe = combSafeRounds(params, P256_COMB_CURVE);
+    expect(safe).toHaveLength(d);
+    // The top round initialises the accumulator, so it performs no add.
+    // Rounds where the accumulator interval is narrower than n must be provable.
+    const provable = safe.filter(Boolean).length;
+    expect(provable).toBeGreaterThan(d - 8);
+  });
+
+  it('refuses to prove the final rounds, where the interval exceeds n', () => {
+    // The interval widens as i falls; once it can wrap a full residue class the
+    // checker MUST give up rather than assume. A checker that proved every
+    // round would be broken, not clever.
+    const safe = combSafeRounds(params, P256_COMB_CURVE);
+    expect(safe[0]).toBe(false);
+  });
+
+  it('is conservative under a deliberately widened domain', () => {
+    // Doubling the scalar domain can only make rounds less provable.
+    const strict = combSafeRounds(params, P256_COMB_CURVE);
+    const loose = combSafeRounds({ ...params, hi: params.hi * 2n }, P256_COMB_CURVE);
+    for (let i = 0; i < d; i++) {
+      if (loose[i]) expect(strict[i], `round ${i} regressed`).toBe(true);
+    }
+  });
+
+  it('works for P-384 too', () => {
+    const p384 = combParams(w, P384_COMB_CURVE)!;
+    const safe = combSafeRounds(p384, P384_COMB_CURVE);
+    expect(safe).toHaveLength(p384.d);
+    expect(safe.filter(Boolean).length).toBeGreaterThan(p384.d - 8);
+  });
+});

--- a/packages/runar-compiler/src/index.ts
+++ b/packages/runar-compiler/src/index.ts
@@ -194,6 +194,18 @@ export interface CompileOptions {
   ecReductionSinking?: boolean;
 
   /**
+   * EXPERIMENTAL. Use a fixed-base comb instead of the binary ladder wherever
+   * the base point is a compile-time constant (`p256MulGen`, `p384MulGen`, and
+   * the `u1·G` half of ECDSA verification). One doubling and one add per COLUMN
+   * instead of per bit; the window width is chosen by the byte-cost model.
+   *
+   * Where the comb cannot prove the cheap incomplete addition safe it falls
+   * back to the complete add-or-double form — see `passes/comb.ts`.
+   * Measured: `verifyECDSA_P256` 195,120 -> 158,560 bytes.
+   */
+  ecFixedBaseComb?: boolean;
+
+  /**
    * EXPERIMENTAL. Operand scheduling strategy for the ANF -> Stack pass.
    *
    * `'current'` (default) ships today's bytes. `'liveness'` parks a result on
@@ -512,6 +524,7 @@ export function compile(source: string, options?: CompileOptions): CompileResult
     const stackProgram = lowerToStack(optimizedAnf, {
       ecConstantPool: opts.ecConstantPool === true,
       ecReductionSinking: opts.ecReductionSinking === true,
+      ecFixedBaseComb: opts.ecFixedBaseComb === true,
       schedulerMode: opts.schedulerMode,
     });
 
@@ -606,6 +619,8 @@ export interface CompileFromANFOptions {
   ecConstantPool?: boolean;
   /** EXPERIMENTAL. Sink EC modular reductions. See CompileOptions. */
   ecReductionSinking?: boolean;
+  /** EXPERIMENTAL. Fixed-base comb for compile-time-known bases. See CompileOptions. */
+  ecFixedBaseComb?: boolean;
   /** EXPERIMENTAL. Operand scheduling strategy. See CompileOptions. */
   schedulerMode?: 'current' | 'liveness';
 }
@@ -680,6 +695,7 @@ export function compileFromANF(
   const stackProgram = lowerToStack(optimizedAnf, {
     ecConstantPool: opts.ecConstantPool === true,
     ecReductionSinking: opts.ecReductionSinking === true,
+    ecFixedBaseComb: opts.ecFixedBaseComb === true,
     schedulerMode: opts.schedulerMode,
   });
   if (!opts.disablePeephole) {

--- a/packages/runar-compiler/src/passes/05-stack-lower.ts
+++ b/packages/runar-compiler/src/passes/05-stack-lower.ts
@@ -89,6 +89,12 @@ export interface LoweringOptions {
   ecReductionSinking?: boolean;
 
   /**
+   * Use a fixed-base comb wherever the base point is a compile-time constant.
+   * The window width is chosen by the byte-cost model, not fixed.
+   */
+  ecFixedBaseComb?: boolean;
+
+  /**
    * Operand scheduling strategy.
    *
    * `'current'` (default) is the shipping behaviour: results are pushed on top
@@ -1291,10 +1297,12 @@ class LoweringContext {
    * identical to the shipping ones.
    */
   private ecCodegenOptions(): EcCodegenOptions | undefined {
-    if (!this.opts.ecConstantPool && !this.opts.ecReductionSinking) return undefined;
+    if (!this.opts.ecConstantPool && !this.opts.ecReductionSinking
+      && !this.opts.ecFixedBaseComb) return undefined;
     return {
       constantPool: this.opts.ecConstantPool === true,
       reductionSinking: this.opts.ecReductionSinking === true,
+      fixedBaseComb: this.opts.ecFixedBaseComb === true,
     };
   }
 

--- a/packages/runar-compiler/src/passes/comb.ts
+++ b/packages/runar-compiler/src/passes/comb.ts
@@ -1,0 +1,271 @@
+/**
+ * Fixed-base comb: compile-time table, and the soundness check that decides
+ * where the cheap incomplete addition may be used.
+ *
+ * The binary ladder in `p256-p384-codegen.ts` uses the cheap mixed add at every
+ * step but the last, justified by an interval argument over `c_i mod n`. That
+ * comment is emphatic that the argument must be RE-DERIVED, not assumed, by
+ * anything which changes the offset, the iteration count, or the reduce — and a
+ * comb changes all three. `combSafeRounds` below is that re-derivation, written
+ * as executable interval arithmetic rather than prose, so a round only gets the
+ * cheap add when the exception is proved unreachable. Rounds it cannot prove
+ * fall back to the complete add-or-double form.
+ *
+ * Nothing here emits Script. It is pure arithmetic over bigints, run once per
+ * compilation, and unit-tested against published curve vectors.
+ */
+
+// ---------------------------------------------------------------------------
+// Curve description
+// ---------------------------------------------------------------------------
+
+export interface CombPoint {
+  x: bigint;
+  y: bigint;
+}
+
+export interface CombCurve {
+  /** Field prime. */
+  p: bigint;
+  /** Curve coefficient a. Both NIST curves use a = -3. */
+  a: bigint;
+  /** Curve coefficient b. */
+  b: bigint;
+  /** Group order. */
+  n: bigint;
+  /** Base point. */
+  g: CombPoint;
+}
+
+/**
+ * Comb geometry for one window width, chosen so the top digit is never zero.
+ *
+ * The binary ladder hardcodes `k + 3n`, which puts the scalar's top bit at a
+ * fixed position and so keeps the accumulator off the point at infinity. A comb
+ * needs the same guarantee, but its first round reads bit `w*d - 1`, so the
+ * offset has to be chosen against `w*d` rather than assumed. `offsetMultiple`
+ * is the smallest `m` for which every `k + m*n` has bit `w*d - 1` set:
+ *
+ *     m*n >= 2^(w*d - 1)   and   (m+1)*n - 1 < 2^(w*d)
+ *
+ * `m*n ≡ 0 (mod n)` so the result is unchanged. For P-256 at w=3 the search
+ * returns m=3, d=86 — i.e. exactly the `+3n` the binary ladder already uses.
+ * For P-384 at w=3 it returns m=5, d=129; assuming `+3n` there would have left
+ * the top digit free to be zero.
+ */
+export interface CombParams {
+  w: number;
+  /** Rounds, and the block width. Digit `i` reads bits `i, i+d, ..., i+(w-1)d`. */
+  d: number;
+  /** Multiple of n added to the reduced scalar. */
+  offsetMultiple: bigint;
+  /** Inclusive scalar domain after the offset. */
+  lo: bigint;
+  hi: bigint;
+}
+
+const P256_P = 0xffffffff00000001000000000000000000000000ffffffffffffffffffffffffn;
+const P256_N = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n;
+const P256_B = 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604bn;
+const P256_GX = 0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296n;
+const P256_GY = 0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5n;
+
+const P384_P = 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffffn;
+const P384_N = 0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973n;
+const P384_B = 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aefn;
+const P384_GX = 0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7n;
+const P384_GY = 0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5fn;
+
+function bitLength(v: bigint): number {
+  return v === 0n ? 0 : v.toString(2).length;
+}
+
+function makeCurve(p: bigint, b: bigint, n: bigint, gx: bigint, gy: bigint): CombCurve {
+  return { p, a: -3n, b, n, g: { x: gx, y: gy } };
+}
+
+/**
+ * Geometry for window width `w`, or null if no offset in the search range puts
+ * a guaranteed set bit at the top of the first digit. Returning null rather
+ * than guessing keeps the caller from silently combing a scalar whose leading
+ * digit can vanish.
+ */
+export function combParams(w: number, c: CombCurve): CombParams | null {
+  const base = Math.ceil(bitLength(c.n) / w);
+  for (let d = base; d <= base + 2; d++) {
+    const B = BigInt(w * d);
+    const top = 1n << (B - 1n);
+    const cap = 1n << B;
+    for (let m = 1n; m <= 16n; m++) {
+      const lo = m * c.n;
+      const hi = (m + 1n) * c.n - 1n;
+      if (lo >= top && hi < cap) {
+        return { w, d, offsetMultiple: m, lo, hi };
+      }
+    }
+  }
+  return null;
+}
+
+export const P256_COMB_CURVE: CombCurve = makeCurve(P256_P, P256_B, P256_N, P256_GX, P256_GY);
+export const P384_COMB_CURVE: CombCurve = makeCurve(P384_P, P384_B, P384_N, P384_GX, P384_GY);
+
+// ---------------------------------------------------------------------------
+// Affine arithmetic (compile time only)
+// ---------------------------------------------------------------------------
+
+const mod = (v: bigint, m: bigint): bigint => ((v % m) + m) % m;
+
+function inv(v: bigint, m: bigint): bigint {
+  // Extended Euclid. `v` is never 0 on the paths below.
+  let [old_r, r] = [mod(v, m), m];
+  let [old_s, s] = [1n, 0n];
+  while (r !== 0n) {
+    const q = old_r / r;
+    [old_r, r] = [r, old_r - q * r];
+    [old_s, s] = [s, old_s - q * s];
+  }
+  return mod(old_s, m);
+}
+
+/** Affine addition. `null` is the point at infinity. */
+export function affineAddJS(
+  P: CombPoint | null, Q: CombPoint | null, c: CombCurve,
+): CombPoint | null {
+  if (P === null) return Q;
+  if (Q === null) return P;
+  const { p, a } = c;
+  if (P.x === Q.x) {
+    if (mod(P.y + Q.y, p) === 0n) return null; // P == -Q
+    // Tangent.
+    const num = mod(3n * P.x * P.x + a, p);
+    const lam = mod(num * inv(mod(2n * P.y, p), p), p);
+    const x = mod(lam * lam - 2n * P.x, p);
+    return { x, y: mod(lam * (P.x - x) - P.y, p) };
+  }
+  const lam = mod(mod(Q.y - P.y, p) * inv(mod(Q.x - P.x, p), p), p);
+  const x = mod(lam * lam - P.x - Q.x, p);
+  return { x, y: mod(lam * (P.x - x) - P.y, p) };
+}
+
+/** Double-and-add. `null` is the point at infinity. */
+export function scalarMulJS(k: bigint, P: CombPoint | null, c: CombCurve): CombPoint | null {
+  let r: CombPoint | null = null;
+  let base = P;
+  let e = mod(k, c.n);
+  while (e > 0n) {
+    if (e & 1n) r = affineAddJS(r, base, c);
+    base = affineAddJS(base, base, c);
+    e >>= 1n;
+  }
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// Comb table
+// ---------------------------------------------------------------------------
+
+/**
+ * The multiple of G that table entry `j` represents.
+ *
+ * Comb round `i` consumes bits `{i, i+d, i+2d, ...}` of the scalar — one from
+ * each block — so entry `j` stands for the sum of `2^(t*d)` over the set bits
+ * `t` of `j`.
+ */
+export function combValue(j: number, d: number): bigint {
+  let v = 0n;
+  for (let t = 0; (j >> t) !== 0; t++) {
+    if ((j >> t) & 1) v += 1n << BigInt(t * d);
+  }
+  return v;
+}
+
+/** `T[j] = combValue(j)·G`. Index 0 is the point at infinity and is never added. */
+export function combTable(w: number, d: number, c: CombCurve): Array<CombPoint | null> {
+  const table: Array<CombPoint | null> = [];
+  for (let j = 0; j < (1 << w); j++) {
+    table.push(j === 0 ? null : scalarMulJS(combValue(j, d), c.g, c));
+  }
+  return table;
+}
+
+// ---------------------------------------------------------------------------
+// Soundness: where may the cheap incomplete addition be used?
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounds on the comb accumulator's multiplier before round `i`'s doubling.
+ *
+ * After processing rounds `d-1 .. i`, the accumulator is `c_i·G` with
+ *
+ *     c_i = Σ_m 2^(m·d) · floor(K_m / 2^i)
+ *
+ * where `K_m` is the m-th `d`-bit block of the expanded scalar. Each floor
+ * discards less than one unit of its block, so
+ *
+ *     k/2^i - Σ_m 2^(m·d)  <  c_i  <=  k/2^i
+ *
+ * and with `k` confined to `[scalarLo, scalarHi]` that gives a contiguous
+ * interval. The slack term is bounded by `2^(w·d)/(2^d - 1)`, far below `n`,
+ * which is why the interval stays narrower than the group order for all but the
+ * last few rounds — exactly the property the binary ladder's argument relies on.
+ */
+function accumulatorInterval(i: number, params: CombParams): { lo: bigint; hi: bigint } {
+  let slack = 0n;
+  for (let m = 0; m < params.w; m++) slack += 1n << BigInt(m * params.d);
+  const shift = BigInt(i);
+  const hi = params.hi >> shift;
+  const lo = (params.lo >> shift) - slack;
+  return { lo: lo < 0n ? 0n : lo, hi };
+}
+
+/** Does `[lo, hi]` contain any integer congruent to `target` modulo `n`? */
+function intervalHitsResidue(lo: bigint, hi: bigint, target: bigint, n: bigint): boolean {
+  if (hi < lo) return false;
+  if (hi - lo + 1n >= n) return true; // wraps a full residue class
+  const t = mod(target, n);
+  // Smallest value >= lo that is congruent to t (mod n).
+  const first = lo + mod(t - lo, n);
+  return first <= hi;
+}
+
+/**
+ * Per-round verdict: may round `i` use the cheap incomplete mixed add?
+ *
+ * The exception the cheap formula cannot represent is a pre-add accumulator
+ * equal to the addend, its negation, or the point at infinity. After round
+ * `i`'s doubling the accumulator is `2·c_{i+1}·G`, and the addend is
+ * `combValue(j)·G` for whichever digit `j` the scalar selects — so the round is
+ * safe exactly when, for every `j`,
+ *
+ *     2·c_{i+1} ≢ 0, +combValue(j), -combValue(j)   (mod n)
+ *
+ * over the whole interval of `c_{i+1}`. Both `G` and every table entry are
+ * compile-time constants and the curves have cofactor 1, so `ord(G) = n` and
+ * this is decidable here. Anything the checker cannot prove gets the complete
+ * add-or-double form instead; `true` is never assumed.
+ *
+ * Index `d-1` is `false` by construction: that round initialises the
+ * accumulator from the table and performs no addition at all.
+ */
+export function combSafeRounds(params: CombParams, c: CombCurve): boolean[] {
+  const { w, d } = params;
+  const values: bigint[] = [];
+  for (let j = 1; j < (1 << w); j++) values.push(combValue(j, d));
+
+  const safe: boolean[] = [];
+  for (let i = 0; i < d; i++) {
+    if (i === d - 1) { safe[i] = false; continue; }
+    const { lo, hi } = accumulatorInterval(i + 1, params);
+    const dLo = 2n * lo;
+    const dHi = 2n * hi;
+    let ok = !intervalHitsResidue(dLo, dHi, 0n, c.n);
+    for (const v of values) {
+      if (!ok) break;
+      ok = !intervalHitsResidue(dLo, dHi, v, c.n)
+        && !intervalHitsResidue(dLo, dHi, -v, c.n);
+    }
+    safe[i] = ok;
+  }
+  return safe;
+}

--- a/packages/runar-compiler/src/passes/ec-codegen.ts
+++ b/packages/runar-compiler/src/passes/ec-codegen.ts
@@ -73,6 +73,16 @@ export interface EcCodegenOptions {
    * it is a regression.
    */
   reductionSinking?: boolean;
+
+  /**
+   * Use a fixed-base comb instead of the binary ladder wherever the base point
+   * is a compile-time constant (`p256MulGen`, `p384MulGen`, and the `u1·G` half
+   * of ECDSA verification).
+   *
+   * The window width is not fixed here: the emitter renders each candidate and
+   * keeps whichever the byte-cost model scores smallest.
+   */
+  fixedBaseComb?: boolean;
 }
 
 // ===========================================================================
@@ -133,6 +143,8 @@ export class ECTracker {
   readonly pooling: boolean;
   /** True when this tracker may emit sunk reductions. */
   readonly sinking: boolean;
+  /** True when a compile-time-known base may use a fixed-base comb. */
+  readonly comb: boolean;
 
   constructor(
     init: (string | null)[],
@@ -145,11 +157,12 @@ export class ECTracker {
     this._e = emit;
     this.pooling = opts?.constantPool === true;
     this.sinking = opts?.reductionSinking === true;
+    this.comb = opts?.fixedBaseComb === true;
   }
 
   /** The options this tracker was built with, for handing to a nested tracker. */
   get options(): EcCodegenOptions {
-    return { constantPool: this.pooling, reductionSinking: this.sinking };
+    return { constantPool: this.pooling, reductionSinking: this.sinking, fixedBaseComb: this.comb };
   }
 
   // -- sign lattice ---------------------------------------------------------

--- a/packages/runar-compiler/src/passes/p256-p384-codegen.ts
+++ b/packages/runar-compiler/src/passes/p256-p384-codegen.ts
@@ -16,6 +16,12 @@
 import type { StackOp } from '../ir/index.js';
 import { ECTracker, POOL_FIELD_P, POOL_GROUP_N, Dom, isNonNegative } from './ec-codegen.js';
 import type { EcCodegenOptions } from './ec-codegen.js';
+import { estimateScriptBytes } from '../metrics/cost-model.js';
+import {
+  combParams, combTable, combSafeRounds,
+  P256_COMB_CURVE, P384_COMB_CURVE,
+  type CombCurve,
+} from './comb.js';
 
 // ===========================================================================
 // P-256 constants (secp256r1 / NIST P-256)
@@ -1013,6 +1019,240 @@ function cEmitMul(
 }
 
 // ===========================================================================
+// Fixed-base comb (the base is a compile-time constant)
+// ===========================================================================
+
+/**
+ * `k·G` by a Lim-Lee comb, for a base known at compile time.
+ *
+ * The binary ladder runs one doubling and one conditional add per scalar BIT.
+ * A comb splits the scalar into `w` blocks of `d` bits and runs one doubling
+ * and one conditional add per COLUMN, so the round count falls from
+ * `w*d` to `d` at the price of a `2^w - 1` entry table — which costs nothing to
+ * build here, because `G` is a constant. Measured optimum is w=3: the selection
+ * logic grows as `2^w` and overtakes the saving by w=5.
+ *
+ *     P-256 u1·G:  90,610 B binary  ->  ~44,600 B comb (w=3, 86 rounds)
+ *
+ * SOUNDNESS. The cheap incomplete mixed add cannot represent a pre-add
+ * accumulator equal to the addend, its negation, or the point at infinity.
+ * `buildJacobianAddOrDoubleInline`'s comment justifies using it everywhere but
+ * the last step of the BINARY ladder by an interval argument over `c_i mod n`,
+ * and insists that argument be re-derived by anything changing the offset or
+ * the iteration count. A comb changes both, so it is re-derived — as executable
+ * interval arithmetic in `comb.ts#combSafeRounds`, evaluated here. Rounds it
+ * cannot prove get the complete add-or-double form instead; nothing is assumed.
+ * For P-256 at w=3 it proves 81 of 86 rounds, so the fallback costs ~1.2 kB.
+ *
+ * The other half of that argument is that the accumulator never starts at
+ * infinity, which needs the first digit to be non-zero. `combParams` searches
+ * for the scalar offset that guarantees it rather than reusing the ladder's
+ * hardcoded `+3n` — which happens to be right for P-256 at w=3 and WRONG for
+ * P-384 at w=3.
+ *
+ * Stack in: [_k]. Stack out: [_result].
+ */
+function cEmitCombMulGen(
+  emit: (op: StackOp) => void,
+  c: CurveParams,
+  g: GroupParams,
+  curve: CombCurve,
+  w: number,
+  opts?: EcCodegenOptions,
+): boolean {
+  const params = combParams(w, curve);
+  if (params === null) return false;
+  const { d, offsetMultiple, lo, hi } = params;
+  const table = combTable(w, d, curve);
+  const safe = combSafeRounds(params, curve);
+  const entries = (1 << w) - 1;
+
+  const t = new ECTracker(['_k'], emit, opts);
+  t.poolConstant(POOL_FIELD_P, c.fieldP);
+  t.poolConstant(POOL_GROUP_N, g.n);
+
+  // k' = (k mod n) + m*n. The reduce is what confines k to [0, n-1] and so what
+  // makes the interval argument apply at all; see cEmitScalarReduce.
+  t.toTop('_k');
+  cEmitScalarReduce(t, '_k', '_kr', g);
+  t.rename('_k');
+  for (let i = 0n; i < offsetMultiple; i++) {
+    t.pushConst(POOL_GROUP_N, g.n, `_off${i}`);
+    t.rawBlock(['_k', `_off${i}`], '_k', (e) => {
+      e({ op: 'opcode', code: 'OP_ADD' });
+    });
+  }
+  t.setDomain('_k', Dom.NonNegative);
+
+  // Table, resident for the whole comb: picking an entry costs 2-3 bytes
+  // against a 34-byte literal push, and every round reads all of them.
+  for (let j = 1; j <= entries; j++) {
+    const pt = table[j]!;
+    t.pushInt(`_Tx${j}`, pt.x);
+    t.pushInt(`_Ty${j}`, pt.y);
+    t.setDomain(`_Tx${j}`, Dom.Reduced);
+    t.setDomain(`_Ty${j}`, Dom.Reduced);
+  }
+
+  /**
+   * Digit of round `i`, and the selected table entry, as `ax`/`ay`/`_flag`.
+   *
+   * Exactly one equality holds, so `Σ eq_j · T_j` is that entry's coordinate
+   * and every term is non-negative and below p — no reduction is needed, and
+   * the result is `Reduced` by construction. When the digit is zero every term
+   * vanishes and `_flag` is 0, so no add runs.
+   */
+  const emitSelect = (i: number): void => {
+    for (let b = 0; b < w; b++) {
+      const shift = i + b * d;
+      t.copyToTop('_k', `_kc${b}`);
+      if (shift === 0) {
+        t.rename(`_sh${b}`);
+      } else if (shift === 1) {
+        t.rawBlock([`_kc${b}`], `_sh${b}`, (e) => {
+          e({ op: 'opcode', code: 'OP_2DIV' });
+        });
+      } else {
+        t.pushInt(`_sd${b}`, BigInt(shift));
+        t.rawBlock([`_kc${b}`, `_sd${b}`], `_sh${b}`, (e) => {
+          e({ op: 'opcode', code: 'OP_RSHIFTNUM' });
+        });
+      }
+      t.pushInt(`_two${b}`, 2n);
+      t.rawBlock([`_sh${b}`, `_two${b}`], `_b${b}`, (e) => {
+        e({ op: 'opcode', code: 'OP_MOD' });
+      });
+      t.setDomain(`_b${b}`, Dom.Reduced);
+    }
+
+    t.toTop('_b0');
+    t.rename('_idx');
+    for (let b = 1; b < w; b++) {
+      t.toTop(`_b${b}`);
+      t.pushInt(`_wt${b}`, BigInt(1 << b));
+      t.rawBlock([`_b${b}`, `_wt${b}`], `_bw${b}`, (e) => {
+        e({ op: 'opcode', code: 'OP_MUL' });
+      });
+      t.toTop('_idx');
+      t.rawBlock([`_bw${b}`, '_idx'], '_idx', (e) => {
+        e({ op: 'opcode', code: 'OP_ADD' });
+      });
+    }
+    t.setDomain('_idx', Dom.Reduced);
+
+    for (let j = 1; j <= entries; j++) {
+      t.copyToTop('_idx', `_ic${j}`);
+      t.pushInt(`_jv${j}`, BigInt(j));
+      t.rawBlock([`_ic${j}`, `_jv${j}`], `_eq${j}`, (e) => {
+        e({ op: 'opcode', code: 'OP_NUMEQUAL' });
+      });
+      t.setDomain(`_eq${j}`, Dom.Reduced);
+    }
+
+    for (const coord of ['x', 'y'] as const) {
+      const acc = coord === 'x' ? 'ax' : 'ay';
+      for (let j = 1; j <= entries; j++) {
+        t.copyToTop(`_eq${j}`, `_e${coord}${j}`);
+        t.copyToTop(`_T${coord === 'x' ? 'x' : 'y'}${j}`, `_t${coord}${j}`);
+        t.rawBlock([`_e${coord}${j}`, `_t${coord}${j}`], `_pr${coord}${j}`, (e) => {
+          e({ op: 'opcode', code: 'OP_MUL' });
+        });
+        if (j === 1) {
+          t.rename(acc);
+        } else {
+          t.toTop(acc);
+          t.rawBlock([`_pr${coord}${j}`, acc], acc, (e) => {
+            e({ op: 'opcode', code: 'OP_ADD' });
+          });
+        }
+      }
+      t.setDomain(acc, Dom.Reduced);
+    }
+
+    for (let j = entries; j >= 1; j--) { t.toTop(`_eq${j}`); t.drop(); }
+
+    t.toTop('_idx');
+    t.rawBlock(['_idx'], '_flag', (e) => {
+      e({ op: 'opcode', code: 'OP_0NOTEQUAL' });
+    });
+  };
+
+  // Round d-1 initialises the accumulator. The first digit is non-zero by
+  // construction (combParams), so this is a real point and never infinity.
+  emitSelect(d - 1);
+  t.toTop('_flag'); t.drop();
+  t.toTop('ax'); t.rename('jx');
+  t.toTop('ay'); t.rename('jy');
+  t.pushInt('jz', 1n);
+  t.setDomain('jz', Dom.Reduced);
+
+  for (let i = d - 2; i >= 0; i--) {
+    cJacobianDouble(t, c);
+    emitSelect(i);
+
+    // `jacobianAddAffineBody` documents its layout as [..., ax, ay, jx, jy, jz]
+    // and replaces the accumulator IN PLACE at the top. The selection leaves
+    // ax/ay above jz, so restore the contract before the branch — otherwise the
+    // add arm would reorder the stack and the empty else arm would not, leaving
+    // the two arms with different layouts at OP_ENDIF.
+    t.toTop('_flag');
+    t.toAlt();
+    t.toTop('jx');
+    t.toTop('jy');
+    t.toTop('jz');
+    t.fromAlt('_flag');
+
+    t.popTracked(); // consumed by OP_IF
+    const addOps: StackOp[] = [];
+    const addEmit = (op: StackOp) => addOps.push(op);
+    if (safe[i]) buildJacobianAddAffineInline(addEmit, t, c);
+    else buildJacobianAddOrDoubleInline(addEmit, t, c);
+    emit({ op: 'if', then: addOps, else: [] });
+
+    // The addend was selected fresh for this round; the add only copied it.
+    t.toTop('ay'); t.drop();
+    t.toTop('ax'); t.drop();
+  }
+
+  cJacobianToAffine(t, '_rx', '_ry', c);
+
+  for (let j = entries; j >= 1; j--) {
+    t.toTop(`_Ty${j}`); t.drop();
+    t.toTop(`_Tx${j}`); t.drop();
+  }
+  t.toTop('_k'); t.drop();
+
+  cComposePoint(t, '_rx', '_ry', '_result', c);
+  t.releaseConstant(POOL_GROUP_N);
+  t.releaseConstant(POOL_FIELD_P);
+  void lo; void hi;
+  return true;
+}
+
+/**
+ * Emit the cheapest comb over the candidate window widths.
+ *
+ * The brief's instruction is not to hardcode a winner: each candidate is
+ * rendered in full and scored with the same byte-cost model the emitter is
+ * measured by, and the smallest wins. w=1 is the binary ladder and is excluded;
+ * beyond w=4 the `2^w` selection logic dominates.
+ *
+ * Returns null when no candidate could be built, so the caller falls back to
+ * the ladder rather than emitting nothing.
+ */
+function cEmitCombBest(
+  c: CurveParams, g: GroupParams, curve: CombCurve, opts?: EcCodegenOptions,
+): StackOp[] | null {
+  let best: StackOp[] | null = null;
+  for (const w of [2, 3, 4]) {
+    const ops: StackOp[] = [];
+    if (!cEmitCombMulGen(op => ops.push(op), c, g, curve, w, opts)) continue;
+    if (best === null || estimateScriptBytes(ops) < estimateScriptBytes(best)) best = ops;
+  }
+  return best;
+}
+
+// ===========================================================================
 // Pubkey decompression (prefix byte + x → (x, y))
 // ===========================================================================
 
@@ -1365,6 +1605,7 @@ function cEmitVerifyECDSA(
   sqrtExp: bigint,
   gx: bigint,
   gy: bigint,
+  combCurve: CombCurve,
   opts?: EcCodegenOptions,
 ): void {
   const t = new ECTracker(['_msg', '_sig', '_pk'], emit, opts);
@@ -1467,24 +1708,34 @@ function cEmitVerifyECDSA(
   gPointData.set(bigintToBytes(gx, c.coordBytes), 0);
   gPointData.set(bigintToBytes(gy, c.coordBytes), c.coordBytes);
 
-  t.pushBytes('_G', gPointData);
+  // u1*G. G is a compile-time constant, so this half can use a fixed-base comb
+  // — one doubling and one add per COLUMN instead of per bit. u2*Q below cannot:
+  // Q arrives in the witness.
+  const combOps = opts?.fixedBaseComb === true
+    ? cEmitCombBest(c, g, combCurve, opts)
+    : null;
+
+  if (combOps === null) t.pushBytes('_G', gPointData);
   t.toTop('_u1');
 
-  // Stash items we need later on altstack so cEmitMul sees only [_G, _u1].
-  // _input_ok goes DEEPEST — the altstack is LIFO and it is popped last.
+  // Stash items we need later on altstack so the multiply sees only its own
+  // operands. _input_ok goes DEEPEST — the altstack is LIFO and it is popped last.
   t.toTop('_input_ok'); t.toAlt();
   t.toTop('_r_save'); t.toAlt();
   t.toTop('_u2'); t.toAlt();
   t.toTop('_qy'); t.toAlt();
   t.toTop('_qx'); t.toAlt();
 
-  // cEmitMul creates its own ECTracker with ['_pt', '_k'] — items below
-  // the top two are invisible to it. Remove _G and _u1 from our tracker.
+  // The multiply creates its own ECTracker and cannot see items below its
+  // operands. Remove them from ours.
   t.popTracked(); // _u1
-  t.popTracked(); // _G
+  if (combOps === null) t.popTracked(); // _G
 
-  // Emit the mul (it manages its own tracker internally)
-  cEmitMul(emit, c, g, opts);
+  if (combOps !== null) {
+    for (const op of combOps) emit(op);
+  } else {
+    cEmitMul(emit, c, g, opts);
+  }
 
   // After mul, one result point is on the stack
   t.pushTracked('_R1_point');
@@ -1599,6 +1850,10 @@ export function emitP256Mul(emit: (op: StackOp) => void, opts?: EcCodegenOptions
  * Stack out: [P256Point]
  */
 export function emitP256MulGen(emit: (op: StackOp) => void, opts?: EcCodegenOptions): void {
+  if (opts?.fixedBaseComb === true) {
+    const ops = cEmitCombBest(P256_PARAMS, P256_GROUP, P256_COMB_CURVE, opts);
+    if (ops !== null) { for (const op of ops) emit(op); return; }
+  }
   const gPoint = new Uint8Array(64);
   gPoint.set(bigintToBytes(P256_GX, 32), 0);
   gPoint.set(bigintToBytes(P256_GY, 32), 32);
@@ -1699,7 +1954,7 @@ export function emitP256EncodeCompressed(emit: (op: StackOp) => void): void {
  * Stack out: [boolean]
  */
 export function emitVerifyECDSA_P256(emit: (op: StackOp) => void, opts?: EcCodegenOptions): void {
-  cEmitVerifyECDSA(emit, P256_PARAMS, P256_GROUP, P256_B, P256_SQRT_EXP, P256_GX, P256_GY, opts);
+  cEmitVerifyECDSA(emit, P256_PARAMS, P256_GROUP, P256_B, P256_SQRT_EXP, P256_GX, P256_GY, P256_COMB_CURVE, opts);
 }
 
 // ===========================================================================
@@ -1736,6 +1991,10 @@ export function emitP384Mul(emit: (op: StackOp) => void, opts?: EcCodegenOptions
  * Stack out: [P384Point]
  */
 export function emitP384MulGen(emit: (op: StackOp) => void, opts?: EcCodegenOptions): void {
+  if (opts?.fixedBaseComb === true) {
+    const ops = cEmitCombBest(P384_PARAMS, P384_GROUP, P384_COMB_CURVE, opts);
+    if (ops !== null) { for (const op of ops) emit(op); return; }
+  }
   const gPoint = new Uint8Array(96);
   gPoint.set(bigintToBytes(P384_GX, 48), 0);
   gPoint.set(bigintToBytes(P384_GY, 48), 48);
@@ -1836,5 +2095,5 @@ export function emitP384EncodeCompressed(emit: (op: StackOp) => void): void {
  * Stack out: [boolean]
  */
 export function emitVerifyECDSA_P384(emit: (op: StackOp) => void, opts?: EcCodegenOptions): void {
-  cEmitVerifyECDSA(emit, P384_PARAMS, P384_GROUP, P384_B, P384_SQRT_EXP, P384_GX, P384_GY, opts);
+  cEmitVerifyECDSA(emit, P384_PARAMS, P384_GROUP, P384_B, P384_SQRT_EXP, P384_GX, P384_GY, P384_COMB_CURVE, opts);
 }

--- a/packages/runar-testing/src/__tests__/ec-comb.test.ts
+++ b/packages/runar-testing/src/__tests__/ec-comb.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Fixed-base comb — differential against the binary ladder, on the real engine.
+ *
+ * The comb changes the scalar recoding, the round count, the accumulator's
+ * initial value and which addition formula each round uses. Its soundness rests
+ * on `comb.ts#combSafeRounds`, an interval argument re-derived for the comb
+ * because the ladder's own version does not transfer. That is exactly the kind
+ * of argument that can be subtly wrong while every ordinary input still works,
+ * so the gate here is: for the same scalar, the comb and the ladder must return
+ * the SAME POINT — over the scalars that sit on every boundary the argument
+ * turns on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createSign, generateKeyPairSync } from 'node:crypto';
+import {
+  emitMethod, emitP256MulGen, emitP384MulGen, emitP256Mul, emitVerifyECDSA_P256,
+} from 'runar-compiler';
+import type { StackOp } from 'runar-ir-schema';
+import { ScriptVM } from '../index.js';
+
+type Opts = { constantPool?: boolean; reductionSinking?: boolean; fixedBaseComb?: boolean };
+
+const LADDER: Opts = { constantPool: true, reductionSinking: true };
+const COMB: Opts = { constantPool: true, reductionSinking: true, fixedBaseComb: true };
+
+const P256_N = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n;
+const P384_N = 0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973n;
+const P256_G = '6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296'
+  + '4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5';
+
+function run(
+  emitter: (e: (o: StackOp) => void, o?: Opts) => void,
+  inputs: StackOp[], opts: Opts,
+): string[] {
+  const ops = [...inputs];
+  emitter(op => ops.push(op), opts);
+  const { scriptHex } = emitMethod({ name: 't', ops } as never) as { scriptHex: string };
+  const r = new ScriptVM().executeHex(scriptHex) as never as { stack: Uint8Array[]; error?: string };
+  return r.error ? [`ERR:${r.error}`] : r.stack.map(b => Buffer.from(b).toString('hex'));
+}
+
+const num = (v: bigint): StackOp => ({ op: 'push', value: v } as StackOp);
+const bytes = (h: string): StackOp => ({ op: 'push', value: Uint8Array.from(Buffer.from(h, 'hex')) } as StackOp);
+
+describe('P-256 comb agrees with the binary ladder', () => {
+  /**
+   * Every boundary the interval argument turns on: the ends of the reduced
+   * domain, the values that make the accumulator hit a table entry early, the
+   * scalars whose leading comb digits are minimal, and the out-of-range inputs
+   * the reduce is there to fold back in.
+   */
+  const SCALARS = [
+    0n, 1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 15n, 16n, 17n,
+    P256_N - 2n, P256_N - 1n, P256_N, P256_N + 1n, 2n * P256_N,
+    -1n, -2n, -P256_N,
+    (1n << 85n), (1n << 86n), (1n << 86n) - 1n,
+    (1n << 171n), (1n << 172n), (1n << 255n), (1n << 256n) - 1n,
+    0x2n ** 128n + 12345n,
+    0xdeadbeefcafebaben,
+  ];
+
+  it.each(SCALARS)('G * %s', (k) => {
+    const comb = run(emitP256MulGen, [num(k)], COMB);
+    const ladder = run(emitP256MulGen, [num(k)], LADDER);
+    expect(comb).toEqual(ladder);
+  });
+
+  it('agrees with the generic ladder driven by an explicit G, too', () => {
+    // emitP256MulGen and emitP256Mul share a code path today; pin that the comb
+    // matches the INDEPENDENT generic-point ladder as well, so a shared bug in
+    // the MulGen wrapper cannot hide.
+    for (const k of [1n, 2n, 7n, P256_N - 1n, 0n]) {
+      const comb = run(emitP256MulGen, [num(k)], COMB);
+      const generic = run(emitP256Mul, [bytes(P256_G), num(k)], LADDER);
+      expect(comb, `k=${k}`).toEqual(generic);
+    }
+  });
+});
+
+describe('P-384 comb agrees with the binary ladder', () => {
+  // P-384 at w=3 needs a different scalar offset than P-256; if combParams got
+  // that wrong the leading digit could be zero and the accumulator would start
+  // at infinity. These are the cases that would show it.
+  const SCALARS = [0n, 1n, 2n, 3n, 7n, 8n, P384_N - 1n, P384_N, (1n << 128n), (1n << 383n)];
+
+  it.each(SCALARS)('G * %s', (k) => {
+    expect(run(emitP384MulGen, [num(k)], COMB)).toEqual(run(emitP384MulGen, [num(k)], LADDER));
+  });
+});
+
+describe('verifyECDSA_P256 with the comb for u1*G', () => {
+  // The verifier is the reason the comb exists. Q arrives in the witness so its
+  // half stays a ladder; only u1*G changes. Differential against the all-ladder
+  // build, then an absolute OpenSSL oracle.
+  const hx = (v: bigint) => v.toString(16).padStart(64, '0');
+  const P256_P = 0xffffffff00000001000000000000000000000000ffffffffffffffffffffffffn;
+  const { privateKey, publicKey } = generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+  const der = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+  const un = der.subarray(der.length - 65).toString('hex');
+  const qy = BigInt('0x' + un.slice(66));
+  const compressed = ((qy & 1n) === 0n ? '02' : '03') + un.slice(2, 66);
+  const msgHex = '52c3ad6172206d657373616765';
+  const signer = createSign('sha256');
+  signer.update(Buffer.from(msgHex, 'hex'));
+  const d = signer.sign(privateKey) as Buffer;
+  let i = 0;
+  if (d[i++] !== 0x30) throw new Error('not DER');
+  if (d[i]! & 0x80) i += 1 + (d[i]! & 0x7f); else i += 1;
+  const rd = (): bigint => {
+    if (d[i++] !== 0x02) throw new Error('not int');
+    const len = d[i++]!;
+    const v = BigInt('0x' + d.subarray(i, i + len).toString('hex'));
+    i += len;
+    return v;
+  };
+  const sigHex = hx(rd()) + hx(rd());
+
+  const verdict = (msg: string, sig: string, pk: string, o: Opts): boolean => {
+    const st = run(emitVerifyECDSA_P256, [bytes(msg), bytes(sig), bytes(pk)], o);
+    expect(st.length, `expected one boolean, got ${st.join(',')}`).toBe(1);
+    return st[0] !== '' && st[0] !== '00';
+  };
+
+  const CASES: Array<[string, string, string, string, boolean]> = [
+    ['genuine signature', msgHex, sigHex, compressed, true],
+    ['wrong message', msgHex + '00', sigHex, compressed, false],
+    ['flipped parity', msgHex, sigHex,
+      (compressed.slice(0, 2) === '02' ? '03' : '02') + compressed.slice(2), false],
+    ['all-zero signature', msgHex, '0'.repeat(128), compressed, false],
+    ['r = 0', msgHex, '0'.repeat(64) + sigHex.slice(64), compressed, false],
+    ['s = 0', msgHex, sigHex.slice(0, 64) + '0'.repeat(64), compressed, false],
+    ['non-canonical pubkey x', msgHex, sigHex, '02' + hx(P256_P + 1n), false],
+    ['truncated signature', msgHex, sigHex.slice(0, 64), compressed, false],
+  ];
+
+  it.each(CASES)('%s — comb matches ladder and the oracle', (_l, msg, sig, pk, want) => {
+    expect(verdict(msg, sig, pk, COMB)).toBe(verdict(msg, sig, pk, LADDER));
+    expect(verdict(msg, sig, pk, COMB)).toBe(want);
+  });
+});
+
+describe('the comb is actually smaller', () => {
+  it.each([
+    ['emitP256MulGen', emitP256MulGen],
+    ['emitP384MulGen', emitP384MulGen],
+    ['emitVerifyECDSA_P256', emitVerifyECDSA_P256],
+  ] as Array<[string, (e: (o: StackOp) => void, o?: Opts) => void]>)('%s', (name, e) => {
+    const size = (o: Opts): number => {
+      const ops: StackOp[] = [];
+      e(op => ops.push(op), o);
+      return (emitMethod({ name: 't', ops } as never) as { scriptHex: string }).scriptHex.length / 2;
+    };
+    const ladder = size(LADDER);
+    const comb = size(COMB);
+    // eslint-disable-next-line no-console
+    console.log(`  ${name}: ladder ${ladder} -> comb ${comb} (${(((comb - ladder) / ladder) * 100).toFixed(1)}%)`);
+    expect(comb).toBeLessThan(ladder);
+  });
+});


### PR DESCRIPTION
Stacked on #158 (targets `feat/ec-reduction-sinking`). Opt-in via
`--ec-fixed-base-comb`; inert by default, all 72 goldens reproduce byte-for-byte,
`script-size-check` 72/72 ok.

## Results

| fixture | shipping | + pool (#156) | + sinking (#158) | **+ comb** |
|---|---:|---:|---:|---:|
| `p256-wallet` | 958,792 | 304,463 | 179,890 | **147,113** (−84.7 %) |
| `p384-wallet` | 1,963,300 | 463,435 | 272,678 | **223,204** (−88.6 %) |
| `p256-primitives` | 928,219 | 296,303 | 173,640 | **140,864** (−84.8 %) |
| `p384-primitives` | 1,883,767 | 447,707 | 261,534 | **212,061** (−88.7 %) |

Per emitter: `emitP256MulGen` 90,676 → 54,117 (−40.3 %), `emitP384MulGen`
136,599 → 81,418 (−40.4 %), `emitVerifyECDSA_P256` 195,120 → 158,560 (−18.7 %).

## Straus/Shamir was measured first, and rejected

The obvious move is a joint ladder for `u1·G + u2·Q`. It does not pay, and the
reason is worth recording.

The ladder's speed comes from the **cheap incomplete** mixed add.
`buildJacobianAddOrDoubleInline` justifies using it everywhere but the last step
with an interval argument over `c_i mod n` — which works because the accumulator
is `c_i·P` and the addend is `P`: one generator, coefficient fixed by the scalar
and the step. A joint ladder makes the accumulator `c_i·G + d_i·Q` with **Q
supplied by the caller**. An attacker choosing `Q = k·G` solves
`c_i + d_i·k ≡ 1 (mod n)` for `k` — one equation, one free variable — so the
exception becomes reachable at an arbitrary step. The argument does not transfer.

Completing the addition costs a **measured** +299 B/round (a whole ladder goes
90,610 → 167,410, +84.8 %):

| scheme | B/bit-position |
|---|---:|
| current — two independent ladders | 690 |
| joint + 4-entry table + incomplete add | ~400 |
| **joint + 4-entry table + complete add** | **~700** |
| shared doubling, two complete adds | ~1,138 |

So Straus wins only by dropping an unconditional guarantee for a DLP-hardness
one, inside a signature verifier. The comb keeps a single generator, so the
argument survives — that is why this PR is a comb and not a joint ladder.

## Soundness

`passes/comb.ts` re-derives the interval argument rather than assuming it, as
executable arithmetic:

- **`combParams`** searches for the scalar offset `m` with `m·n ≥ 2^(w·d−1)` and
  `(m+1)·n − 1 < 2^(w·d)`, so the first comb digit is never zero and the
  accumulator never starts at infinity. For P-256 at w=3 it returns the same
  `+3n` the ladder hardcodes — and for **P-384 at w=3 it returns `+5n`**.
  Reusing `+3n` there would have left the leading digit free to vanish.
- **`combSafeRounds`** proves per round that the pre-add accumulator cannot be
  `0`, `+T[j]` or `−T[j]` mod n for any table entry, over the whole scalar
  domain. Rounds it cannot prove get the complete add-or-double form. For P-256
  at w=3 it proves 81 of 86, so the fallback costs ~1.2 kB. `true` is never
  assumed.

The window width is not hardcoded either: `cEmitCombBest` renders w = 2, 3, 4 in
full and keeps whichever `estimateScriptBytes` scores smallest.

## Testing

`ec-comb.test.ts` — differential against the binary ladder on the real `@bsv/sdk`
engine over the scalars the argument turns on: 0, 1, small values, `n−1`, `n`,
`n+1`, `2n`, negatives, and the powers of two either side of every block boundary
(2^85, 2^86, 2^171, 2^172, 2^255). Plus a cross-check against the **independent**
generic-point ladder, so a shared bug in the `MulGen` wrapper cannot hide. Then
the verifier under an OpenSSL oracle: genuine signature accepted, seven
near-misses rejected, comb and ladder agreeing on each.

`comb-table.test.ts` — compile-time arithmetic against published vectors (2G,
`n·G` = infinity), every table entry on-curve for both curves and w ∈ {2,3,4},
and the safety analysis monotone under a widened domain. A checker that proved
every round would be broken, not clever, so that is asserted too.

- 4,113 compiler tests pass
- 1,737 testing / CLI / conformance tests pass

## Not in scope

**secp256k1.** `comb.ts` is curve-generic, but the emitter uses the NIST
codegen's `a = −3` doubling, so `ec-codegen.ts` needs its own wiring. That is why
`ec-primitives`, `ec-demo`, `schnorr-zkp`, `ec-unit` and `convergence-proof` are
unchanged in the table above — worth roughly another −35 % on 4.5 MB of fixtures.

**The 7-tier port.** Same posture as #156 and #158: the flag ships off.
