### PR TITLE
docs(test): #149 pin is fixed and live, not skipped

### DIFF
--- a/packages/runar-testing/src/__tests__/nested-declared-results-arm-layout-vm.test.ts
+++ b/packages/runar-testing/src/__tests__/nested-declared-results-arm-layout-vm.test.ts
@@ -1,18 +1,18 @@
 /**
- * OPEN DEFECT — a declared-results `if` nested inside another `if`'s arm
- * rotates the slots it inherited from that arm.
+ * REGRESSION PIN — issue #149: a declared-results `if` nested inside another
+ * `if`'s arm rotated the slots it inherited from that arm.
  *
  * ===========================================================================
- * THIS SUITE IS SKIPPED BECAUSE THE DEFECT IS NOT FIXED. It is checked in as
- * the pinned reduction: un-skip it to work on the defect and it goes red
- * immediately, with post-state values derived from the source by hand.
+ * FIXED in 9cfd953f. This suite is checked in as the pinned reduction and is
+ * LIVE — post-state values are derived from the source by hand, not read back
+ * from compiler output, so a regression goes red here immediately.
  * ===========================================================================
  *
  * Found by an independent adversarial review of the multi-result branch node
  * (4b0f688f) as finding P1-1, and CONFIRMED PRE-EXISTING: the `taken/else`
- * case fails identically with 04-anf-lower.ts reverted to 4b0f688f, so this is
+ * case failed identically with 04-anf-lower.ts reverted to 4b0f688f, so it was
  * neither introduced nor widened by the assert-false-else / nesting fixes that
- * ship alongside this file.
+ * shipped alongside this file.
  *
  * THE MECHANISM. The inner `if` merges one local in both arms with a non-empty
  * else, so it declares `results: ["a"]`. Adopting a declared result physically
@@ -22,30 +22,42 @@
  * (`preIfNames` minus `thenCtx.stackMap.namedSlots()`) and by DEPTH (Layer C's
  * `stackMap.depth + postEndifDrops === armDepth`). Neither can see a slot
  * removed from the MIDDLE while a same-named slot appears on TOP: the name set
- * is unchanged and the depths agree exactly. Only the LAYOUT is wrong.
+ * is unchanged and the depths agree exactly. Only the LAYOUT was wrong — which
+ * is why all seven tiers agreed on the broken bytes.
  *
- * So the outer `if`'s two paths leave the same depth with different layouts —
- * the then-path ends `[..., y, a_new]` where the else-path (empty, padded)
- * still has `a` at its original depth — and everything after OP_ENDIF is
- * generated against one assumed layout. The else path compiles to a script
- * that runs to the end and fails OP_VERIFY. Funds locked.
+ * So the outer `if`'s two paths left the same depth with different layouts —
+ * the then-path ending `[..., y, a_new]` where the else-path (empty, padded)
+ * still had `a` at its original depth — and everything after OP_ENDIF was
+ * generated against one assumed layout. The else path compiled to a script
+ * that ran to the end and failed OP_VERIFY. Funds locked.
  *
- * WHY IT IS NOT FIXED HERE. The two invariants that catch it are both
- * over-strict at HEAD, measured rather than assumed:
+ * THE FIX (9cfd953f). After the adopt loop, `lowerIf` sinks the result block
+ * back under the slots it crossed, restoring the order the parent's own model
+ * already records. Applied unconditionally and NOT gated on this `if`'s own
+ * else: the asymmetry belongs to the ENCLOSING `if`, which `lowerIf` cannot see
+ * from here. Gating on `elseBindings.length === 0` was tried and is wrong — the
+ * #149 inner `if` has a real else, so the gate disables the repair exactly
+ * where it is needed.
+ *
+ * REJECTED ALTERNATIVES. Two stricter invariants would also catch the defect,
+ * and both are over-strict at HEAD — measured, not assumed:
  *
  *   - "parent model == arms' model minus the result slots" (the form §9 of
  *     packages/runar-compiler/docs/multi-result-branch-node.md prototyped and
  *     predicted would be clean once the K=1 alias rebind was deleted) fails
- *     41 test files at HEAD. The alias rebind was deleted only for DECLARING
- *     `if`s; every `if` without an else, and every lifted chain, still takes it
- *     and still moves a slot by design.
+ *     41 test files. The alias rebind was deleted only for DECLARING `if`s;
+ *     every `if` without an else, and every lifted chain, still takes it and
+ *     still moves a slot by design.
  *   - the arms-vs-arms variant ("both arms must agree on the layout they
  *     inherited") narrows that to three contracts, but one is TicTacToe, whose
  *     spendability is proven on a regtest node — so it is over-strict too.
  *
- * A real fix means teaching `lowerIf`'s reconcile about an arm that rearranged
- * inherited slots, which moves bytes in all seven tiers. That is deliberately
- * a separate change from the boundary fixes this file ships beside.
+ * SIBLING COVERAGE. branch-inherited-layout-directions-vm.test.ts pins the two
+ * further surfaces of the same root cause that this reduction does not reach:
+ * the wrongly-SPENDABLE mirror direction (the rotation makes a FALSE guard
+ * evaluate true, bypassing the contract's only spending condition) and the
+ * stateful `addOutput` case (the rotation crosses two values inside the state
+ * continuation, failing its own OP_NUM2BIN).
  */
 
 import { describe, it, expect } from 'vitest';


### PR DESCRIPTION
The header of `nested-declared-results-arm-layout-vm.test.ts` still announced `OPEN DEFECT` and `THIS SUITE IS SKIPPED BECAUSE THE DEFECT IS NOT FIXED`. Both stale:

- `9cfd953f` fixed the inherited-arm rotation (lowerIf sinks the result block back under the slots it crossed).
- `e27d8675` un-skipped the suite.
- It is green today: 6/6 in this file, 18/18 with `branch-inherited-layout-directions-vm.test.ts`, both fold modes. Verified on `2b3af765`.

Anyone reading the file was being told a fixed fund-locking defect is open and unpinned.

## What changed

Comment only — no test, source, or golden bytes touched.

- Retitled `REGRESSION PIN — issue #149`; banner now records the fix commit and that the suite is live.
- Mechanism moved to past tense, plus the line that explains why it survived: name set and depth both unchanged, so all seven tiers agreed on the broken bytes.
- `WHY IT IS NOT FIXED HERE` replaced with the fix itself, including why it is applied unconditionally and why gating on `elseBindings.length === 0` is wrong.
- The two over-strict invariants are kept as REJECTED ALTERNATIVES — still the reason the fix is shaped this way.
- Added a pointer to the sibling suite covering the wrongly-spendable mirror and the stateful `addOutput` / OP_NUM2BIN surfaces.

Found while re-verifying stale audit findings against current `main`.